### PR TITLE
Itineraries: point-first add flow with unified place picker

### DIFF
--- a/src/app/(app)/itineraries/[id]/add-stop-form.tsx
+++ b/src/app/(app)/itineraries/[id]/add-stop-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { cn } from "@/lib/utils";
 import {
   FormField,
   Input,
@@ -245,14 +246,9 @@ export function AddStopForm({
         label="How long here? (minutes, optional)"
         htmlFor="duration_minutes"
       >
-        <Input
-          id="duration_minutes"
-          name="duration_minutes"
-          type="number"
-          min={5}
-          max={24 * 60}
-          placeholder="e.g. 180 for a 3-hour event"
-        />
+        <div className="flex flex-col gap-2">
+          <DurationField />
+        </div>
       </FormField>
 
       <FormField label="Notes (optional)" htmlFor="notes">
@@ -273,6 +269,53 @@ export function AddStopForm({
         </button>
       </div>
     </form>
+  );
+}
+
+const DURATION_PRESETS: { label: string; minutes: number }[] = [
+  { label: "30m", minutes: 30 },
+  { label: "1h", minutes: 60 },
+  { label: "2h", minutes: 120 },
+  { label: "3h", minutes: 180 },
+  { label: "Half day", minutes: 240 },
+  { label: "Full day", minutes: 480 },
+];
+
+function DurationField() {
+  const [minutes, setMinutes] = useState<number | "">("");
+  return (
+    <>
+      <div className="flex flex-wrap gap-1">
+        {DURATION_PRESETS.map((p) => (
+          <button
+            type="button"
+            key={p.label}
+            onClick={() => setMinutes(p.minutes)}
+            className={cn(
+              "rounded-full border px-2 py-0.5 text-xs",
+              minutes === p.minutes
+                ? "border-rust bg-rust-2/40 text-rust"
+                : "border-rule",
+            )}
+          >
+            {p.label}
+          </button>
+        ))}
+      </div>
+      <input
+        id="duration_minutes"
+        name="duration_minutes"
+        type="number"
+        min={5}
+        max={24 * 60}
+        placeholder="Custom — minutes"
+        value={minutes === "" ? "" : String(minutes)}
+        onChange={(e) =>
+          setMinutes(e.target.value === "" ? "" : Number(e.target.value))
+        }
+        className="input-base"
+      />
+    </>
   );
 }
 

--- a/src/app/(app)/itineraries/[id]/add-stop-form.tsx
+++ b/src/app/(app)/itineraries/[id]/add-stop-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import {
   FormField,
   Input,
@@ -8,7 +8,14 @@ import {
   SubmitButton,
   Textarea,
 } from "@/components/ui/form";
-import type { LocationType, StopType } from "@/lib/types/domain";
+import {
+  PlacePicker,
+  type PlaceSelection,
+  type PlacePickerCustomer,
+  type PlacePickerCustomerSite,
+  type PlacePickerLocation,
+} from "@/components/place-picker";
+import type { StopType } from "@/lib/types/domain";
 
 type StopFormValues = {
   itinerary_id: string;
@@ -17,6 +24,7 @@ type StopFormValues = {
   start_time?: string | null;
   end_time?: string | null;
   duration_minutes?: number | null;
+  is_time_fixed?: boolean;
   location_id?: string | null;
   customer_id?: string | null;
   customer_site_id?: string | null;
@@ -29,15 +37,36 @@ type StopFormValues = {
 
 const STOP_TYPE_OPTIONS: { value: StopType; label: string }[] = [
   { value: "appointment", label: "Customer appointment" },
-  { value: "transport_booked", label: "Booked transport (train/flight/bus)" },
-  { value: "transit_arrival", label: "Arrival point (e.g. London King's Cross)" },
+  { value: "transit_arrival", label: "Arrival at station / airport" },
   { value: "accommodation", label: "Accommodation (hotel)" },
   { value: "event", label: "Event (expo / talk / training)" },
   { value: "meal", label: "Meal / reservation" },
+  { value: "transport_booked", label: "Booked transport" },
   { value: "start", label: "Start of day" },
   { value: "end", label: "End of day" },
   { value: "other", label: "Other" },
 ];
+
+// Infer a sensible default stop type from the chosen place.
+function inferStopType(sel: PlaceSelection): StopType {
+  if (sel.kind === "customer" || sel.kind === "customer_site")
+    return "appointment";
+  switch (sel.location_type) {
+    case "station":
+      return "transit_arrival";
+    case "hotel":
+      return "accommodation";
+    case "home":
+    case "office":
+      return "other";
+    case "parking":
+      return "other";
+    case "customer_site":
+      return "appointment";
+    case "other":
+      return "other";
+  }
+}
 
 export function AddStopForm({
   itineraryId,
@@ -50,30 +79,34 @@ export function AddStopForm({
   pending,
 }: {
   itineraryId: string;
-  customers: { id: string; name: string }[];
-  customerSites: { id: string; customer_id: string; name: string | null; address: string | null }[];
-  locations: { id: string; name: string; type: LocationType; address: string | null }[];
+  customers: PlacePickerCustomer[];
+  customerSites: PlacePickerCustomerSite[];
+  locations: PlacePickerLocation[];
   contacts: { id: string; customer_id: string; name: string }[];
   onCancel: () => void;
   onSubmit: (input: StopFormValues) => void;
   pending: boolean;
 }) {
-  const [type, setType] = useState<StopType>("appointment");
-  const [customerId, setCustomerId] = useState<string>("");
+  const [place, setPlace] = useState<PlaceSelection | null>(null);
+  const [type, setType] = useState<StopType>("other");
+  const [typeTouched, setTypeTouched] = useState(false);
+  const [isAnchor, setIsAnchor] = useState(false);
 
-  const filteredSites = useMemo(
-    () => customerSites.filter((s) => s.customer_id === customerId),
-    [customerSites, customerId],
-  );
-  const filteredContacts = useMemo(
-    () => contacts.filter((c) => c.customer_id === customerId),
-    [contacts, customerId],
-  );
+  const contactsForCustomer =
+    place && (place.kind === "customer" || place.kind === "customer_site")
+      ? contacts.filter((c) => c.customer_id === place.customer_id)
+      : [];
+
+  const onPick = (sel: PlaceSelection | null) => {
+    setPlace(sel);
+    if (sel && !typeTouched) setType(inferStopType(sel));
+  };
 
   return (
     <form
       className="j-card flex flex-col gap-4 p-5"
       action={(formData) => {
+        if (!place) return;
         const values: StopFormValues = {
           itinerary_id: itineraryId,
           type,
@@ -87,15 +120,19 @@ export function AddStopForm({
           duration_minutes: formData.get("duration_minutes")
             ? Number(formData.get("duration_minutes"))
             : null,
-          location_id: (formData.get("location_id") as string) || null,
-          customer_id: (formData.get("customer_id") as string) || null,
-          customer_site_id: (formData.get("customer_site_id") as string) || null,
+          is_time_fixed: isAnchor,
+          location_id: place.kind === "location" ? place.location_id : null,
+          customer_id:
+            place.kind === "customer" || place.kind === "customer_site"
+              ? place.customer_id
+              : null,
+          customer_site_id:
+            place.kind === "customer_site" ? place.customer_site_id : null,
           contact_id: (formData.get("contact_id") as string) || null,
-          external_reference: String(formData.get("external_reference") ?? "") || null,
-          external_url: String(formData.get("external_url") ?? "") || null,
+          external_reference:
+            String(formData.get("external_reference") ?? "") || null,
           notes: String(formData.get("notes") ?? "") || null,
         };
-        // Type-specific metadata (e.g. flight number for transport_booked).
         const flightIata = String(formData.get("flight_iata") ?? "").trim();
         if (flightIata) {
           values.metadata = { flight_iata: flightIata.toUpperCase() };
@@ -103,11 +140,25 @@ export function AddStopForm({
         onSubmit(values);
       }}
     >
-      <FormField label="Type" htmlFor="type">
+      <FormField label="Where?" htmlFor="place">
+        <PlacePicker
+          customers={customers}
+          customerSites={customerSites}
+          locations={locations}
+          value={place}
+          onChange={onPick}
+          disabled={pending}
+        />
+      </FormField>
+
+      <FormField label="What kind of stop?" htmlFor="type">
         <Select
           id="type"
           value={type}
-          onChange={(e) => setType(e.target.value as StopType)}
+          onChange={(e) => {
+            setType(e.target.value as StopType);
+            setTypeTouched(true);
+          }}
         >
           {STOP_TYPE_OPTIONS.map((o) => (
             <option key={o.value} value={o.value}>
@@ -118,73 +169,23 @@ export function AddStopForm({
       </FormField>
 
       <FormField label="Title (optional)" htmlFor="title">
-        <Input id="title" name="title" maxLength={200} />
+        <Input
+          id="title"
+          name="title"
+          maxLength={200}
+          placeholder="Short label for this stop"
+        />
       </FormField>
 
-      {/* Type-specific fields */}
-      {type === "appointment" ? (
-        <>
-          <FormField label="Customer" htmlFor="customer_id">
-            <Select
-              id="customer_id"
-              name="customer_id"
-              value={customerId}
-              onChange={(e) => setCustomerId(e.target.value)}
-            >
-              <option value="">— Select a customer —</option>
-              {customers.map((c) => (
-                <option key={c.id} value={c.id}>
-                  {c.name}
-                </option>
-              ))}
-            </Select>
-          </FormField>
-          <FormField label="Site (optional)" htmlFor="customer_site_id">
-            <Select
-              id="customer_site_id"
-              name="customer_site_id"
-              defaultValue=""
-              disabled={!customerId}
-            >
-              <option value="">— None —</option>
-              {filteredSites.map((s) => (
-                <option key={s.id} value={s.id}>
-                  {s.name ?? s.address ?? "Site"}
-                </option>
-              ))}
-            </Select>
-          </FormField>
-          <FormField label="Contact (optional)" htmlFor="contact_id">
-            <Select
-              id="contact_id"
-              name="contact_id"
-              defaultValue=""
-              disabled={!customerId}
-            >
-              <option value="">— None —</option>
-              {filteredContacts.map((c) => (
-                <option key={c.id} value={c.id}>
-                  {c.name}
-                </option>
-              ))}
-            </Select>
-          </FormField>
-        </>
-      ) : null}
-
-      {type === "accommodation" ||
-      type === "event" ||
-      type === "meal" ||
-      type === "start" ||
-      type === "end" ||
-      type === "other" ||
-      type === "transit_arrival" ? (
-        <FormField label="Location" htmlFor="location_id">
-          <Select id="location_id" name="location_id" defaultValue="">
+      {place &&
+      (place.kind === "customer" || place.kind === "customer_site") &&
+      contactsForCustomer.length > 0 ? (
+        <FormField label="Contact (optional)" htmlFor="contact_id">
+          <Select id="contact_id" name="contact_id" defaultValue="">
             <option value="">— None —</option>
-            {locations.map((l) => (
-              <option key={l.id} value={l.id}>
-                {l.name} ({l.type})
+            {contactsForCustomer.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
               </option>
             ))}
           </Select>
@@ -215,9 +216,24 @@ export function AddStopForm({
         </>
       ) : null}
 
-      {/* Times */}
+      <div className="rounded-md border border-rule bg-card-2/50 p-3">
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={isAnchor}
+            onChange={(e) => setIsAnchor(e.target.checked)}
+          />
+          <span>
+            This time is fixed (anchor) — e.g. a booked train, a scheduled event
+          </span>
+        </label>
+      </div>
+
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-        <FormField label="Start time" htmlFor="start_time">
+        <FormField
+          label={isAnchor ? "Start time (fixed)" : "Start time (optional)"}
+          htmlFor="start_time"
+        >
           <Input id="start_time" name="start_time" type="datetime-local" />
         </FormField>
         <FormField label="End time (optional)" htmlFor="end_time">
@@ -225,14 +241,17 @@ export function AddStopForm({
         </FormField>
       </div>
 
-      <FormField label="Duration (minutes, optional)" htmlFor="duration_minutes">
+      <FormField
+        label="How long here? (minutes, optional)"
+        htmlFor="duration_minutes"
+      >
         <Input
           id="duration_minutes"
           name="duration_minutes"
           type="number"
           min={5}
           max={24 * 60}
-          placeholder="If end time not set"
+          placeholder="e.g. 180 for a 3-hour event"
         />
       </FormField>
 
@@ -241,7 +260,9 @@ export function AddStopForm({
       </FormField>
 
       <div className="flex gap-2">
-        <SubmitButton pending={pending}>Add stop</SubmitButton>
+        <SubmitButton pending={pending} disabled={!place}>
+          Add point
+        </SubmitButton>
         <button
           type="button"
           onClick={onCancel}
@@ -254,3 +275,4 @@ export function AddStopForm({
     </form>
   );
 }
+

--- a/src/app/(app)/itineraries/[id]/add-train-booking-form.tsx
+++ b/src/app/(app)/itineraries/[id]/add-train-booking-form.tsx
@@ -1,0 +1,319 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import {
+  FormField,
+  Input,
+  SubmitButton,
+} from "@/components/ui/form";
+import {
+  PlacePicker,
+  type PlaceSelection,
+  type PlacePickerCustomer,
+  type PlacePickerCustomerSite,
+  type PlacePickerLocation,
+} from "@/components/place-picker";
+import { feedbackFromError } from "@/lib/actions/_form";
+import { attachTrainBookingToStop } from "@/lib/actions/bookings";
+import { createInlineLocation } from "@/lib/actions/locations";
+
+type Segment = {
+  from_location_name: string;
+  to_location_name: string;
+  departure_at: string; // datetime-local string
+  arrival_at: string;
+  train_number: string;
+  platform_dep: string;
+  platform_arr: string;
+};
+
+function emptySegment(): Segment {
+  return {
+    from_location_name: "",
+    to_location_name: "",
+    departure_at: "",
+    arrival_at: "",
+    train_number: "",
+    platform_dep: "",
+    platform_arr: "",
+  };
+}
+
+export function AddTrainBookingForm({
+  fromStopId,
+  fromStopLabel,
+  customers,
+  customerSites,
+  locations,
+  onCancel,
+  onDone,
+}: {
+  fromStopId: string;
+  fromStopLabel: string;
+  customers: PlacePickerCustomer[];
+  customerSites: PlacePickerCustomerSite[];
+  locations: PlacePickerLocation[];
+  onCancel: () => void;
+  onDone: () => void;
+}) {
+  const [arrival, setArrival] = useState<PlaceSelection | null>(null);
+  const [segments, setSegments] = useState<Segment[]>([emptySegment()]);
+  const [reference, setReference] = useState("");
+  const [price, setPrice] = useState("");
+  const [seat, setSeat] = useState("");
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  // Restrict the place picker to stations + free-text. We do that by only
+  // surfacing station-type locations here.
+  const stationOnly = locations.filter((l) => l.type === "station");
+
+  const updateSegment = (i: number, patch: Partial<Segment>) => {
+    setSegments((prev) =>
+      prev.map((s, idx) => (idx === i ? { ...s, ...patch } : s)),
+    );
+  };
+
+  const addSegment = () => setSegments((prev) => [...prev, emptySegment()]);
+  const removeSegment = (i: number) =>
+    setSegments((prev) => prev.filter((_, idx) => idx !== i));
+
+  const submit = () => {
+    setError(null);
+    if (!arrival) {
+      setError("Pick an arrival station");
+      return;
+    }
+    for (const s of segments) {
+      if (
+        !s.from_location_name ||
+        !s.to_location_name ||
+        !s.departure_at ||
+        !s.arrival_at
+      ) {
+        setError("Each segment needs from, to, depart and arrive times");
+        return;
+      }
+    }
+    startTransition(async () => {
+      let arrivalLocationId: string | null = null;
+      let arrivalLocationName: string | null = null;
+      if (arrival.kind === "location") {
+        arrivalLocationId = arrival.location_id;
+      } else {
+        // Customer / customer_site doesn't fit "arrival station" — create
+        // a station location from the picker's label as a fallback.
+        const created = await createInlineLocation({
+          name: arrival.label,
+          type: "station",
+        });
+        if (!created.ok) {
+          setError(feedbackFromError(created.error).message);
+          return;
+        }
+        arrivalLocationId = created.value.id;
+        arrivalLocationName = created.value.name;
+      }
+      const result = await attachTrainBookingToStop({
+        from_stop_id: fromStopId,
+        arrival_location_id: arrivalLocationId,
+        arrival_location_name: arrivalLocationName,
+        booking_reference: reference || null,
+        actual_price: price ? Number(price) : null,
+        currency: "GBP",
+        seat_reservation: seat || null,
+        segments: segments.map((s) => ({
+          from_location_name: s.from_location_name,
+          to_location_name: s.to_location_name,
+          departure_at: new Date(s.departure_at).toISOString(),
+          arrival_at: new Date(s.arrival_at).toISOString(),
+          train_number: s.train_number || null,
+          platform_dep: s.platform_dep || null,
+          platform_arr: s.platform_arr || null,
+        })),
+      });
+      if (!result.ok) {
+        setError(feedbackFromError(result.error).message);
+        return;
+      }
+      onDone();
+    });
+  };
+
+  return (
+    <div className="j-card flex flex-col gap-4 p-5">
+      <header>
+        <p className="uc">Booked train</p>
+        <h3 className="h3">From {fromStopLabel}</h3>
+        <p className="small mt-1">
+          Add a confirmed train ticket. The destination station will be added
+          as the next point, and the leg between will be locked to the
+          ticket's times.
+        </p>
+      </header>
+
+      <FormField label="Arrival station" htmlFor="arrival">
+        <PlacePicker
+          customers={customers}
+          customerSites={customerSites}
+          locations={stationOnly}
+          value={arrival}
+          onChange={setArrival}
+          placeholder="Pick a saved station or type to add"
+        />
+      </FormField>
+
+      <div className="flex flex-col gap-3">
+        {segments.map((s, i) => (
+          <div
+            key={i}
+            className="flex flex-col gap-2 rounded-md border border-rule bg-card-2/40 p-3"
+          >
+            <div className="flex items-center justify-between">
+              <p className="uc">
+                Segment {i + 1}
+                {segments.length > 1 ? ` of ${segments.length}` : ""}
+              </p>
+              {segments.length > 1 ? (
+                <button
+                  type="button"
+                  className="text-xs text-rust hover:underline"
+                  onClick={() => removeSegment(i)}
+                  disabled={pending}
+                >
+                  Remove
+                </button>
+              ) : null}
+            </div>
+            <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+              <FormField label="From station" htmlFor={`seg-from-${i}`}>
+                <Input
+                  id={`seg-from-${i}`}
+                  value={s.from_location_name}
+                  onChange={(e) =>
+                    updateSegment(i, { from_location_name: e.target.value })
+                  }
+                  placeholder="e.g. Wellingborough"
+                />
+              </FormField>
+              <FormField label="To station" htmlFor={`seg-to-${i}`}>
+                <Input
+                  id={`seg-to-${i}`}
+                  value={s.to_location_name}
+                  onChange={(e) =>
+                    updateSegment(i, { to_location_name: e.target.value })
+                  }
+                  placeholder="e.g. Birmingham New St"
+                />
+              </FormField>
+              <FormField label="Departure" htmlFor={`seg-dep-${i}`}>
+                <Input
+                  id={`seg-dep-${i}`}
+                  type="datetime-local"
+                  value={s.departure_at}
+                  onChange={(e) =>
+                    updateSegment(i, { departure_at: e.target.value })
+                  }
+                />
+              </FormField>
+              <FormField label="Arrival" htmlFor={`seg-arr-${i}`}>
+                <Input
+                  id={`seg-arr-${i}`}
+                  type="datetime-local"
+                  value={s.arrival_at}
+                  onChange={(e) =>
+                    updateSegment(i, { arrival_at: e.target.value })
+                  }
+                />
+              </FormField>
+              <FormField label="Train no. (optional)" htmlFor={`seg-no-${i}`}>
+                <Input
+                  id={`seg-no-${i}`}
+                  value={s.train_number}
+                  onChange={(e) =>
+                    updateSegment(i, { train_number: e.target.value })
+                  }
+                  placeholder="e.g. 1A45"
+                />
+              </FormField>
+              <div className="grid grid-cols-2 gap-2">
+                <FormField label="Platform dep." htmlFor={`seg-pd-${i}`}>
+                  <Input
+                    id={`seg-pd-${i}`}
+                    value={s.platform_dep}
+                    onChange={(e) =>
+                      updateSegment(i, { platform_dep: e.target.value })
+                    }
+                  />
+                </FormField>
+                <FormField label="Platform arr." htmlFor={`seg-pa-${i}`}>
+                  <Input
+                    id={`seg-pa-${i}`}
+                    value={s.platform_arr}
+                    onChange={(e) =>
+                      updateSegment(i, { platform_arr: e.target.value })
+                    }
+                  />
+                </FormField>
+              </div>
+            </div>
+          </div>
+        ))}
+        <button
+          type="button"
+          onClick={addSegment}
+          className="btn-ghost self-start"
+          style={{ padding: "6px 12px", fontSize: 13 }}
+          disabled={pending}
+        >
+          + Add changeover
+        </button>
+      </div>
+
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <FormField label="Booking ref. (optional)" htmlFor="ref">
+          <Input
+            id="ref"
+            value={reference}
+            onChange={(e) => setReference(e.target.value)}
+            placeholder="ABC123"
+          />
+        </FormField>
+        <FormField label="Price (£, optional)" htmlFor="price">
+          <Input
+            id="price"
+            value={price}
+            type="number"
+            min={0}
+            step="0.01"
+            onChange={(e) => setPrice(e.target.value)}
+          />
+        </FormField>
+        <FormField label="Seat (optional)" htmlFor="seat">
+          <Input
+            id="seat"
+            value={seat}
+            onChange={(e) => setSeat(e.target.value)}
+            placeholder="Coach C, Seat 42"
+          />
+        </FormField>
+      </div>
+
+      {error ? <p className="text-xs text-rust">{error}</p> : null}
+
+      <div className="flex gap-2">
+        <SubmitButton pending={pending} onClick={submit} type="button">
+          Attach train booking
+        </SubmitButton>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="btn-ghost"
+          disabled={pending}
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/itineraries/[id]/itinerary-editor.tsx
+++ b/src/app/(app)/itineraries/[id]/itinerary-editor.tsx
@@ -58,6 +58,7 @@ type StopRow = {
   start_time: string | null;
   end_time: string | null;
   duration_minutes: number | null;
+  is_time_fixed: boolean;
   external_reference: string | null;
   notes: string | null;
   location: { name?: string; address?: string } | null;
@@ -306,11 +307,23 @@ export function ItineraryEditor({
                       </div>
                       <div className="text-right">
                         <p className="mono">
+                          {stop.is_time_fixed ? (
+                            <span title="Time is fixed (anchor)" aria-label="anchor">
+                              📌{" "}
+                            </span>
+                          ) : null}
                           {fmtTime(stop.start_time, timezone)}
-                          {stop.end_time
+                          {stop.end_time && stop.end_time !== stop.start_time
                             ? ` – ${fmtTime(stop.end_time, timezone)}`
                             : ""}
                         </p>
+                        {i === 0 &&
+                        !stop.is_time_fixed &&
+                        stop.start_time ? (
+                          <p className="tiny" style={{ color: "var(--rust)" }}>
+                            Leave by {fmtTime(stop.start_time, timezone)}
+                          </p>
+                        ) : null}
                         {stop.duration_minutes ? (
                           <p className="tiny">{stop.duration_minutes} min</p>
                         ) : null}

--- a/src/app/(app)/itineraries/[id]/itinerary-editor.tsx
+++ b/src/app/(app)/itineraries/[id]/itinerary-editor.tsx
@@ -74,12 +74,27 @@ type TransitionRow = {
   computed_duration_minutes: number | null;
   distance_miles: number | null;
   is_locked: boolean;
+  overview_polyline: string | null;
+};
+
+type JourneyLegRow = {
+  id: string;
+  transition_id: string;
+  sequence: number;
+  leg_type: string; // walk | drive | train | bus | taxi | wait | meeting | buffer
+  start_location_name: string | null;
+  end_location_name: string | null;
+  duration_minutes: number | null;
+  distance_miles: number | null;
+  service_number: string | null;
+  instructions: string | null;
 };
 
 export function ItineraryEditor({
   itinerary,
   stops,
   transitions,
+  journeyLegs,
   customers,
   customerSites,
   locations,
@@ -96,6 +111,7 @@ export function ItineraryEditor({
   };
   stops: StopRow[];
   transitions: TransitionRow[];
+  journeyLegs: JourneyLegRow[];
   customers: { id: string; name: string }[];
   customerSites: { id: string; customer_id: string; name: string | null; address: string | null }[];
   locations: { id: string; name: string; type: LocationType; address: string | null }[];
@@ -113,6 +129,17 @@ export function ItineraryEditor({
     for (const t of transitions) m.set(t.from_stop_id, t);
     return m;
   }, [transitions]);
+
+  const legsByTransition = useMemo(() => {
+    const m = new Map<string, JourneyLegRow[]>();
+    for (const l of journeyLegs) {
+      const arr = m.get(l.transition_id) ?? [];
+      arr.push(l);
+      m.set(l.transition_id, arr);
+    }
+    for (const arr of m.values()) arr.sort((a, b) => a.sequence - b.sequence);
+    return m;
+  }, [journeyLegs]);
 
   const sortedStops = useMemo(
     () => [...stops].sort((a, b) => a.sequence - b.sequence),
@@ -320,51 +347,14 @@ export function ItineraryEditor({
 
                   {/* Transition card between this stop and the next */}
                   {next && transitionToNext ? (
-                    <div className="my-3 ml-4 flex items-center gap-3 text-sm">
-                      <span className="uc">via</span>
-                      <select
-                        value={transitionToNext.mode}
-                        disabled={pending}
-                        onChange={(e) =>
-                          handleSetMode(
-                            transitionToNext.id,
-                            e.target.value as TransitionMode,
-                          )
-                        }
-                        className="input-base"
-                        style={{
-                          width: "auto",
-                          padding: "4px 8px",
-                          fontSize: 12,
-                        }}
-                      >
-                        {(
-                          [
-                            "walk",
-                            "drive",
-                            "taxi",
-                            "bus",
-                            "tube",
-                            "train",
-                            "flight",
-                          ] as TransitionMode[]
-                        ).map((m) => (
-                          <option key={m} value={m}>
-                            {MODE_LABEL[m]}
-                          </option>
-                        ))}
-                      </select>
-                      {transitionToNext.computed_duration_minutes ? (
-                        <span className="mono text-ink-dim">
-                          {transitionToNext.computed_duration_minutes} min
-                        </span>
-                      ) : null}
-                      {transitionToNext.distance_miles ? (
-                        <span className="mono text-ink-dim">
-                          {Number(transitionToNext.distance_miles).toFixed(1)} mi
-                        </span>
-                      ) : null}
-                    </div>
+                    <LegCard
+                      transition={transitionToNext}
+                      legs={legsByTransition.get(transitionToNext.id) ?? []}
+                      pending={pending}
+                      onSetMode={(mode) =>
+                        handleSetMode(transitionToNext.id, mode)
+                      }
+                    />
                   ) : null}
                 </div>
               </li>
@@ -408,4 +398,131 @@ function fmtTime(iso: string | null, tz: string): string {
     minute: "2-digit",
     timeZone: tz,
   });
+}
+
+const LEG_TYPE_ICON: Record<string, string> = {
+  walk: "🚶",
+  drive: "🚗",
+  taxi: "🚕",
+  bus: "🚌",
+  train: "🚆",
+  wait: "⏱",
+  meeting: "🤝",
+  buffer: "·",
+};
+
+function LegCard({
+  transition,
+  legs,
+  pending,
+  onSetMode,
+}: {
+  transition: TransitionRow;
+  legs: JourneyLegRow[];
+  pending: boolean;
+  onSetMode: (mode: TransitionMode) => void;
+}) {
+  const mapSrc = transition.overview_polyline
+    ? buildClientStaticMapUrl({
+        width: 480,
+        height: 140,
+        paths: [
+          {
+            encoded: transition.overview_polyline,
+            color: "c25c3a",
+            weight: 4,
+          },
+        ],
+      })
+    : null;
+
+  return (
+    <div className="my-3 ml-4 rounded-md border border-rule/60 bg-card-2/40 p-3 text-sm">
+      <div className="mb-2 flex flex-wrap items-center gap-3">
+        <span className="uc">via</span>
+        <select
+          value={transition.mode}
+          disabled={pending}
+          onChange={(e) => onSetMode(e.target.value as TransitionMode)}
+          className="input-base"
+          style={{ width: "auto", padding: "4px 8px", fontSize: 12 }}
+        >
+          {(
+            [
+              "walk",
+              "drive",
+              "taxi",
+              "bus",
+              "tube",
+              "train",
+              "flight",
+            ] as TransitionMode[]
+          ).map((m) => (
+            <option key={m} value={m}>
+              {MODE_LABEL[m]}
+            </option>
+          ))}
+        </select>
+        {transition.computed_duration_minutes ? (
+          <span className="mono text-ink-dim">
+            {transition.computed_duration_minutes} min
+          </span>
+        ) : null}
+        {transition.distance_miles ? (
+          <span className="mono text-ink-dim">
+            {Number(transition.distance_miles).toFixed(1)} mi
+          </span>
+        ) : null}
+      </div>
+
+      {legs.length > 1 ? (
+        <ol className="mb-2 flex flex-col gap-1">
+          {legs.map((l) => (
+            <li
+              key={l.id}
+              className="flex items-baseline gap-2 text-xs"
+              style={{ color: "var(--ink-dim)" }}
+            >
+              <span aria-hidden>{LEG_TYPE_ICON[l.leg_type] ?? "·"}</span>
+              <span className="mono">
+                {l.duration_minutes ? `${l.duration_minutes}m` : ""}
+              </span>
+              <span className="truncate">
+                {l.service_number
+                  ? `${l.service_number}: ${l.start_location_name ?? ""} → ${l.end_location_name ?? ""}`
+                  : (l.instructions ?? l.start_location_name ?? l.leg_type)}
+              </span>
+            </li>
+          ))}
+        </ol>
+      ) : null}
+
+      {mapSrc ? (
+        <img
+          src={mapSrc}
+          alt="Route map"
+          className="block w-full rounded border border-rule"
+          style={{ aspectRatio: "480 / 140", objectFit: "cover" }}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+// Client-safe builder for /api/maps/static URLs (mirrors the server-side
+// StaticMap component but uses btoa instead of Buffer).
+function buildClientStaticMapUrl(spec: {
+  width: number;
+  height: number;
+  zoom?: number;
+  center?: { lat: number; lng: number };
+  paths?: { encoded: string; color?: string; weight?: number }[];
+}): string {
+  const json = JSON.stringify({ ...spec, markers: [] });
+  // base64url encode
+  const b64 = btoa(unescape(encodeURIComponent(json)))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+  return `/api/maps/static?s=${b64}`;
 }

--- a/src/app/(app)/itineraries/[id]/itinerary-editor.tsx
+++ b/src/app/(app)/itineraries/[id]/itinerary-editor.tsx
@@ -568,6 +568,15 @@ function LegCard({
     <div className="my-3 ml-4 rounded-md border border-rule/60 bg-card-2/40 p-3 text-sm">
       <div className="mb-2 flex flex-wrap items-center gap-3">
         <span className="uc">via</span>
+        {transition.is_locked ? (
+          <span
+            className="uc"
+            title="Locked — driven by a booked ticket"
+            style={{ color: "var(--rust)" }}
+          >
+            🔒 booked
+          </span>
+        ) : null}
         <select
           value={transition.mode}
           disabled={pending}

--- a/src/app/(app)/itineraries/[id]/itinerary-editor.tsx
+++ b/src/app/(app)/itineraries/[id]/itinerary-editor.tsx
@@ -14,6 +14,7 @@ import type {
   TransitionMode,
 } from "@/lib/types/domain";
 import { AddStopForm } from "./add-stop-form";
+import { AddTrainBookingForm } from "./add-train-booking-form";
 
 const STOP_ICON: Record<StopType, string> = {
   start: "📍",
@@ -64,7 +65,7 @@ type StopRow = {
   customer_site_id: string | null;
   external_reference: string | null;
   notes: string | null;
-  location: { name?: string; address?: string } | null;
+  location: { name?: string; type?: string; address?: string } | null;
   customer: { name?: string } | null;
   customer_site: { name?: string; address?: string } | null;
   metadata: Record<string, unknown> | null;
@@ -126,6 +127,10 @@ export function ItineraryEditor({
   const [pending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
   const [adding, setAdding] = useState(false);
+  const [trainBookingFor, setTrainBookingFor] = useState<{
+    stopId: string;
+    label: string;
+  } | null>(null);
 
   // Transitions keyed by from_stop_id for fast lookup.
   const transitionByFrom = useMemo(() => {
@@ -410,7 +415,26 @@ export function ItineraryEditor({
                     {stop.notes ? (
                       <p className="small mt-2 line-clamp-3">{stop.notes}</p>
                     ) : null}
-                    <footer className="mt-3 flex justify-end">
+                    <footer className="mt-3 flex flex-wrap items-center justify-end gap-3">
+                      {stop.location?.type === "station" ? (
+                        <button
+                          type="button"
+                          className="text-xs hover:underline disabled:opacity-50"
+                          style={{ color: "var(--rust)" }}
+                          onClick={() =>
+                            setTrainBookingFor({
+                              stopId: stop.id,
+                              label:
+                                stop.location?.name ??
+                                stop.title ??
+                                "this station",
+                            })
+                          }
+                          disabled={pending}
+                        >
+                          + Add booked train
+                        </button>
+                      ) : null}
                       <button
                         type="button"
                         className="text-xs text-rust hover:underline disabled:opacity-50"
@@ -439,6 +463,22 @@ export function ItineraryEditor({
           })}
         </ol>
       )}
+
+      {/* Booked-train modal-ish */}
+      {trainBookingFor ? (
+        <AddTrainBookingForm
+          fromStopId={trainBookingFor.stopId}
+          fromStopLabel={trainBookingFor.label}
+          customers={customers}
+          customerSites={customerSites}
+          locations={locations}
+          onCancel={() => setTrainBookingFor(null)}
+          onDone={() => {
+            setTrainBookingFor(null);
+            router.refresh();
+          }}
+        />
+      ) : null}
 
       {/* Add stop */}
       {adding ? (

--- a/src/app/(app)/itineraries/[id]/itinerary-editor.tsx
+++ b/src/app/(app)/itineraries/[id]/itinerary-editor.tsx
@@ -59,6 +59,9 @@ type StopRow = {
   end_time: string | null;
   duration_minutes: number | null;
   is_time_fixed: boolean;
+  location_id: string | null;
+  customer_id: string | null;
+  customer_site_id: string | null;
   external_reference: string | null;
   notes: string | null;
   location: { name?: string; address?: string } | null;
@@ -147,6 +150,34 @@ export function ItineraryEditor({
     [stops],
   );
 
+  // The most recent prior place we could "return to" — i.e. the second-to-last
+  // stop's place. Lets a user quickly close a hotel → expo → hotel hop without
+  // re-typing the place.
+  const returnToTarget = useMemo(() => {
+    if (sortedStops.length < 2) return null;
+    const last = sortedStops[sortedStops.length - 1];
+    const prev = sortedStops[sortedStops.length - 2];
+    // Don't offer "return to" if the last stop is already at the prev place.
+    if (
+      prev.location_id &&
+      prev.location_id === last.location_id &&
+      prev.customer_site_id === last.customer_site_id
+    )
+      return null;
+    const label =
+      prev.customer_site?.name ??
+      prev.customer?.name ??
+      prev.location?.name ??
+      prev.title ??
+      "previous place";
+    return {
+      label,
+      location_id: prev.location_id,
+      customer_id: prev.customer_id,
+      customer_site_id: prev.customer_site_id,
+    };
+  }, [sortedStops]);
+
   const handleAdd = (input: Parameters<typeof createStop>[0]) => {
     startTransition(async () => {
       setError(null);
@@ -169,6 +200,39 @@ export function ItineraryEditor({
         });
       }
       setAdding(false);
+      router.refresh();
+    });
+  };
+
+  const handleReturnTo = (target: {
+    label: string;
+    location_id: string | null;
+    customer_id: string | null;
+    customer_site_id: string | null;
+  }) => {
+    startTransition(async () => {
+      setError(null);
+      const result = await createStop({
+        itinerary_id: itinerary.id,
+        type: "other",
+        title: `Back to ${target.label}`,
+        location_id: target.location_id,
+        customer_id: target.customer_id,
+        customer_site_id: target.customer_site_id,
+      });
+      if (!result.ok) {
+        setError(feedbackFromError(result.error).message);
+        return;
+      }
+      const newStop = result.value;
+      const precedingStop = sortedStops[sortedStops.length - 1];
+      if (precedingStop) {
+        await upsertTransition({
+          itinerary_id: itinerary.id,
+          from_stop_id: precedingStop.id,
+          to_stop_id: newStop.id,
+        });
+      }
       router.refresh();
     });
   };
@@ -389,7 +453,7 @@ export function ItineraryEditor({
           pending={pending}
         />
       ) : (
-        <div className="flex justify-center">
+        <div className="flex flex-wrap items-center justify-center gap-2">
           <button
             type="button"
             onClick={() => setAdding(true)}
@@ -398,6 +462,17 @@ export function ItineraryEditor({
           >
             + Add point
           </button>
+          {returnToTarget ? (
+            <button
+              type="button"
+              onClick={() => handleReturnTo(returnToTarget)}
+              className="btn-ghost"
+              disabled={pending}
+              title="Add a back-hop to the previous place"
+            >
+              ↩ Return to {returnToTarget.label}
+            </button>
+          ) : null}
         </div>
       )}
     </div>

--- a/src/app/(app)/itineraries/[id]/itinerary-editor.tsx
+++ b/src/app/(app)/itineraries/[id]/itinerary-editor.tsx
@@ -36,7 +36,7 @@ const STOP_LABEL: Record<StopType, string> = {
   meal: "Meal",
   transport_booked: "Transport",
   transit_arrival: "Arrival",
-  other: "Other",
+  other: "Point",
 };
 
 const MODE_LABEL: Record<TransitionMode, string> = {
@@ -146,7 +146,7 @@ export function ItineraryEditor({
   };
 
   const handleDelete = (stopId: string) => {
-    if (!window.confirm("Delete this stop?")) return;
+    if (!window.confirm("Delete this point?")) return;
     startTransition(async () => {
       setError(null);
       const result = await deleteStop(stopId);
@@ -222,7 +222,9 @@ export function ItineraryEditor({
       {/* Timeline */}
       {sortedStops.length === 0 ? (
         <div className="j-card-soft p-6 text-center">
-          <p className="body mb-2">No stops yet. Add the first one.</p>
+          <p className="body mb-2">
+            No points yet. Add your first point — usually home.
+          </p>
         </div>
       ) : (
         <ol className="flex flex-col">
@@ -391,7 +393,7 @@ export function ItineraryEditor({
             className="btn-terra"
             disabled={pending}
           >
-            + Add stop
+            + Add point
           </button>
         </div>
       )}

--- a/src/app/(app)/itineraries/[id]/page.tsx
+++ b/src/app/(app)/itineraries/[id]/page.tsx
@@ -24,6 +24,39 @@ export default async function ItineraryDetailPage({
     .maybeSingle();
   if (!itinerary) notFound();
 
+  // Auto-seed the first "start" point from the user's travel profile defaults
+  // (drive origin → rail origin → return location). Only fires when the
+  // itinerary has zero stops, so it's idempotent on refresh.
+  const { count: stopCount } = await supabase
+    .from("stops")
+    .select("id", { count: "exact", head: true })
+    .eq("itinerary_id", id);
+  if (stopCount === 0) {
+    const { data: profile } = await supabase
+      .from("travel_profiles")
+      .select(
+        "default_drive_origin_location_id, default_rail_origin_location_id, default_return_location_id",
+      )
+      .eq("user_id", ctx.userId)
+      .eq("workspace_id", ctx.workspaceId)
+      .maybeSingle();
+    const homeId =
+      profile?.default_drive_origin_location_id ??
+      profile?.default_rail_origin_location_id ??
+      profile?.default_return_location_id ??
+      null;
+    if (homeId) {
+      await supabase.from("stops").insert({
+        itinerary_id: id,
+        workspace_id: ctx.workspaceId,
+        sequence: 0,
+        type: "start",
+        location_id: homeId,
+        is_time_fixed: false,
+      });
+    }
+  }
+
   const [{ data: stops }, { data: transitions }, { data: customers }, { data: customerSites }, { data: locations }, { data: contacts }] =
     await Promise.all([
       supabase

--- a/src/app/(app)/itineraries/[id]/page.tsx
+++ b/src/app/(app)/itineraries/[id]/page.tsx
@@ -98,6 +98,18 @@ export default async function ItineraryDetailPage({
         .eq("workspace_id", ctx.workspaceId),
     ]);
 
+  const transitionIds = (transitions ?? []).map((t) => t.id);
+  const { data: journeyLegs } =
+    transitionIds.length > 0
+      ? await supabase
+          .from("journey_legs")
+          .select(
+            "id, transition_id, sequence, leg_type, start_location_name, end_location_name, start_time, end_time, duration_minutes, distance_miles, service_number, instructions",
+          )
+          .in("transition_id", transitionIds)
+          .order("sequence")
+      : { data: [] as never[] };
+
   return (
     <PageShell
       title={itinerary.title ?? `Itinerary · ${itinerary.date_start}`}
@@ -123,6 +135,7 @@ export default async function ItineraryDetailPage({
         }}
         stops={(stops ?? []) as never}
         transitions={(transitions ?? []) as never}
+        journeyLegs={(journeyLegs ?? []) as never}
         customers={customers ?? []}
         customerSites={customerSites ?? []}
         locations={locations ?? []}

--- a/src/app/(app)/itineraries/[id]/page.tsx
+++ b/src/app/(app)/itineraries/[id]/page.tsx
@@ -65,7 +65,7 @@ export default async function ItineraryDetailPage({
           `id, sequence, type, title, start_time, end_time, duration_minutes,
            is_time_fixed, location_id, customer_id, customer_site_id, contact_id,
            external_reference, external_url, metadata, notes,
-           location:locations(name, address, latitude, longitude),
+           location:locations(name, type, address, latitude, longitude),
            customer:customers(name),
            customer_site:customer_sites(name, address, latitude, longitude)`,
         )

--- a/src/components/place-picker.tsx
+++ b/src/components/place-picker.tsx
@@ -1,0 +1,437 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+import { createInlineLocation } from "@/lib/actions/locations";
+import { feedbackFromError } from "@/lib/actions/_form";
+import type { LocationType } from "@/lib/types/domain";
+
+export type PlacePickerCustomer = { id: string; name: string };
+export type PlacePickerCustomerSite = {
+  id: string;
+  customer_id: string;
+  name: string | null;
+  address: string | null;
+};
+export type PlacePickerLocation = {
+  id: string;
+  name: string;
+  type: LocationType;
+  address: string | null;
+};
+
+// What the picker hands back when the user makes a choice.
+export type PlaceSelection =
+  | {
+      kind: "location";
+      location_id: string;
+      label: string;
+      sublabel?: string;
+      location_type: LocationType;
+    }
+  | {
+      kind: "customer_site";
+      customer_id: string;
+      customer_site_id: string;
+      label: string;
+      sublabel?: string;
+    }
+  | {
+      kind: "customer";
+      customer_id: string;
+      label: string;
+    };
+
+type Row =
+  | {
+      key: string;
+      kind: "location";
+      label: string;
+      sublabel?: string;
+      location: PlacePickerLocation;
+    }
+  | {
+      key: string;
+      kind: "customer_site";
+      label: string;
+      sublabel?: string;
+      site: PlacePickerCustomerSite;
+      customer_name: string;
+    }
+  | {
+      key: string;
+      kind: "customer";
+      label: string;
+      customer: PlacePickerCustomer;
+    };
+
+const PLACE_KINDS: { value: LocationType; label: string }[] = [
+  { value: "station", label: "Station" },
+  { value: "hotel", label: "Hotel" },
+  { value: "office", label: "Office" },
+  { value: "home", label: "Home" },
+  { value: "parking", label: "Parking" },
+  { value: "other", label: "Other" },
+];
+
+export function PlacePicker({
+  customers,
+  customerSites,
+  locations,
+  value,
+  onChange,
+  disabled,
+  placeholder = "Where? (saved place, customer, or new place)",
+}: {
+  customers: PlacePickerCustomer[];
+  customerSites: PlacePickerCustomerSite[];
+  locations: PlacePickerLocation[];
+  value: PlaceSelection | null;
+  onChange: (selection: PlaceSelection | null) => void;
+  disabled?: boolean;
+  placeholder?: string;
+}) {
+  const [query, setQuery] = useState("");
+  const [open, setOpen] = useState(false);
+  const [highlight, setHighlight] = useState(0);
+  const [creating, setCreating] = useState<string | null>(null); // pending query → new place form
+  const [newType, setNewType] = useState<LocationType>("other");
+  const [newAddress, setNewAddress] = useState("");
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  const customerById = useMemo(() => {
+    const m = new Map<string, PlacePickerCustomer>();
+    for (const c of customers) m.set(c.id, c);
+    return m;
+  }, [customers]);
+
+  const allRows = useMemo<Row[]>(() => {
+    const rows: Row[] = [];
+    for (const l of locations) {
+      rows.push({
+        key: `loc-${l.id}`,
+        kind: "location",
+        label: l.name,
+        sublabel: `${labelForLocationType(l.type)}${l.address ? " · " + l.address : ""}`,
+        location: l,
+      });
+    }
+    for (const s of customerSites) {
+      const cust = customerById.get(s.customer_id);
+      if (!cust) continue;
+      rows.push({
+        key: `site-${s.id}`,
+        kind: "customer_site",
+        label: `${cust.name}${s.name ? " — " + s.name : ""}`,
+        sublabel: s.address ?? "Customer site",
+        site: s,
+        customer_name: cust.name,
+      });
+    }
+    for (const c of customers) {
+      rows.push({
+        key: `cust-${c.id}`,
+        kind: "customer",
+        label: c.name,
+        customer: c,
+      });
+    }
+    return rows;
+  }, [locations, customerSites, customers, customerById]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return allRows.slice(0, 30);
+    return allRows
+      .filter((r) =>
+        (r.label + " " + (("sublabel" in r && r.sublabel) || ""))
+          .toLowerCase()
+          .includes(q),
+      )
+      .slice(0, 30);
+  }, [allRows, query]);
+
+  // Close dropdown on outside click.
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (!wrapperRef.current?.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  const pick = (row: Row) => {
+    setOpen(false);
+    setQuery("");
+    if (row.kind === "location") {
+      onChange({
+        kind: "location",
+        location_id: row.location.id,
+        label: row.location.name,
+        sublabel: row.sublabel,
+        location_type: row.location.type,
+      });
+    } else if (row.kind === "customer_site") {
+      onChange({
+        kind: "customer_site",
+        customer_id: row.site.customer_id,
+        customer_site_id: row.site.id,
+        label: row.label,
+        sublabel: row.sublabel,
+      });
+    } else {
+      onChange({
+        kind: "customer",
+        customer_id: row.customer.id,
+        label: row.label,
+      });
+    }
+  };
+
+  const startCreate = () => {
+    setCreating(query.trim());
+    setOpen(false);
+  };
+
+  const submitCreate = async () => {
+    if (!creating) return;
+    setPending(true);
+    setError(null);
+    const result = await createInlineLocation({
+      name: creating,
+      type: newType,
+      address: newAddress.trim() || null,
+    });
+    setPending(false);
+    if (!result.ok) {
+      setError(feedbackFromError(result.error).message);
+      return;
+    }
+    const loc = result.value;
+    onChange({
+      kind: "location",
+      location_id: loc.id,
+      label: loc.name,
+      sublabel: loc.address ?? labelForLocationType(loc.type),
+      location_type: loc.type,
+    });
+    setCreating(null);
+    setNewAddress("");
+    setNewType("other");
+    setQuery("");
+  };
+
+  const cancelCreate = () => {
+    setCreating(null);
+    setNewAddress("");
+    setNewType("other");
+    setError(null);
+  };
+
+  if (value && !creating) {
+    return (
+      <div className="flex items-center justify-between gap-2 rounded-md border border-rule bg-card-2 px-3 py-2">
+        <div className="min-w-0">
+          <p className="font-medium leading-tight">
+            {value.label}
+            {value.kind === "customer" ? (
+              <span className="uc ml-2">customer</span>
+            ) : value.kind === "customer_site" ? (
+              <span className="uc ml-2">site</span>
+            ) : (
+              <span className="uc ml-2">
+                {labelForLocationType(value.location_type)}
+              </span>
+            )}
+          </p>
+          {"sublabel" in value && value.sublabel ? (
+            <p className="small truncate">{value.sublabel}</p>
+          ) : null}
+        </div>
+        <button
+          type="button"
+          className="text-xs text-rust hover:underline disabled:opacity-50"
+          onClick={() => onChange(null)}
+          disabled={disabled}
+        >
+          Change
+        </button>
+      </div>
+    );
+  }
+
+  if (creating) {
+    return (
+      <div className="flex flex-col gap-2 rounded-md border border-rule bg-card-2 p-3">
+        <p className="small">
+          New place: <span className="font-medium">{creating}</span>
+        </p>
+        <div className="flex flex-wrap gap-1">
+          {PLACE_KINDS.map((k) => (
+            <button
+              type="button"
+              key={k.value}
+              onClick={() => setNewType(k.value)}
+              className={cn(
+                "rounded-full border px-2 py-0.5 text-xs",
+                newType === k.value
+                  ? "border-rust bg-rust-2/40 text-rust"
+                  : "border-rule",
+              )}
+              disabled={pending}
+            >
+              {k.label}
+            </button>
+          ))}
+        </div>
+        <input
+          className="input-base"
+          placeholder="Address (optional — helps Google find it)"
+          value={newAddress}
+          onChange={(e) => setNewAddress(e.target.value)}
+          disabled={pending}
+        />
+        {error ? <p className="text-xs text-rust">{error}</p> : null}
+        <div className="flex gap-2">
+          <button
+            type="button"
+            className="btn-terra"
+            style={{ padding: "6px 12px", fontSize: 13 }}
+            onClick={submitCreate}
+            disabled={pending}
+          >
+            {pending ? "Saving…" : "Save place"}
+          </button>
+          <button
+            type="button"
+            className="btn-ghost"
+            style={{ padding: "6px 12px", fontSize: 13 }}
+            onClick={cancelCreate}
+            disabled={pending}
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const showCreate = query.trim().length >= 2;
+  return (
+    <div ref={wrapperRef} className="relative">
+      <input
+        className="input-base"
+        placeholder={placeholder}
+        value={query}
+        onChange={(e) => {
+          setQuery(e.target.value);
+          setOpen(true);
+          setHighlight(0);
+        }}
+        onFocus={() => setOpen(true)}
+        onKeyDown={(e) => {
+          if (!open) return;
+          const total = filtered.length + (showCreate ? 1 : 0);
+          if (e.key === "ArrowDown") {
+            e.preventDefault();
+            setHighlight((h) => Math.min(total - 1, h + 1));
+          } else if (e.key === "ArrowUp") {
+            e.preventDefault();
+            setHighlight((h) => Math.max(0, h - 1));
+          } else if (e.key === "Enter") {
+            e.preventDefault();
+            if (highlight < filtered.length) {
+              pick(filtered[highlight]);
+            } else if (showCreate) {
+              startCreate();
+            }
+          } else if (e.key === "Escape") {
+            setOpen(false);
+          }
+        }}
+        disabled={disabled}
+        autoComplete="off"
+      />
+      {open ? (
+        <div
+          className="absolute z-10 mt-1 max-h-72 w-full overflow-auto rounded-md border border-rule bg-card-2 shadow-lg"
+          role="listbox"
+        >
+          {filtered.length === 0 && !showCreate ? (
+            <p className="small p-3 text-center">No matches. Type a name to add a new place.</p>
+          ) : null}
+          {filtered.map((row, i) => (
+            <button
+              key={row.key}
+              type="button"
+              role="option"
+              aria-selected={i === highlight}
+              onMouseEnter={() => setHighlight(i)}
+              onClick={() => pick(row)}
+              className={cn(
+                "flex w-full flex-col items-start gap-0 border-b border-rule/50 px-3 py-2 text-left last:border-b-0",
+                i === highlight ? "bg-rust-2/30" : "",
+              )}
+            >
+              <span className="text-sm">
+                {row.label}
+                {row.kind === "location" ? (
+                  <span className="uc ml-2">
+                    {labelForLocationType(row.location.type)}
+                  </span>
+                ) : row.kind === "customer_site" ? (
+                  <span className="uc ml-2">site</span>
+                ) : (
+                  <span className="uc ml-2">customer</span>
+                )}
+              </span>
+              {"sublabel" in row && row.sublabel ? (
+                <span className="small truncate">{row.sublabel}</span>
+              ) : null}
+            </button>
+          ))}
+          {showCreate ? (
+            <button
+              type="button"
+              onMouseEnter={() => setHighlight(filtered.length)}
+              onClick={startCreate}
+              className={cn(
+                "flex w-full items-center gap-2 px-3 py-2 text-left text-sm",
+                highlight === filtered.length ? "bg-rust-2/30" : "",
+              )}
+            >
+              <span className="text-rust">+</span>
+              <span>
+                Add new place: <span className="font-medium">{query.trim()}</span>
+              </span>
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function labelForLocationType(t: LocationType): string {
+  switch (t) {
+    case "home":
+      return "Home";
+    case "office":
+      return "Office";
+    case "station":
+      return "Station";
+    case "hotel":
+      return "Hotel";
+    case "customer_site":
+      return "Customer site";
+    case "parking":
+      return "Parking";
+    case "other":
+      return "Place";
+  }
+}

--- a/src/lib/actions/bookings.ts
+++ b/src/lib/actions/bookings.ts
@@ -5,7 +5,8 @@ import { createClient } from "@/lib/supabase/server";
 import { requireUserContext } from "@/lib/auth";
 import { recordAudit } from "@/lib/audit/with-audit";
 import { dbResult, parseInput } from "./_helpers";
-import type { Result } from "@/lib/errors";
+import { err, errors, ok, type Result } from "@/lib/errors";
+import { resolveItineraryTimes } from "./itineraries";
 
 // Bookings now belong to a STOP (typically a transport_booked stop). The
 // optional itinerary back-ref keeps "all bookings for trip X" queries cheap.
@@ -124,6 +125,263 @@ export async function updateBookingIntentStatus(
     });
   }
   return result;
+}
+
+// ---- attachTrainBookingToStop
+//
+// Booking flow for a manually-entered train ticket. From the station point
+// the user is currently at, capture an arrival station + 1+ segments
+// (each segment = a single train, with departure/arrival times and
+// platforms). This action:
+//
+//   * inserts an arrival stop at the arrival station (creating its
+//     location if needed),
+//   * creates a booking_intent (status='booked') + travel_booking record
+//     with the first/last segment times,
+//   * writes travel_booking_segments rows,
+//   * creates a locked transition between origin & arrival stops with
+//     mode='train' and timestamps from the segments,
+//   * runs the time solver so adjacent stops re-time.
+
+const segmentSchema = z.object({
+  from_location_name: z.string().trim().min(1).max(200),
+  to_location_name: z.string().trim().min(1).max(200),
+  departure_at: z.string().datetime(),
+  arrival_at: z.string().datetime(),
+  train_number: z.string().trim().max(40).nullable().optional(),
+  platform_dep: z.string().trim().max(20).nullable().optional(),
+  platform_arr: z.string().trim().max(20).nullable().optional(),
+  notes: z.string().trim().max(500).nullable().optional(),
+});
+
+const attachTrainBookingSchema = z
+  .object({
+    from_stop_id: z.string().uuid(),
+    arrival_location_id: z.string().uuid().nullable().optional(),
+    arrival_location_name: z.string().trim().max(200).nullable().optional(),
+    booking_reference: z.string().trim().max(120).nullable().optional(),
+    actual_price: z.number().nonnegative().nullable().optional(),
+    currency: z.enum(["GBP", "EUR", "USD"]).optional(),
+    seat_reservation: z.string().trim().max(120).nullable().optional(),
+    segments: z.array(segmentSchema).min(1),
+  })
+  .refine(
+    (v) => v.arrival_location_id != null || v.arrival_location_name != null,
+    {
+      message: "Provide arrival_location_id or arrival_location_name",
+      path: ["arrival_location_id"],
+    },
+  );
+
+export async function attachTrainBookingToStop(
+  input: z.input<typeof attachTrainBookingSchema>,
+): Promise<Result<{ arrival_stop_id: string; travel_booking_id: string }>> {
+  const parsed = parseInput(attachTrainBookingSchema, input);
+  if (!parsed.ok) return parsed;
+
+  const ctx = await requireUserContext();
+  const supabase = await createClient();
+
+  // 1. Verify origin stop ownership and pull its details.
+  const { data: fromStop } = await supabase
+    .from("stops")
+    .select("id, itinerary_id, sequence, location_id")
+    .eq("id", parsed.value.from_stop_id)
+    .eq("workspace_id", ctx.workspaceId)
+    .maybeSingle();
+  if (!fromStop) return err(errors.notFound("stop"));
+
+  // 2. Resolve arrival location: existing id, or create one from the name.
+  let arrivalLocationId = parsed.value.arrival_location_id ?? null;
+  if (!arrivalLocationId && parsed.value.arrival_location_name) {
+    const { data: newLoc, error: locErr } = await supabase
+      .from("locations")
+      .insert({
+        name: parsed.value.arrival_location_name,
+        type: "station",
+        workspace_id: ctx.workspaceId,
+        user_id: ctx.userId,
+      })
+      .select("id")
+      .single();
+    if (locErr || !newLoc) return err(errors.notFound("location"));
+    arrivalLocationId = newLoc.id;
+  }
+
+  // 3. Shift any stops at sequence > fromStop.sequence by +1 so we can
+  //    insert the new arrival stop immediately after fromStop.
+  const newSeq = fromStop.sequence + 1;
+  const { data: laterStops } = await supabase
+    .from("stops")
+    .select("id, sequence")
+    .eq("itinerary_id", fromStop.itinerary_id)
+    .eq("workspace_id", ctx.workspaceId)
+    .gte("sequence", newSeq)
+    .order("sequence", { ascending: false });
+  for (const s of laterStops ?? []) {
+    await supabase
+      .from("stops")
+      .update({ sequence: s.sequence + 1 })
+      .eq("id", s.id)
+      .eq("workspace_id", ctx.workspaceId);
+  }
+
+  const first = parsed.value.segments[0];
+  const last = parsed.value.segments[parsed.value.segments.length - 1];
+
+  // 4. Create the arrival stop pinned to the arrival time.
+  const { data: arrivalStop, error: arrivalErr } = await supabase
+    .from("stops")
+    .insert({
+      itinerary_id: fromStop.itinerary_id,
+      workspace_id: ctx.workspaceId,
+      sequence: newSeq,
+      type: "transit_arrival",
+      location_id: arrivalLocationId,
+      start_time: last.arrival_at,
+      end_time: last.arrival_at,
+      is_time_fixed: true,
+    })
+    .select("id")
+    .single();
+  if (arrivalErr || !arrivalStop) return err(errors.notFound("stop"));
+
+  // 5. booking_intent + travel_booking.
+  const { data: intent, error: intentErr } = await supabase
+    .from("booking_intents")
+    .insert({
+      stop_id: parsed.value.from_stop_id,
+      itinerary_id: fromStop.itinerary_id,
+      workspace_id: ctx.workspaceId,
+      provider: "trainline",
+      status: "booked",
+      currency: parsed.value.currency ?? "GBP",
+    })
+    .select("id")
+    .single();
+  if (intentErr || !intent) return err(errors.notFound("booking_intent"));
+
+  const { data: booking, error: bookingErr } = await supabase
+    .from("travel_bookings")
+    .insert({
+      booking_intent_id: intent.id,
+      workspace_id: ctx.workspaceId,
+      provider: "trainline",
+      booking_reference: parsed.value.booking_reference ?? null,
+      ticket_status: "booked",
+      actual_price: parsed.value.actual_price ?? null,
+      currency: parsed.value.currency ?? "GBP",
+      booked_at: new Date().toISOString(),
+      departure_location_id: fromStop.location_id,
+      arrival_location_id: arrivalLocationId,
+      departure_at: first.departure_at,
+      arrival_at: last.arrival_at,
+      seat_reservation: parsed.value.seat_reservation ?? null,
+    })
+    .select("id")
+    .single();
+  if (bookingErr || !booking) return err(errors.notFound("travel_booking"));
+
+  // 6. travel_booking_segments rows.
+  const segmentRows = parsed.value.segments.map((s, i) => ({
+    travel_booking_id: booking.id,
+    workspace_id: ctx.workspaceId,
+    sequence: i,
+    from_location_name: s.from_location_name,
+    to_location_name: s.to_location_name,
+    departure_at: s.departure_at,
+    arrival_at: s.arrival_at,
+    train_number: s.train_number ?? null,
+    platform_dep: s.platform_dep ?? null,
+    platform_arr: s.platform_arr ?? null,
+    notes: s.notes ?? null,
+  }));
+  await supabase.from("travel_booking_segments").insert(segmentRows);
+
+  // 7. Locked transition for the booked train. computed_duration_minutes
+  //    is taken from the booking timespan so the solver can treat the lock
+  //    as a time anchor.
+  const totalMinutes = Math.round(
+    (new Date(last.arrival_at).getTime() -
+      new Date(first.departure_at).getTime()) /
+      60_000,
+  );
+  const { data: transition } = await supabase
+    .from("transitions")
+    .upsert(
+      {
+        itinerary_id: fromStop.itinerary_id,
+        workspace_id: ctx.workspaceId,
+        from_stop_id: parsed.value.from_stop_id,
+        to_stop_id: arrivalStop.id,
+        mode: "train",
+        is_locked: true,
+        start_time: first.departure_at,
+        end_time: last.arrival_at,
+        computed_duration_minutes: totalMinutes,
+      },
+      { onConflict: "from_stop_id,to_stop_id" },
+    )
+    .select("id")
+    .single();
+
+  // 7b. Mirror each booked segment as a journey_legs row so the editor's
+  // sub-step UI renders the changeover detail (platforms appear in
+  // instructions for now).
+  if (transition?.id) {
+    await supabase
+      .from("journey_legs")
+      .delete()
+      .eq("transition_id", transition.id)
+      .eq("workspace_id", ctx.workspaceId);
+    const legRows = parsed.value.segments.map((s, i) => {
+      const segMinutes = Math.round(
+        (new Date(s.arrival_at).getTime() -
+          new Date(s.departure_at).getTime()) /
+          60_000,
+      );
+      const platformBits = [
+        s.platform_dep ? `Plat ${s.platform_dep}` : null,
+        s.platform_arr ? `→ Plat ${s.platform_arr}` : null,
+      ]
+        .filter(Boolean)
+        .join(" ");
+      return {
+        transition_id: transition.id,
+        workspace_id: ctx.workspaceId,
+        sequence: i,
+        leg_type: "train" as const,
+        start_location_name: s.from_location_name,
+        end_location_name: s.to_location_name,
+        start_time: s.departure_at,
+        end_time: s.arrival_at,
+        duration_minutes: segMinutes,
+        service_number: s.train_number ?? null,
+        platform: s.platform_dep ?? null,
+        instructions: platformBits || null,
+        booking_required: true,
+      };
+    });
+    await supabase.from("journey_legs").insert(legRows);
+  }
+
+  await recordAudit({
+    entityType: "travel_booking",
+    entityId: booking.id,
+    action: "create_train_booking",
+    after: {
+      booking_id: booking.id,
+      arrival_stop_id: arrivalStop.id,
+      segments: parsed.value.segments.length,
+    },
+  });
+
+  await resolveItineraryTimes(fromStop.itinerary_id);
+
+  return ok({
+    arrival_stop_id: arrivalStop.id,
+    travel_booking_id: booking.id,
+  });
 }
 
 export async function recordTravelBooking(

--- a/src/lib/actions/itineraries.ts
+++ b/src/lib/actions/itineraries.ts
@@ -6,7 +6,8 @@ import { requireUserContext } from "@/lib/auth";
 import { recordAudit } from "@/lib/audit/with-audit";
 import { dbResult, parseInput } from "./_helpers";
 import { transitionItinerary } from "@/lib/state/transitions";
-import type { Result } from "@/lib/errors";
+import { solveTimes } from "@/lib/itinerary/solver";
+import { ok, type Result } from "@/lib/errors";
 import type { ItineraryStatus } from "@/lib/types/domain";
 
 const createSchema = z
@@ -147,4 +148,70 @@ export async function transitionItineraryStatus(
   metadata?: Record<string, unknown>,
 ) {
   return transitionItinerary(id, toStatus, metadata);
+}
+
+// Run the time solver over an itinerary and write back any newly-computed
+// start/end times on stops and transitions. Idempotent and cheap — safe to
+// call after every stop/transition mutation.
+export async function resolveItineraryTimes(
+  itineraryId: string,
+): Promise<Result<{ itinerary_id: string; conflicts: number }>> {
+  const ctx = await requireUserContext();
+  const supabase = await createClient();
+
+  const [{ data: stops }, { data: transitions }] = await Promise.all([
+    supabase
+      .from("stops")
+      .select(
+        "id, sequence, start_time, end_time, duration_minutes, is_time_fixed",
+      )
+      .eq("itinerary_id", itineraryId)
+      .eq("workspace_id", ctx.workspaceId)
+      .order("sequence"),
+    supabase
+      .from("transitions")
+      .select(
+        "id, from_stop_id, to_stop_id, start_time, end_time, computed_duration_minutes, is_locked",
+      )
+      .eq("itinerary_id", itineraryId)
+      .eq("workspace_id", ctx.workspaceId),
+  ]);
+
+  const result = solveTimes({
+    stops: (stops ?? []) as Parameters<typeof solveTimes>[0]["stops"],
+    transitions:
+      (transitions ?? []) as Parameters<typeof solveTimes>[0]["transitions"],
+  });
+
+  // Write only the rows whose times actually changed, to keep audit chatter
+  // and DB writes minimal. Sequential await — itineraries hold ~10s of stops.
+  const stopsById = new Map(stops?.map((s) => [s.id, s]) ?? []);
+  const transById = new Map(transitions?.map((t) => [t.id, t]) ?? []);
+  for (const s of result.stops) {
+    const orig = stopsById.get(s.id);
+    if (!orig) continue;
+    if (orig.start_time === s.start_time && orig.end_time === s.end_time)
+      continue;
+    await supabase
+      .from("stops")
+      .update({ start_time: s.start_time, end_time: s.end_time })
+      .eq("id", s.id)
+      .eq("workspace_id", ctx.workspaceId);
+  }
+  for (const t of result.transitions) {
+    const orig = transById.get(t.id);
+    if (!orig) continue;
+    if (orig.start_time === t.start_time && orig.end_time === t.end_time)
+      continue;
+    await supabase
+      .from("transitions")
+      .update({ start_time: t.start_time, end_time: t.end_time })
+      .eq("id", t.id)
+      .eq("workspace_id", ctx.workspaceId);
+  }
+
+  return ok({
+    itinerary_id: itineraryId,
+    conflicts: result.conflicts.length,
+  });
 }

--- a/src/lib/actions/itineraries.ts
+++ b/src/lib/actions/itineraries.ts
@@ -210,6 +210,42 @@ export async function resolveItineraryTimes(
       .eq("workspace_id", ctx.workspaceId);
   }
 
+  // Refresh "leave_soon" notification rules. Strategy: replace the
+  // itinerary's auto-generated rules (payload.kind === 'auto_leave_soon')
+  // with a fresh batch — one per stop that has a computed start_time and
+  // a preceding leg to actually "leave" for.
+  await supabase
+    .from("notification_rules")
+    .delete()
+    .eq("itinerary_id", itineraryId)
+    .eq("workspace_id", ctx.workspaceId)
+    .eq("type", "leave_soon")
+    .filter("payload->>kind", "eq", "auto_leave_soon");
+  const bufferMinutes = 5;
+  const notifications: {
+    itinerary_id: string;
+    workspace_id: string;
+    type: "leave_soon";
+    trigger_time: string;
+    payload: Record<string, unknown>;
+  }[] = [];
+  for (const s of result.stops) {
+    if (!s.start_time) continue;
+    const triggerTime = new Date(
+      new Date(s.start_time).getTime() - bufferMinutes * 60_000,
+    ).toISOString();
+    notifications.push({
+      itinerary_id: itineraryId,
+      workspace_id: ctx.workspaceId,
+      type: "leave_soon",
+      trigger_time: triggerTime,
+      payload: { kind: "auto_leave_soon", stop_id: s.id },
+    });
+  }
+  if (notifications.length > 0) {
+    await supabase.from("notification_rules").insert(notifications);
+  }
+
   return ok({
     itinerary_id: itineraryId,
     conflicts: result.conflicts.length,

--- a/src/lib/actions/locations.ts
+++ b/src/lib/actions/locations.ts
@@ -5,6 +5,7 @@ import { createClient } from "@/lib/supabase/server";
 import { requireUserContext } from "@/lib/auth";
 import { recordAudit } from "@/lib/audit/with-audit";
 import { dbResult, maybeGeocode, parseInput } from "./_helpers";
+import { geocodeAddress } from "@/lib/google/maps";
 import type { Result } from "@/lib/errors";
 import type { LocationType } from "@/lib/types/domain";
 
@@ -110,6 +111,63 @@ export async function updateLocation(
       entityId: result.value.id,
       action: "update",
       before,
+      after: result.value,
+    });
+  }
+  return result;
+}
+
+// Inline-create a location from the place picker. Distinct from createLocation
+// because the user may only know the name ("Wellingborough train station"),
+// not a clean address — so we geocode by name when no address is given.
+const inlineLocationSchema = z.object({
+  name: z.string().trim().min(1).max(200),
+  type: locationTypeEnum.optional(),
+  address: z.string().trim().max(500).nullable().optional(),
+});
+
+export async function createInlineLocation(
+  input: z.input<typeof inlineLocationSchema>,
+): Promise<Result<Location>> {
+  const parsed = parseInput(inlineLocationSchema, input);
+  if (!parsed.ok) return parsed;
+
+  const ctx = await requireUserContext();
+  const supabase = await createClient();
+
+  let address = parsed.value.address ?? null;
+  let latitude: number | null = null;
+  let longitude: number | null = null;
+
+  // Geocode by best query: address if given, otherwise the name itself.
+  const query = address ?? parsed.value.name;
+  const geo = await geocodeAddress(query);
+  if (geo) {
+    latitude = geo.lat;
+    longitude = geo.lng;
+    if (!address) address = geo.formattedAddress;
+  }
+
+  const { data, error } = await supabase
+    .from("locations")
+    .insert({
+      name: parsed.value.name,
+      type: parsed.value.type ?? "other",
+      address,
+      latitude,
+      longitude,
+      workspace_id: ctx.workspaceId,
+      user_id: ctx.userId,
+    })
+    .select("*")
+    .single();
+
+  const result = dbResult<Location>(data, error, "location");
+  if (result.ok) {
+    await recordAudit({
+      entityType: "location",
+      entityId: result.value.id,
+      action: "create",
       after: result.value,
     });
   }

--- a/src/lib/actions/stops.ts
+++ b/src/lib/actions/stops.ts
@@ -6,6 +6,7 @@ import { requireUserContext } from "@/lib/auth";
 import { recordAudit } from "@/lib/audit/with-audit";
 import { dbResult, parseInput } from "./_helpers";
 import { err, errors, ok, type Result } from "@/lib/errors";
+import { resolveItineraryTimes } from "./itineraries";
 import type { StopType } from "@/lib/types/domain";
 
 const stopTypeEnum = z.enum([
@@ -126,6 +127,7 @@ export async function createStop(
       action: "create",
       after: result.value,
     });
+    await resolveItineraryTimes(result.value.itinerary_id);
   }
   return result;
 }
@@ -164,6 +166,7 @@ export async function updateStop(
       before,
       after: result.value,
     });
+    await resolveItineraryTimes(result.value.itinerary_id);
   }
   return result;
 }
@@ -192,6 +195,9 @@ export async function deleteStop(id: string): Promise<Result<{ id: string }>> {
     action: "delete",
     before,
   });
+  if (before?.itinerary_id) {
+    await resolveItineraryTimes(before.itinerary_id);
+  }
   return ok({ id });
 }
 

--- a/src/lib/actions/transitions.ts
+++ b/src/lib/actions/transitions.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { createClient } from "@/lib/supabase/server";
 import { requireUserContext } from "@/lib/auth";
 import { recordAudit } from "@/lib/audit/with-audit";
-import { getRoute } from "@/lib/integrations/routing";
+import { routeForTransition, type TransitionRoute } from "@/lib/integrations/routing";
 import { dbResult, parseInput } from "./_helpers";
 import { err, errors, ok, type Result } from "@/lib/errors";
 import type { TransitionMode } from "@/lib/types/domain";
@@ -84,28 +84,18 @@ export async function upsertTransition(
   const fromPoint = pickPoint(fromStop);
   const toPoint = pickPoint(toStop);
 
-  let computedDurationMinutes: number | null = null;
-  let distanceMiles: number | null = null;
-  let overviewPolyline: string | null = null;
-
-  if (
-    parsed.value.mode === "drive" ||
-    (parsed.value.mode === undefined && fromPoint && toPoint)
-  ) {
-    if (fromPoint && toPoint) {
-      const route = await getRoute({
-        origin: fromPoint,
-        destination: toPoint,
-        mode: "drive",
-      });
-      if (route.mode !== "unavailable") {
-        computedDurationMinutes = route.data.totalDurationMinutes;
-        distanceMiles = route.data.totalDistanceMiles ?? null;
-        overviewPolyline =
-          (route.data as { overviewPolyline?: string }).overviewPolyline ?? null;
-      }
-    }
+  const mode = parsed.value.mode ?? ("drive" as TransitionMode);
+  let route: TransitionRoute | null = null;
+  if (fromPoint && toPoint) {
+    route = await routeForTransition({
+      mode,
+      origin: fromPoint,
+      destination: toPoint,
+    });
   }
+  const computedDurationMinutes = route?.totalDurationMinutes ?? null;
+  const distanceMiles = route?.totalDistanceMiles ?? null;
+  const overviewPolyline = route?.overviewPolyline ?? null;
 
   const start = fromStop.end_time ?? fromStop.start_time;
   const end =
@@ -121,7 +111,7 @@ export async function upsertTransition(
     workspace_id: ctx.workspaceId,
     from_stop_id: parsed.value.from_stop_id,
     to_stop_id: parsed.value.to_stop_id,
-    mode: parsed.value.mode ?? ("drive" as TransitionMode),
+    mode,
     is_locked: parsed.value.is_locked ?? false,
     notes: parsed.value.notes ?? null,
     start_time: start,
@@ -139,6 +129,7 @@ export async function upsertTransition(
 
   const result = dbResult<Transition>(data, error, "transition");
   if (result.ok) {
+    await writeJourneyLegs(result.value.id, ctx.workspaceId, route);
     await recordAudit({
       entityType: "transition",
       entityId: result.value.id,
@@ -147,6 +138,37 @@ export async function upsertTransition(
     });
   }
   return result;
+}
+
+// Replace the journey_legs rows attached to a transition with the breakdown
+// from the latest route. No-op if routing returned nothing.
+async function writeJourneyLegs(
+  transitionId: string,
+  workspaceId: string,
+  route: TransitionRoute | null,
+): Promise<void> {
+  const supabase = await createClient();
+  await supabase
+    .from("journey_legs")
+    .delete()
+    .eq("transition_id", transitionId)
+    .eq("workspace_id", workspaceId);
+  if (!route || route.steps.length === 0) return;
+  const rows = route.steps.map((s) => ({
+    transition_id: transitionId,
+    workspace_id: workspaceId,
+    sequence: s.sequence,
+    leg_type: s.legType,
+    start_location_name: s.startName || null,
+    end_location_name: s.endName || null,
+    start_time: s.startTime ?? null,
+    end_time: s.endTime ?? null,
+    duration_minutes: s.durationMinutes,
+    distance_miles: s.distanceMiles ?? null,
+    service_number: s.serviceNumber ?? null,
+    instructions: s.instructions ?? null,
+  }));
+  await supabase.from("journey_legs").insert(rows);
 }
 
 export async function setTransitionMode(
@@ -158,18 +180,73 @@ export async function setTransitionMode(
   const ctx = await requireUserContext();
   const supabase = await createClient();
 
+  // Read the existing transition + adjacent stops so we can re-route under
+  // the new mode and rewrite journey_legs in the same call.
+  const { data: existing } = await supabase
+    .from("transitions")
+    .select(
+      `id, itinerary_id, from_stop_id, to_stop_id,
+       from_stop:from_stop_id (
+         id, start_time, end_time,
+         location:locations(latitude, longitude),
+         customer_site:customer_sites(latitude, longitude)
+       ),
+       to_stop:to_stop_id (
+         id, start_time,
+         location:locations(latitude, longitude),
+         customer_site:customer_sites(latitude, longitude)
+       )`,
+    )
+    .eq("id", parsed.value.id)
+    .eq("workspace_id", ctx.workspaceId)
+    .maybeSingle();
+  if (!existing) return dbResult<Transition>(null, null, "transition");
+
+  const fromPoint = pickPoint(existing.from_stop);
+  const toPoint = pickPoint(existing.to_stop);
+  let route: TransitionRoute | null = null;
+  if (fromPoint && toPoint) {
+    route = await routeForTransition({
+      mode: parsed.value.mode,
+      origin: fromPoint,
+      destination: toPoint,
+    });
+  }
+  const fromStop = first(existing.from_stop) as
+    | { end_time?: string | null; start_time?: string | null }
+    | null;
+  const toStop = first(existing.to_stop) as
+    | { start_time?: string | null }
+    | null;
+  const start = fromStop?.end_time ?? fromStop?.start_time ?? null;
+  const end =
+    start && route?.totalDurationMinutes
+      ? new Date(
+          new Date(start).getTime() + route.totalDurationMinutes * 60_000,
+        ).toISOString()
+      : (toStop?.start_time ?? null);
+
   const { data, error } = await supabase
     .from("transitions")
     .update({
       mode: parsed.value.mode,
-      is_locked: parsed.value.is_locked ?? true,
+      is_locked: parsed.value.is_locked ?? false,
+      computed_duration_minutes: route?.totalDurationMinutes ?? null,
+      distance_miles: route?.totalDistanceMiles ?? null,
+      overview_polyline: route?.overviewPolyline ?? null,
+      start_time: start,
+      end_time: end,
     })
     .eq("id", parsed.value.id)
     .eq("workspace_id", ctx.workspaceId)
     .select("*")
     .single();
 
-  return dbResult<Transition>(data, error, "transition");
+  const result = dbResult<Transition>(data, error, "transition");
+  if (result.ok) {
+    await writeJourneyLegs(result.value.id, ctx.workspaceId, route);
+  }
+  return result;
 }
 
 export async function deleteTransition(
@@ -186,19 +263,24 @@ export async function deleteTransition(
   return ok({ id });
 }
 
+// Supabase returns related rows as either an object or an array depending on
+// the FK shape. `first` normalises both into a single record.
+function first<T>(v: T | T[] | null | undefined): T | null {
+  if (v == null) return null;
+  return (Array.isArray(v) ? v[0] : v) ?? null;
+}
+
 function pickPoint(stop: unknown): { lat: number; lng: number } | null {
-  // Supabase returns related rows as either an object or an array depending on
-  // the FK shape. Normalise both into a single record.
-  const s = stop as {
-    location?: unknown;
-    customer_site?: unknown;
-  };
-  const first = (v: unknown) => (Array.isArray(v) ? v[0] : v) as
+  const s = first(stop) as
+    | { location?: unknown; customer_site?: unknown }
+    | null;
+  if (!s) return null;
+  const cs = first(s.customer_site) as
     | { latitude?: number | null; longitude?: number | null }
-    | null
-    | undefined;
-  const cs = first(s.customer_site);
-  const loc = first(s.location);
+    | null;
+  const loc = first(s.location) as
+    | { latitude?: number | null; longitude?: number | null }
+    | null;
   if (cs?.latitude != null && cs?.longitude != null)
     return { lat: cs.latitude, lng: cs.longitude };
   if (loc?.latitude != null && loc?.longitude != null)

--- a/src/lib/actions/transitions.ts
+++ b/src/lib/actions/transitions.ts
@@ -5,6 +5,7 @@ import { createClient } from "@/lib/supabase/server";
 import { requireUserContext } from "@/lib/auth";
 import { recordAudit } from "@/lib/audit/with-audit";
 import { routeForTransition, type TransitionRoute } from "@/lib/integrations/routing";
+import { resolveItineraryTimes } from "./itineraries";
 import { dbResult, parseInput } from "./_helpers";
 import { err, errors, ok, type Result } from "@/lib/errors";
 import type { TransitionMode } from "@/lib/types/domain";
@@ -136,6 +137,7 @@ export async function upsertTransition(
       action: "upsert",
       after: result.value,
     });
+    await resolveItineraryTimes(result.value.itinerary_id);
   }
   return result;
 }
@@ -245,6 +247,7 @@ export async function setTransitionMode(
   const result = dbResult<Transition>(data, error, "transition");
   if (result.ok) {
     await writeJourneyLegs(result.value.id, ctx.workspaceId, route);
+    await resolveItineraryTimes(result.value.itinerary_id);
   }
   return result;
 }

--- a/src/lib/google/maps.ts
+++ b/src/lib/google/maps.ts
@@ -55,6 +55,27 @@ export async function geocodeAddress(
   }
 }
 
+export type DirectionsStep = {
+  travelMode: "WALKING" | "DRIVING" | "TRANSIT" | "BICYCLING" | string;
+  durationSeconds: number;
+  distanceMeters: number;
+  startLocation: LatLng;
+  endLocation: LatLng;
+  polyline: string;
+  htmlInstructions?: string;
+  // Present when travelMode is TRANSIT.
+  transit?: {
+    line: string; // e.g. "Bus 24" or "Northern Line"
+    vehicleType: string; // BUS, SUBWAY, RAIL, TRAM, …
+    headsign?: string;
+    departureStop: string;
+    arrivalStop: string;
+    departureTime?: string; // ISO
+    arrivalTime?: string; // ISO
+    numStops?: number;
+  };
+};
+
 export type DirectionsResult = {
   durationSeconds: number;
   distanceMeters: number;
@@ -63,6 +84,7 @@ export type DirectionsResult = {
   overviewPolyline: string;
   startAddress: string;
   endAddress: string;
+  steps: DirectionsStep[];
 };
 
 export async function getDirections(args: {
@@ -97,6 +119,24 @@ export async function getDirections(args: {
   try {
     const res = await fetch(url.toString(), { cache: "no-store" });
     if (!res.ok) return null;
+    type ApiStep = {
+      travel_mode: string;
+      duration: { value: number };
+      distance: { value: number };
+      start_location: { lat: number; lng: number };
+      end_location: { lat: number; lng: number };
+      polyline: { points: string };
+      html_instructions?: string;
+      transit_details?: {
+        line: { short_name?: string; name?: string; vehicle: { type: string; name?: string } };
+        headsign?: string;
+        departure_stop: { name: string };
+        arrival_stop: { name: string };
+        departure_time?: { value: number };
+        arrival_time?: { value: number };
+        num_stops?: number;
+      };
+    };
     const data = (await res.json()) as {
       status: string;
       routes: Array<{
@@ -105,6 +145,7 @@ export async function getDirections(args: {
           distance: { value: number };
           start_address: string;
           end_address: string;
+          steps: ApiStep[];
         }>;
         overview_polyline: { points: string };
       }>;
@@ -112,12 +153,42 @@ export async function getDirections(args: {
     if (data.status !== "OK" || data.routes.length === 0) return null;
     const route = data.routes[0];
     const leg = route.legs[0];
+    const steps: DirectionsStep[] = (leg.steps ?? []).map((s) => {
+      const out: DirectionsStep = {
+        travelMode: s.travel_mode,
+        durationSeconds: s.duration?.value ?? 0,
+        distanceMeters: s.distance?.value ?? 0,
+        startLocation: s.start_location,
+        endLocation: s.end_location,
+        polyline: s.polyline?.points ?? "",
+        htmlInstructions: s.html_instructions,
+      };
+      if (s.transit_details) {
+        const td = s.transit_details;
+        out.transit = {
+          line: td.line.short_name ?? td.line.name ?? td.line.vehicle.name ?? "",
+          vehicleType: td.line.vehicle.type,
+          headsign: td.headsign,
+          departureStop: td.departure_stop.name,
+          arrivalStop: td.arrival_stop.name,
+          departureTime: td.departure_time
+            ? new Date(td.departure_time.value * 1000).toISOString()
+            : undefined,
+          arrivalTime: td.arrival_time
+            ? new Date(td.arrival_time.value * 1000).toISOString()
+            : undefined,
+          numStops: td.num_stops,
+        };
+      }
+      return out;
+    });
     return {
       durationSeconds: leg.duration.value,
       distanceMeters: leg.distance.value,
       overviewPolyline: route.overview_polyline.points,
       startAddress: leg.start_address,
       endAddress: leg.end_address,
+      steps,
     };
   } catch (e) {
     console.error("getDirections failed", e);

--- a/src/lib/integrations/routing.ts
+++ b/src/lib/integrations/routing.ts
@@ -1,7 +1,13 @@
 import { features } from "@/lib/features";
 import { isDemoModeActive } from "@/lib/demo-mode";
-import { getDirections, mapsApiKey } from "@/lib/google/maps";
+import {
+  getDirections,
+  mapsApiKey,
+  type DirectionsStep,
+  type LatLng,
+} from "@/lib/google/maps";
 import type { IntegrationResult, RouteRequest, RouteResult } from "./types";
+import type { TransitionMode, LegType } from "@/lib/types/domain";
 
 // Extra fields beyond the IntegrationResult contract that real callers
 // (planning, the map widget) want. Kept optional so the stub return path
@@ -82,6 +88,165 @@ export async function getRoute(
     mode: "unavailable",
     reason:
       "Routing provider not connected. Set GOOGLE_MAPS_API_KEY to enable live journey planning.",
+  };
+}
+
+// ---- Transition-mode routing
+// Higher-level entry point used by the itinerary editor: takes our
+// TransitionMode (walk/drive/taxi/bus/tube/train/mixed), maps to a Google
+// Directions mode, and returns enough sub-step detail to populate
+// journey_legs for the transition.
+
+export type TransitionStep = {
+  sequence: number;
+  legType: LegType;
+  startName: string;
+  endName: string;
+  startTime?: string; // ISO
+  endTime?: string;
+  durationMinutes: number;
+  distanceMiles?: number;
+  serviceNumber?: string; // e.g. "Bus 24", "Northern Line"
+  instructions?: string;
+  // For potential map rendering of just this sub-leg.
+  polyline?: string;
+};
+
+export type TransitionRoute = {
+  totalDurationMinutes: number;
+  totalDistanceMiles?: number;
+  overviewPolyline?: string;
+  steps: TransitionStep[];
+};
+
+function googleModeFor(
+  mode: TransitionMode,
+): "driving" | "walking" | "transit" | null {
+  switch (mode) {
+    case "walk":
+      return "walking";
+    case "drive":
+    case "taxi":
+      return "driving";
+    case "bus":
+    case "tube":
+    case "train":
+    case "mixed":
+      return "transit";
+    case "flight":
+      return null; // handled by booking flow, not Maps
+  }
+}
+
+function vehicleToLegType(vehicleType: string): LegType {
+  const v = vehicleType.toUpperCase();
+  if (v.includes("BUS")) return "bus";
+  if (v.includes("SUBWAY") || v.includes("METRO_RAIL") || v.includes("TRAM"))
+    return "train"; // closest enum value we have
+  if (v.includes("RAIL") || v.includes("HEAVY_RAIL") || v.includes("MONORAIL"))
+    return "train";
+  return "train";
+}
+
+function stepToTransitionStep(
+  s: DirectionsStep,
+  sequence: number,
+): TransitionStep {
+  const minutes = Math.round(s.durationSeconds / 60);
+  const miles = s.distanceMeters / 1609.344;
+  if (s.travelMode === "WALKING") {
+    return {
+      sequence,
+      legType: "walk",
+      startName: stripHtml(s.htmlInstructions ?? "") || "Walk",
+      endName: "",
+      durationMinutes: minutes,
+      distanceMiles: miles,
+      instructions: stripHtml(s.htmlInstructions ?? ""),
+      polyline: s.polyline,
+    };
+  }
+  if (s.travelMode === "TRANSIT" && s.transit) {
+    return {
+      sequence,
+      legType: vehicleToLegType(s.transit.vehicleType),
+      startName: s.transit.departureStop,
+      endName: s.transit.arrivalStop,
+      startTime: s.transit.departureTime,
+      endTime: s.transit.arrivalTime,
+      durationMinutes: minutes,
+      serviceNumber:
+        s.transit.line + (s.transit.headsign ? ` → ${s.transit.headsign}` : ""),
+      instructions: stripHtml(s.htmlInstructions ?? ""),
+      polyline: s.polyline,
+    };
+  }
+  // DRIVING / BICYCLING / fallback.
+  return {
+    sequence,
+    legType: "drive",
+    startName: stripHtml(s.htmlInstructions ?? "") || "Drive",
+    endName: "",
+    durationMinutes: minutes,
+    distanceMiles: miles,
+    instructions: stripHtml(s.htmlInstructions ?? ""),
+    polyline: s.polyline,
+  };
+}
+
+function stripHtml(s: string): string {
+  return s.replace(/<[^>]+>/g, "").trim();
+}
+
+export async function routeForTransition(args: {
+  mode: TransitionMode;
+  origin: LatLng;
+  destination: LatLng;
+  arriveBy?: Date;
+  departAt?: Date;
+}): Promise<TransitionRoute | null> {
+  if (!mapsApiKey()) return null;
+  const gmode = googleModeFor(args.mode);
+  if (!gmode) return null;
+
+  const dir = await getDirections({
+    origin: args.origin,
+    destination: args.destination,
+    mode: gmode,
+    arrivalTime: args.arriveBy,
+    departureTime: args.departAt,
+  });
+  if (!dir) return null;
+
+  const totalMinutes = Math.round(dir.durationSeconds / 60);
+  const totalMiles = dir.distanceMeters / 1609.344;
+
+  // For drive / walk Google returns a long list of turn-by-turn maneuvers
+  // which is too noisy for the timeline. Collapse them into a single step.
+  // For transit, keep each step (walk → bus → walk → train …).
+  let steps: TransitionStep[];
+  const isTransit = gmode === "transit";
+  if (isTransit) {
+    steps = dir.steps.map((s, i) => stepToTransitionStep(s, i));
+  } else {
+    steps = [
+      {
+        sequence: 0,
+        legType: gmode === "walking" ? "walk" : args.mode === "taxi" ? "taxi" : "drive",
+        startName: dir.startAddress,
+        endName: dir.endAddress,
+        durationMinutes: totalMinutes,
+        distanceMiles: totalMiles,
+        instructions: gmode === "walking" ? "Walk" : "Drive",
+      },
+    ];
+  }
+
+  return {
+    totalDurationMinutes: totalMinutes,
+    totalDistanceMiles: gmode === "walking" || isTransit ? undefined : totalMiles,
+    overviewPolyline: dir.overviewPolyline,
+    steps,
   };
 }
 

--- a/src/lib/itinerary/solver.test.ts
+++ b/src/lib/itinerary/solver.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "vitest";
+import { solveTimes, type SolverStop, type SolverTransition } from "./solver";
+
+function stop(
+  id: string,
+  sequence: number,
+  partial: Partial<SolverStop> = {},
+): SolverStop {
+  return {
+    id,
+    sequence,
+    start_time: null,
+    end_time: null,
+    duration_minutes: null,
+    is_time_fixed: false,
+    ...partial,
+  };
+}
+
+function trans(
+  id: string,
+  from: string,
+  to: string,
+  durationMinutes: number | null,
+  partial: Partial<SolverTransition> = {},
+): SolverTransition {
+  return {
+    id,
+    from_stop_id: from,
+    to_stop_id: to,
+    start_time: null,
+    end_time: null,
+    computed_duration_minutes: durationMinutes,
+    is_locked: false,
+    ...partial,
+  };
+}
+
+describe("solveTimes", () => {
+  it("back-times the first stop from a single fixed anchor", () => {
+    // home → station (12 min walk) → train at 09:20 (anchor)
+    const result = solveTimes({
+      stops: [
+        stop("a", 0),
+        stop("b", 1, { is_time_fixed: true, start_time: "2026-05-15T09:20:00.000Z" }),
+      ],
+      transitions: [trans("t1", "a", "b", 12)],
+    });
+    const a = result.stops.find((s) => s.id === "a")!;
+    expect(a.start_time).toBe("2026-05-15T09:08:00.000Z");
+    expect(a.end_time).toBe("2026-05-15T09:08:00.000Z"); // no duration
+    const t = result.transitions[0];
+    expect(t.start_time).toBe("2026-05-15T09:08:00.000Z");
+    expect(t.end_time).toBe("2026-05-15T09:20:00.000Z");
+    expect(result.conflicts).toEqual([]);
+  });
+
+  it("propagates forward through a chain with durations", () => {
+    // anchor at 09:00, +30 min duration, walk 10 min, next stop
+    const result = solveTimes({
+      stops: [
+        stop("a", 0, {
+          is_time_fixed: true,
+          start_time: "2026-05-15T09:00:00.000Z",
+          duration_minutes: 30,
+        }),
+        stop("b", 1),
+      ],
+      transitions: [trans("t1", "a", "b", 10)],
+    });
+    const b = result.stops.find((s) => s.id === "b")!;
+    expect(b.start_time).toBe("2026-05-15T09:40:00.000Z");
+  });
+
+  it("flags conflicts when two anchors disagree", () => {
+    // anchor a at 09:00 with no duration, walk 10, anchor b at 09:30
+    const result = solveTimes({
+      stops: [
+        stop("a", 0, {
+          is_time_fixed: true,
+          start_time: "2026-05-15T09:00:00.000Z",
+        }),
+        stop("b", 1, {
+          is_time_fixed: true,
+          start_time: "2026-05-15T09:30:00.000Z",
+        }),
+      ],
+      transitions: [trans("t1", "a", "b", 10)],
+    });
+    // Each anchor propagates and finds the conflict from its direction.
+    expect(result.conflicts.length).toBeGreaterThanOrEqual(1);
+    expect(result.conflicts.every((c) => c.kind === "stop_anchor_mismatch")).toBe(true);
+  });
+
+  it("stops propagating when transition duration is unknown", () => {
+    const result = solveTimes({
+      stops: [
+        stop("a", 0, {
+          is_time_fixed: true,
+          start_time: "2026-05-15T09:00:00.000Z",
+        }),
+        stop("b", 1),
+        stop("c", 2),
+      ],
+      transitions: [trans("t1", "a", "b", null), trans("t2", "b", "c", 20)],
+    });
+    const b = result.stops.find((s) => s.id === "b")!;
+    expect(b.start_time).toBeNull();
+  });
+
+  it("respects a locked transition window", () => {
+    // a (unanchored) → locked train 09:20 → 11:00 → b
+    const result = solveTimes({
+      stops: [
+        stop("a", 0),
+        stop("b", 1),
+      ],
+      transitions: [
+        trans("t1", "a", "b", 100, {
+          is_locked: true,
+          start_time: "2026-05-15T09:20:00.000Z",
+          end_time: "2026-05-15T11:00:00.000Z",
+        }),
+      ],
+    });
+    // No anchor on either stop — solver does nothing.
+    expect(result.stops[0].start_time).toBeNull();
+    expect(result.stops[1].start_time).toBeNull();
+  });
+});

--- a/src/lib/itinerary/solver.ts
+++ b/src/lib/itinerary/solver.ts
@@ -1,0 +1,188 @@
+// Itinerary time solver.
+//
+// Given an ordered chain of stops and the transitions between them, propagate
+// times outward from anchors (stops with is_time_fixed=true or locked
+// transitions with both start/end set) so every other stop and transition
+// gets a computed start/end.
+//
+// Pure / deterministic: takes plain rows in, returns plain rows out, no IO.
+// Server-side use only — the caller writes the result back to the database.
+
+export type SolverStop = {
+  id: string;
+  sequence: number;
+  start_time: string | null;
+  end_time: string | null;
+  duration_minutes: number | null;
+  is_time_fixed: boolean;
+};
+
+export type SolverTransition = {
+  id: string;
+  from_stop_id: string;
+  to_stop_id: string;
+  start_time: string | null;
+  end_time: string | null;
+  computed_duration_minutes: number | null;
+  is_locked: boolean;
+};
+
+export type SolverConflict = {
+  kind: "stop_anchor_mismatch" | "transition_locked_mismatch";
+  entityId: string;
+  expected: string;
+  actual: string;
+};
+
+export type SolverResult = {
+  stops: SolverStop[];
+  transitions: SolverTransition[];
+  conflicts: SolverConflict[];
+};
+
+export function solveTimes(input: {
+  stops: SolverStop[];
+  transitions: SolverTransition[];
+}): SolverResult {
+  // Clone shallow so we can write computed fields without mutating callers.
+  const stops = [...input.stops]
+    .sort((a, b) => a.sequence - b.sequence)
+    .map((s) => ({ ...s }));
+  const tByFrom = new Map<string, SolverTransition>();
+  for (const t of input.transitions) tByFrom.set(t.from_stop_id, { ...t });
+
+  const conflicts: SolverConflict[] = [];
+
+  // Helper: stop duration in minutes (default 0).
+  const stopDur = (s: SolverStop) => s.duration_minutes ?? 0;
+
+  // Anchor index: any stop with is_time_fixed AND a start_time, OR any with
+  // a fully-known start+end window (e.g. an event with both fields).
+  const anchorIdxs: number[] = [];
+  for (let i = 0; i < stops.length; i++) {
+    const s = stops[i];
+    if (s.is_time_fixed && s.start_time) anchorIdxs.push(i);
+  }
+  // Also treat the first stop as a soft anchor only if it already has a
+  // start_time (and is not pinned). We don't auto-anchor anything — the user
+  // anchors what they care about.
+
+  // Propagate from each anchor outward.
+  for (const anchorIdx of anchorIdxs) {
+    propagate(stops, tByFrom, anchorIdx, conflicts);
+  }
+
+  return {
+    stops,
+    transitions: Array.from(tByFrom.values()),
+    conflicts,
+  };
+
+  // -- inner: walks forward and backward from a single anchor, filling
+  //    start/end on every reachable stop+transition, stopping when it hits
+  //    a missing transition.computed_duration_minutes or another anchor.
+  function propagate(
+    stops: SolverStop[],
+    tByFrom: Map<string, SolverTransition>,
+    anchorIdx: number,
+    conflicts: SolverConflict[],
+  ) {
+    const anchor = stops[anchorIdx];
+    if (!anchor.start_time) return;
+    if (!anchor.end_time) {
+      anchor.end_time = addMinutes(anchor.start_time, stopDur(anchor));
+    }
+
+    // Forward.
+    for (let i = anchorIdx; i < stops.length - 1; i++) {
+      const cur = stops[i];
+      const next = stops[i + 1];
+      const tr = tByFrom.get(cur.id);
+      if (!tr) break;
+      const trDur = tr.computed_duration_minutes;
+      // Need either a duration or a locked window to advance.
+      if (trDur == null && !tr.is_locked) break;
+      if (!cur.end_time) break;
+      const trStart = cur.end_time;
+      const trEnd = trDur != null ? addMinutes(trStart, trDur) : tr.end_time;
+      if (!trEnd) break;
+
+      if (tr.is_locked && tr.start_time && tr.start_time !== trStart) {
+        conflicts.push({
+          kind: "transition_locked_mismatch",
+          entityId: tr.id,
+          expected: trStart,
+          actual: tr.start_time,
+        });
+        // honour the lock.
+      } else {
+        tr.start_time = trStart;
+      }
+      tr.end_time = trEnd;
+
+      // Next stop start = transition end.
+      if (next.is_time_fixed && next.start_time && next.start_time !== trEnd) {
+        conflicts.push({
+          kind: "stop_anchor_mismatch",
+          entityId: next.id,
+          expected: trEnd,
+          actual: next.start_time,
+        });
+        break; // honour the user's anchor; don't overwrite.
+      }
+      if (!next.is_time_fixed) next.start_time = trEnd;
+      next.end_time = addMinutes(
+        next.start_time ?? trEnd,
+        stopDur(next),
+      );
+    }
+
+    // Backward.
+    for (let i = anchorIdx; i > 0; i--) {
+      const cur = stops[i];
+      const prev = stops[i - 1];
+      const tr = tByFrom.get(prev.id);
+      if (!tr) break;
+      const trDur = tr.computed_duration_minutes;
+      if (trDur == null && !tr.is_locked) break;
+      if (!cur.start_time) break;
+      const trEnd = cur.start_time;
+      const trStart =
+        trDur != null ? addMinutes(trEnd, -trDur) : tr.start_time;
+      if (!trStart) break;
+
+      if (tr.is_locked && tr.end_time && tr.end_time !== trEnd) {
+        conflicts.push({
+          kind: "transition_locked_mismatch",
+          entityId: tr.id,
+          expected: trEnd,
+          actual: tr.end_time,
+        });
+      } else {
+        tr.end_time = trEnd;
+      }
+      tr.start_time = trStart;
+
+      // Previous stop end = transition start; previous stop start = end - duration.
+      const prevEnd = trStart;
+      const prevStart = addMinutes(prevEnd, -stopDur(prev));
+      if (prev.is_time_fixed && prev.start_time && prev.start_time !== prevStart) {
+        conflicts.push({
+          kind: "stop_anchor_mismatch",
+          entityId: prev.id,
+          expected: prevStart,
+          actual: prev.start_time,
+        });
+        break;
+      }
+      if (!prev.is_time_fixed) {
+        prev.start_time = prevStart;
+        prev.end_time = prevEnd;
+      }
+    }
+  }
+}
+
+function addMinutes(iso: string, minutes: number): string {
+  return new Date(new Date(iso).getTime() + minutes * 60_000).toISOString();
+}

--- a/supabase/migrations/0011_train_bookings.sql
+++ b/supabase/migrations/0011_train_bookings.sql
@@ -1,0 +1,66 @@
+-- ============================================================================
+-- 0011: Train bookings
+--
+-- Extends travel_bookings with booked-train-specific fields (departure /
+-- arrival station + clock time, seat reservation) and adds a
+-- travel_booking_segments table for changeovers / platforms.
+--
+-- A booked train is modelled as:
+--   * a `transit_arrival` stop at the arrival station
+--   * a single `transitions` row between the booking's origin stop and the
+--     new arrival stop, with mode='train' and is_locked=true
+--   * a booking_intent (status='booked') + travel_booking record carrying the
+--     ticket data, with one row per segment in travel_booking_segments
+-- ============================================================================
+
+alter table travel_bookings
+  add column if not exists departure_location_id uuid
+    references locations(id) on delete set null,
+  add column if not exists arrival_location_id uuid
+    references locations(id) on delete set null,
+  add column if not exists departure_at timestamptz,
+  add column if not exists arrival_at timestamptz,
+  add column if not exists seat_reservation text;
+
+create index if not exists travel_bookings_departure_loc_idx
+  on travel_bookings(departure_location_id);
+create index if not exists travel_bookings_arrival_loc_idx
+  on travel_bookings(arrival_location_id);
+
+create table if not exists travel_booking_segments (
+  id uuid primary key default gen_random_uuid(),
+  travel_booking_id uuid not null references travel_bookings(id) on delete cascade,
+  workspace_id uuid not null references workspaces(id) on delete cascade,
+  sequence integer not null,
+  from_location_name text not null,
+  to_location_name text not null,
+  departure_at timestamptz not null,
+  arrival_at timestamptz not null,
+  train_number text,
+  platform_dep text,
+  platform_arr text,
+  notes text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (travel_booking_id, sequence)
+);
+create index if not exists travel_booking_segments_booking_idx
+  on travel_booking_segments(travel_booking_id);
+create index if not exists travel_booking_segments_workspace_idx
+  on travel_booking_segments(workspace_id);
+
+create trigger travel_booking_segments_updated_at
+  before update on travel_booking_segments
+  for each row execute function set_updated_at();
+
+alter table travel_booking_segments enable row level security;
+
+create policy travel_booking_segments_member_select on travel_booking_segments
+  for select using (is_workspace_member(workspace_id));
+create policy travel_booking_segments_member_insert on travel_booking_segments
+  for insert with check (is_workspace_member(workspace_id));
+create policy travel_booking_segments_member_update on travel_booking_segments
+  for update using (is_workspace_member(workspace_id))
+  with check (is_workspace_member(workspace_id));
+create policy travel_booking_segments_member_delete on travel_booking_segments
+  for delete using (is_workspace_member(workspace_id));


### PR DESCRIPTION
Stage 1 of the itineraries refactor. The old "Add stop" form forced
every stop to be tied to a pre-created customer or location record,
making "I'm walking to Wellingborough station" awkward.

- New PlacePicker component: one combobox over saved locations,
  customers, and customer_sites with an inline "Add new place" path.
- createInlineLocation action: creates a location, geocoding by name
  when no address is given.
- Add-point form: PlacePicker first, stop type auto-inferred from the
  chosen place (station → arrival, hotel → accommodation, customer →
  appointment), anchor toggle exposed.
- Itinerary page auto-seeds the first "start" point from the user's
  travel profile defaults so a new itinerary opens with Home already
  in place.
- "Stop" relabelled to "Point" in user-facing copy.