### PR TITLE
Port editorial design system from deck into app components

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -1,11 +1,16 @@
 import Link from "next/link";
 import type { Route } from "next";
-import { PageShell } from "@/components/ui/page-shell";
 import { createClient } from "@/lib/supabase/server";
 import { requireUserContext } from "@/lib/auth";
 import { getWorkspaceConfig } from "@/lib/flags/workspace-flags";
 import { formatDateInTz } from "@/lib/types/time";
 import { WeekCalendar } from "@/components/week-calendar";
+import {
+  FlankEyebrow,
+  Masthead,
+  Stat,
+  StatGroup,
+} from "@/components/ui/editorial";
 import type { ItineraryStatus } from "@/lib/types/domain";
 
 const STATUS_LABEL: Record<ItineraryStatus, string> = {
@@ -72,16 +77,10 @@ export default async function DashboardPage() {
       .limit(5),
   ]);
 
+  const totalActive = (draftCount ?? 0) + (plannedCount ?? 0) + (inProgressCount ?? 0);
+
   return (
-    <PageShell
-      title="Dashboard"
-      description="Your day. What's next, what's still being planned, and where Journies thinks you should be."
-      actions={
-        <Link href="/itineraries/new" className="btn-terra">
-          + New itinerary
-        </Link>
-      }
-    >
+    <div className="flex flex-col gap-10 px-4 py-6 sm:px-6 sm:py-9 md:px-10 md:py-12">
       {nextItinerary ? (
         <NextItineraryHero
           title={
@@ -100,25 +99,39 @@ export default async function DashboardPage() {
 
       <WeekCalendar timezone={wsCfg.timezone} />
 
-      <section className="grid gap-4 md:grid-cols-3">
-        <DashStat
-          label="In planning"
-          value={draftCount ?? 0}
-          href="/itineraries"
-          description="Drafts being assembled."
-        />
-        <DashStat
-          label="Planned"
-          value={plannedCount ?? 0}
-          href="/itineraries"
-          description="Ready to go."
-        />
-        <DashStat
-          label="In progress"
-          value={inProgressCount ?? 0}
-          href="/itineraries"
-          description="Happening now."
-        />
+      <section className="flex flex-col gap-4">
+        <FlankEyebrow align="left">
+          On the books · {totalActive} active
+        </FlankEyebrow>
+        <StatGroup up={3} className="px-1">
+          <Link href={"/itineraries" as Route} className="group">
+            <Stat
+              value={draftCount ?? 0}
+              label="In planning · drafts assembling"
+            />
+            <span className="mt-1 block text-[11px] text-ink-faint group-hover:text-terra">
+              View →
+            </span>
+          </Link>
+          <Link href={"/itineraries" as Route} className="group">
+            <Stat
+              value={plannedCount ?? 0}
+              label="Planned · ready to go"
+            />
+            <span className="mt-1 block text-[11px] text-ink-faint group-hover:text-terra">
+              View →
+            </span>
+          </Link>
+          <Link href={"/itineraries" as Route} className="group">
+            <Stat
+              value={inProgressCount ?? 0}
+              label="In progress · happening now"
+            />
+            <span className="mt-1 block text-[11px] text-ink-faint group-hover:text-terra">
+              View →
+            </span>
+          </Link>
+        </StatGroup>
       </section>
 
       <section className="grid gap-4 md:grid-cols-2">
@@ -187,8 +200,32 @@ export default async function DashboardPage() {
           )}
         </div>
       </section>
-    </PageShell>
+    </div>
   );
+}
+
+// Splits a "Visit to Pride Park" / "On site at Pride Park" title into a
+// neutral prefix + a terra-italic destination fragment, falling back to the
+// whole title if no obvious split point exists. Mirrors the deck masthead
+// treatment ("On site at *Pride Park.*").
+function splitTitleForMasthead(title: string): { head: string; em: string | null } {
+  // Prefer the last connective preposition so the destination becomes the em.
+  const connectives = [" to ", " at ", " in ", " — ", " – ", ": "];
+  for (const c of connectives) {
+    const idx = title.lastIndexOf(c);
+    if (idx > 0 && idx + c.length < title.length) {
+      return {
+        head: title.slice(0, idx + c.length).trim(),
+        em: title.slice(idx + c.length).trim(),
+      };
+    }
+  }
+  // Otherwise — em the last word so something carries colour.
+  const words = title.trim().split(/\s+/);
+  if (words.length >= 2) {
+    return { head: words.slice(0, -1).join(" "), em: words.at(-1) ?? null };
+  }
+  return { head: title, em: null };
 }
 
 function NextItineraryHero({
@@ -206,61 +243,47 @@ function NextItineraryHero({
   timezone: string;
   id: string;
 }) {
+  const { head, em } = splitTitleForMasthead(title);
+  const startLabel = formatDateInTz(new Date(startDate), timezone);
+  const dateLine =
+    endDate !== startDate
+      ? `${startLabel} → ${formatDateInTz(new Date(endDate), timezone)}`
+      : startLabel;
+
   return (
-    <section className="j-card p-6">
-      <div className="flex flex-wrap items-start justify-between gap-4">
-        <div>
-          <p className="uc mb-2">Next up</p>
-          <h2 className="h2 mb-1">{title}</h2>
-        </div>
-        <div className="text-right">
-          <p className="mono text-2xl text-ink">
-            {formatDateInTz(new Date(startDate), timezone)}
-          </p>
-          {endDate !== startDate ? (
-            <p className="small">
-              → {formatDateInTz(new Date(endDate), timezone)}
-            </p>
-          ) : null}
-          <span className="chip mt-2 inline-flex">{STATUS_LABEL[status]}</span>
-        </div>
-      </div>
-      <div className="mt-4 flex gap-2">
-        <Link href={`/itineraries/${id}`} className="btn-primary">
-          Open itinerary
-        </Link>
-      </div>
-    </section>
+    <Masthead
+      eyebrow={`Next up · ${dateLine} · ${STATUS_LABEL[status]}`}
+      chapter="01"
+      title={head}
+      em={em}
+      standfirst="Your nearest planned day, anchored on the destination Journies thinks matters most."
+      actions={
+        <>
+          <Link href={`/itineraries/${id}`} className="btn-terra">
+            Open itinerary
+          </Link>
+          <Link href={"/itineraries/new" as Route} className="btn-ghost">
+            + New
+          </Link>
+        </>
+      }
+    />
   );
 }
 
 function NoNext() {
   return (
-    <section className="j-card-soft p-6">
-      <p className="uc mb-2">Next up</p>
-      <p className="body">
-        Nothing planned yet. Start an itinerary to see your day land here.
-      </p>
-    </section>
-  );
-}
-
-function DashStat({
-  label,
-  value,
-  href,
-  description,
-}: {
-  label: string;
-  value: number;
-  href: Route;
-  description: string;
-}) {
-  return (
-    <Link href={href} className="j-card block p-5 hover:bg-card-2">
-      <p className="uc mb-2">{label}</p>
-      <p className="mono mb-1 text-3xl font-medium text-ink">{value}</p>
-      <p className="small">{description}</p>
-    </Link>
+    <Masthead
+      eyebrow="Next up · nothing on the books"
+      chapter="01"
+      title="Plan the next"
+      em="trip."
+      standfirst="No itinerary is queued. Start one to see your day land here — anchored to the appointment, with travel built backwards from it."
+      actions={
+        <Link href={"/itineraries/new" as Route} className="btn-terra">
+          + New itinerary
+        </Link>
+      }
+    />
   );
 }

--- a/src/app/(app)/itineraries/[id]/itinerary-editor.tsx
+++ b/src/app/(app)/itineraries/[id]/itinerary-editor.tsx
@@ -1199,6 +1199,9 @@ function buildClientStaticMapUrl(spec: {
     ...spec,
     markers: spec.markers ?? [],
     paths: spec.paths ?? [],
+    // Pin the inline route maps to the Journies map style so the warm
+    // editorial palette carries into every embedded map.
+    style: "journies",
   });
   // base64url encode
   const b64 = btoa(unescape(encodeURIComponent(json)))

--- a/src/app/(app)/itineraries/page.tsx
+++ b/src/app/(app)/itineraries/page.tsx
@@ -1,9 +1,10 @@
 import Link from "next/link";
-import { PageShell } from "@/components/ui/page-shell";
+import type { Route } from "next";
 import { createClient } from "@/lib/supabase/server";
 import { requireUserContext } from "@/lib/auth";
 import { getWorkspaceConfig } from "@/lib/flags/workspace-flags";
 import { formatDateInTz } from "@/lib/types/time";
+import { FlankEyebrow, Masthead } from "@/components/ui/editorial";
 import type { ItineraryStatus } from "@/lib/types/domain";
 
 type Row = {
@@ -64,19 +65,23 @@ export default async function ItinerariesPage() {
   );
 
   return (
-    <PageShell
-      title="Itineraries"
-      description="Each itinerary is a day (or trip) made of ordered stops with transitions between them."
-      actions={
-        <Link href="/itineraries/new" className="btn-terra">
-          + New itinerary
-        </Link>
-      }
-    >
+    <div className="flex flex-col gap-9 px-4 py-6 sm:px-6 sm:py-9 md:px-10 md:py-12">
+      <Masthead
+        eyebrow={`Itineraries · ${rows.length} on file`}
+        title="Every trip,"
+        em="ordered."
+        standfirst="An itinerary is a day — or a multi-day run — made of stops with transitions between them. Drafts live alongside the booked ones until the day arrives."
+        actions={
+          <Link href={"/itineraries/new" as Route} className="btn-terra">
+            + New itinerary
+          </Link>
+        }
+      />
+
       {rows.length === 0 ? (
-        <div className="j-card-soft p-8 text-center">
+        <div className="j-card-soft p-10 text-center">
           <p className="body mb-3">No itineraries yet.</p>
-          <Link href="/itineraries/new" className="btn-terra">
+          <Link href={"/itineraries/new" as Route} className="btn-terra">
             Start your first one
           </Link>
         </div>
@@ -107,7 +112,7 @@ export default async function ItinerariesPage() {
           ) : null}
         </>
       )}
-    </PageShell>
+    </div>
   );
 }
 
@@ -124,10 +129,9 @@ function Section({
 }) {
   return (
     <section className="flex flex-col gap-3">
-      <header className="flex items-baseline justify-between">
-        <h2 className="h3">{heading}</h2>
-        <span className="small">{rows.length}</span>
-      </header>
+      <FlankEyebrow>
+        {heading} · {rows.length}
+      </FlankEyebrow>
       <div className="grid gap-3 md:grid-cols-2">
         {rows.map((r) => (
           <Link

--- a/src/app/(app)/locations/page.tsx
+++ b/src/app/(app)/locations/page.tsx
@@ -15,13 +15,15 @@ export default async function LocationsPage() {
     .order("type")
     .order("name");
 
+  // Each location type gets its own brand-palette pin so the saved-locations
+  // map reads as a clear key without needing a legend.
   const TYPE_COLOR: Record<string, StaticMapMarker["color"]> = {
-    home: "green",
-    office: "blue",
-    station: "purple",
-    hotel: "orange",
-    parking: "yellow",
-    other: "black",
+    home: "sage",
+    office: "ink",
+    station: "rust",
+    hotel: "terra",
+    parking: "amber",
+    other: "ink",
   };
   const markers: StaticMapMarker[] = (locations ?? [])
     .filter((l) => l.latitude != null && l.longitude != null)
@@ -37,7 +39,13 @@ export default async function LocationsPage() {
       description="Home, office, preferred stations and other starting points used when generating travel options."
     >
       {markers.length > 0 ? (
-        <StaticMap markers={markers} width={1200} height={320} alt="Saved locations" />
+        <StaticMap
+          markers={markers}
+          width={1200}
+          height={320}
+          alt="Saved locations"
+          style="journies"
+        />
       ) : null}
       <LocationsPanel locations={locations ?? []} />
     </PageShell>

--- a/src/app/api/maps/static/route.ts
+++ b/src/app/api/maps/static/route.ts
@@ -11,6 +11,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import { requireUser } from "@/lib/auth";
 import {
   buildStaticMapUrl,
+  type MapStyle,
   type StaticMapMarker,
   type StaticMapPath,
 } from "@/lib/google/maps";
@@ -22,6 +23,7 @@ type Spec = {
   center?: { lat: number; lng: number };
   markers?: StaticMapMarker[];
   paths?: StaticMapPath[];
+  style?: MapStyle;
 };
 
 export async function GET(request: NextRequest) {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -714,6 +714,140 @@
     }
   }
 
+  /* ------------------------------------------------------------------
+   * Deck-style atoms — chapter numbers, ink hero pages, flanked eyebrows.
+   * Ported from the Journeys story deck so the app can speak the same
+   * editorial language as the marketing artefact.
+   * ------------------------------------------------------------------ */
+
+  /* Giant serif italic chapter numeral — used as the kickoff for a story
+     block ("01", "02", "03" in the deck). Terra so the eye finds it first. */
+  .chapter-number {
+    font-family: var(--serif);
+    font-style: italic;
+    font-weight: 500;
+    font-size: 64px;
+    line-height: 0.95;
+    letter-spacing: -0.03em;
+    color: var(--terra);
+    display: inline-block;
+  }
+  .chapter-number.lg {
+    font-size: 96px;
+  }
+  .chapter-number.sm {
+    font-size: 44px;
+  }
+
+  /* Eyebrow row with a hairline rule flanking the label — the
+     "01.2 · TUE 14:43 · PLAN INTENT" treatment in the deck. */
+  .flank-eyebrow {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    font-family: var(--mono);
+    font-size: 10.5px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--ink-dim);
+  }
+  .flank-eyebrow::before,
+  .flank-eyebrow::after {
+    content: "";
+    flex: 1;
+    height: 1px;
+    background: var(--rule);
+    min-width: 16px;
+  }
+  .flank-eyebrow.left::before {
+    display: none;
+  }
+  .flank-eyebrow.right::after {
+    display: none;
+  }
+
+  /* Grouped editorial stat layout — 2-up / 3-up / 4-up that respects the
+     stat-col atom (large serif italic value + mono label). */
+  .stat-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 20px 32px;
+  }
+  @media (min-width: 720px) {
+    .stat-grid.three {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+    .stat-grid.four {
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+  }
+  .stat-grid .stat-col .v {
+    font-size: 44px;
+  }
+  .stat-grid.compact .stat-col .v {
+    font-size: 30px;
+  }
+
+  /* Editorial dark hero — a full-bleed ink page block. The deck uses this
+     for the chapter intros ("Three trips. One app.", "Plan, do, repeat.").
+     All descendant editorial atoms invert to paper for legibility. */
+  .editorial-dark {
+    background: var(--ink);
+    color: var(--paper);
+    border-radius: 6px;
+    padding: 36px 32px;
+    position: relative;
+    overflow: hidden;
+  }
+  .editorial-dark::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(
+      circle at 80% 20%,
+      rgba(194, 92, 58, 0.18),
+      transparent 60%
+    );
+    pointer-events: none;
+  }
+  .editorial-dark > * {
+    position: relative;
+    z-index: 1;
+  }
+  .editorial-dark .masthead-title,
+  .editorial-dark .h0,
+  .editorial-dark .h1,
+  .editorial-dark .h2 {
+    color: var(--paper);
+  }
+  .editorial-dark .standfirst,
+  .editorial-dark .body {
+    color: var(--paper-2);
+  }
+  .editorial-dark .standfirst em,
+  .editorial-dark .masthead-title em,
+  .editorial-dark .masthead-title .em {
+    color: var(--terra);
+  }
+  .editorial-dark .uc,
+  .editorial-dark .stat-col .l,
+  .editorial-dark .flank-eyebrow {
+    color: var(--ink-faint);
+  }
+  .editorial-dark .flank-eyebrow::before,
+  .editorial-dark .flank-eyebrow::after {
+    background: rgba(244, 240, 231, 0.14);
+  }
+  .editorial-dark .stat-col .v {
+    color: var(--paper);
+  }
+  .editorial-dark .chapter-number {
+    color: var(--terra);
+  }
+  .editorial-dark .j-hr {
+    background: rgba(244, 240, 231, 0.14);
+  }
+
   /* Day-of-week eyebrow inside timeline */
   .day-header {
     display: flex;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,29 +1,41 @@
 import Link from "next/link";
+import { FlankEyebrow, Masthead, Stat, StatGroup } from "@/components/ui/editorial";
 
 export default function LandingPage() {
   return (
     <main className="paper-tex flex min-h-screen flex-col">
-      <div className="mx-auto flex w-full max-w-3xl flex-1 flex-col justify-center gap-8 px-5 py-12 sm:gap-10 sm:px-6 sm:py-16">
+      <div className="mx-auto flex w-full max-w-3xl flex-1 flex-col justify-center gap-10 px-5 py-12 sm:gap-12 sm:px-6 sm:py-16">
         <div className="brand-glyph">Journies</div>
-        <div className="space-y-4">
-          <h1 className="h0 text-[36px] leading-[1.06] sm:text-[44px] md:text-[56px]">
-            Know whether you can actually{" "}
-            <span className="text-terra">get there</span> — before you say yes.
-          </h1>
-          <p className="body max-w-xl text-base">
-            Plan, book, calendar and navigate on-site business visits from door
-            to door. Travel-aware feasibility, rail vs drive comparison, partner
-            rail booking and travel-day guidance.
-          </p>
-        </div>
-        <div className="flex gap-3">
-          <Link href="/login" className="btn-terra">
-            Sign in
-          </Link>
-          <Link href="/signup" className="btn-ghost">
-            Create account
-          </Link>
-        </div>
+
+        <Masthead
+          eyebrow={<FlankEyebrow align="left">A travel-aware visit planner</FlankEyebrow>}
+          title="Know whether you can"
+          em="actually get there"
+          trailing={<span className="text-ink">— before you say yes.</span>}
+          standfirst={
+            <>
+              Plan, book, calendar and navigate on-site business visits door to
+              door. Travel-aware feasibility, <em>rail vs drive</em> comparison,
+              partner rail booking and travel-day guidance.
+            </>
+          }
+          actions={
+            <>
+              <Link href="/login" className="btn-terra">
+                Sign in
+              </Link>
+              <Link href="/signup" className="btn-ghost">
+                Create account
+              </Link>
+            </>
+          }
+        />
+
+        <StatGroup up={3} compact>
+          <Stat value="door → door" label="every leg planned" />
+          <Stat value="rail · drive" label="feasibility compared" />
+          <Stat value="one app" label="for the whole trip" />
+        </StatGroup>
       </div>
     </main>
   );

--- a/src/components/static-map.tsx
+++ b/src/components/static-map.tsx
@@ -1,4 +1,8 @@
-import type { StaticMapMarker, StaticMapPath } from "@/lib/google/maps";
+import type {
+  MapStyle,
+  StaticMapMarker,
+  StaticMapPath,
+} from "@/lib/google/maps";
 
 // Server-side component that renders a static map via our proxy. We encode
 // the spec into a base64url query param so the URL is stable and easily
@@ -13,6 +17,7 @@ export function StaticMap({
   center,
   alt = "Map",
   className,
+  style = "journies",
 }: {
   markers?: StaticMapMarker[];
   paths?: StaticMapPath[];
@@ -22,23 +27,35 @@ export function StaticMap({
   center?: { lat: number; lng: number };
   alt?: string;
   className?: string;
+  style?: MapStyle;
 }) {
   if (markers.length === 0 && paths.length === 0) return null;
 
-  const spec = { width, height, zoom, center, markers, paths };
+  const spec = { width, height, zoom, center, markers, paths, style };
   const encoded = Buffer.from(JSON.stringify(spec), "utf8").toString("base64url");
   const src = `/api/maps/static?s=${encoded}`;
 
   // Two-up size: ask for 2x scale upstream (handled by the proxy via the
   // builder) for retina sharpness. The <img> renders at logical size.
+  // The framing — paper-toned border + faint inner ring — keeps the map
+  // sitting inside the editorial palette rather than punching out of it.
   return (
-    <img
-      src={src}
-      alt={alt}
-      width={width}
-      height={height}
-      className={`block w-full rounded border border-rule ${className ?? ""}`}
-      style={{ aspectRatio: `${width} / ${height}`, objectFit: "cover" }}
-    />
+    <figure
+      className={`relative overflow-hidden rounded-md border border-rule bg-card ${className ?? ""}`}
+      style={{ aspectRatio: `${width} / ${height}` }}
+    >
+      <img
+        src={src}
+        alt={alt}
+        width={width}
+        height={height}
+        className="block h-full w-full"
+        style={{ objectFit: "cover" }}
+      />
+      <span
+        aria-hidden
+        className="pointer-events-none absolute inset-0 rounded-md ring-1 ring-inset ring-[rgba(26,22,18,0.04)]"
+      />
+    </figure>
   );
 }

--- a/src/components/ui/editorial.tsx
+++ b/src/components/ui/editorial.tsx
@@ -1,0 +1,168 @@
+// Editorial atoms — the deck-style language ported into reusable React.
+// These are zero-logic: they exist so feature screens (dashboard, itinerary
+// list, landing) can speak the same language as the Journeys story deck
+// without each page re-declaring the same markup.
+//
+// The two-word vocabulary:
+//   • Masthead         large serif italic title + standfirst, with optional
+//                      chapter-number eyebrow and ink-dark variant.
+//   • StatGroup        n-up row of stat columns (large serif italic numeric
+//                      value over a mono uppercase label).
+//
+// Both are server-safe — no client hooks.
+
+import { cn } from "@/lib/utils";
+
+export function FlankEyebrow({
+  children,
+  align = "both",
+  className,
+}: {
+  children: React.ReactNode;
+  align?: "both" | "left" | "right";
+  className?: string;
+}) {
+  return (
+    <div className={cn("flank-eyebrow", align !== "both" ? align : "", className)}>
+      <span>{children}</span>
+    </div>
+  );
+}
+
+export function ChapterNumber({
+  value,
+  size = "md",
+  className,
+}: {
+  value: string;
+  size?: "sm" | "md" | "lg";
+  className?: string;
+}) {
+  return (
+    <span className={cn("chapter-number", size === "lg" && "lg", size === "sm" && "sm", className)}>
+      {value}
+    </span>
+  );
+}
+
+// A magazine masthead: optional chapter eyebrow, a serif-italic title with a
+// terra-emphasised fragment, and an optional standfirst paragraph. The `em`
+// is a string that's pulled out and rendered in terra italic — pass the
+// destination, the customer name, the verb that matters.
+//
+//   <Masthead
+//     eyebrow="Next up · Tue 14:43"
+//     title="On site at"
+//     em="Pride Park"
+//     standfirst="Tue 14:43 boss asks · Thu 14:44 booked & shared."
+//   />
+//
+export function Masthead({
+  eyebrow,
+  chapter,
+  title,
+  em,
+  trailing,
+  standfirst,
+  actions,
+  dark,
+  children,
+  className,
+}: {
+  eyebrow?: React.ReactNode;
+  chapter?: string;
+  title: React.ReactNode;
+  em?: React.ReactNode;
+  trailing?: React.ReactNode;
+  standfirst?: React.ReactNode;
+  actions?: React.ReactNode;
+  dark?: boolean;
+  children?: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <section
+      className={cn(
+        "flex flex-col gap-4",
+        dark && "editorial-dark",
+        className,
+      )}
+    >
+      {eyebrow ? (
+        typeof eyebrow === "string" ? (
+          <FlankEyebrow align="left">{eyebrow}</FlankEyebrow>
+        ) : (
+          eyebrow
+        )
+      ) : null}
+
+      <div className="flex flex-wrap items-end justify-between gap-6">
+        <div className="flex min-w-0 flex-1 items-start gap-5">
+          {chapter ? <ChapterNumber value={chapter} /> : null}
+          <h1 className="masthead-title">
+            {title}
+            {em ? (
+              <>
+                {" "}
+                <em>{em}</em>
+              </>
+            ) : null}
+            {trailing ? (
+              <>
+                {" "}
+                {trailing}
+              </>
+            ) : null}
+          </h1>
+        </div>
+        {actions ? <div className="flex flex-wrap gap-2">{actions}</div> : null}
+      </div>
+
+      {standfirst ? <p className="standfirst">{standfirst}</p> : null}
+      {children}
+    </section>
+  );
+}
+
+export function StatGroup({
+  up = 3,
+  compact,
+  className,
+  children,
+}: {
+  up?: 2 | 3 | 4;
+  compact?: boolean;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        "stat-grid",
+        up === 3 && "three",
+        up === 4 && "four",
+        compact && "compact",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function Stat({
+  value,
+  label,
+  className,
+}: {
+  value: React.ReactNode;
+  label: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={cn("stat-col", className)}>
+      <span className="v">{value}</span>
+      <span className="l">{label}</span>
+    </div>
+  );
+}

--- a/src/lib/google/maps.ts
+++ b/src/lib/google/maps.ts
@@ -196,11 +196,48 @@ export async function getDirections(args: {
   }
 }
 
+// Named pin slots for the Journies map: each maps onto a brand hex. Use these
+// instead of Google's stock colours (which only offer red/blue/green/…) so
+// every pin sits inside the warm editorial palette.
+export type MarkerColor =
+  | "terra"
+  | "sage"
+  | "amber"
+  | "rust"
+  | "ink"
+  // legacy aliases — older code (e.g. locations page) still passes these.
+  | "red"
+  | "blue"
+  | "green"
+  | "orange"
+  | "purple"
+  | "yellow"
+  | "black";
+
+const MARKER_HEX: Record<MarkerColor, string> = {
+  // brand
+  terra: "c25c3a",
+  sage: "5f7053",
+  amber: "a07520",
+  rust: "9b3422",
+  ink: "1a1612",
+  // legacy aliases mapped onto the closest brand colour so existing
+  // call-sites stay cohesive without needing a sweep.
+  red: "c25c3a",
+  orange: "c25c3a",
+  blue: "5f7053",
+  green: "5f7053",
+  yellow: "a07520",
+  purple: "9b3422",
+  black: "1a1612",
+};
+
 export type StaticMapMarker = {
   lat: number;
   lng: number;
-  color?: "red" | "blue" | "green" | "orange" | "purple" | "yellow" | "black";
-  label?: string; // single character
+  color?: MarkerColor;
+  label?: string; // single character (A–Z, 0–9)
+  size?: "tiny" | "small" | "mid" | "normal";
 };
 
 export type StaticMapPath = {
@@ -209,6 +246,72 @@ export type StaticMapPath = {
   color?: string; // hex without "#"
   weight?: number;
 };
+
+export type MapStyle = "journies" | "minimal" | "default";
+
+// The Journies map style — a hand-tuned cohesive look that matches the
+// warm-paper editorial palette. Built around three rules:
+//   1. Hide commercial POIs entirely — the map exists to orient, not advertise.
+//   2. Roads + landscape stay in the cream/card range; the only contrast is
+//      water (sage) and the terra-tinted highway hairlines.
+//   3. Labels are stripped to administrative + locality + major roads, all
+//      in ink-dim, so the route + pins read first.
+const JOURNIES_STYLE = [
+  // Global label treatment — ink-dim text on a paper halo.
+  "feature:all|element:labels.text.fill|color:0x6e6557",
+  "feature:all|element:labels.text.stroke|color:0xfbf8f1|weight:2",
+  "feature:all|element:labels.icon|visibility:off",
+
+  // Landscape — warm paper.
+  "feature:landscape|element:geometry|color:0xf4f0e7",
+  "feature:landscape.man_made|element:geometry|color:0xede7d8",
+  "feature:landscape.natural|element:geometry|color:0xede7d8",
+
+  // POIs — hidden. We surface our own markers instead.
+  "feature:poi|element:all|visibility:off",
+  "feature:poi.park|element:geometry|color:0xe6ebdb|visibility:on",
+  "feature:poi.park|element:labels|visibility:off",
+
+  // Transit lines — off (we own the route polyline).
+  "feature:transit|element:all|visibility:off",
+  "feature:transit.station|element:labels.text|visibility:on|color:0x9c917f",
+
+  // Roads — three-tier hierarchy, all in the cream range.
+  "feature:road|element:geometry.fill|color:0xfbf8f1",
+  "feature:road|element:geometry.stroke|color:0xe4ddcd",
+  "feature:road|element:labels.icon|visibility:off",
+  "feature:road.local|element:labels|visibility:simplified",
+  "feature:road.local|element:geometry|color:0xf7f2e6",
+  "feature:road.arterial|element:geometry.fill|color:0xfbf8f1",
+  "feature:road.arterial|element:geometry.stroke|color:0xd6cdb8",
+  "feature:road.highway|element:geometry.fill|color:0xf0e6c8",
+  "feature:road.highway|element:geometry.stroke|color:0xa07520",
+  "feature:road.highway|element:labels.text.fill|color:0x8e3c20",
+
+  // Water — sage-tinted, the one cool note in the palette.
+  "feature:water|element:geometry|color:0xb8c2a8",
+  "feature:water|element:labels.text.fill|color:0x5f7053",
+
+  // Administrative — faint hairlines.
+  "feature:administrative|element:geometry.stroke|color:0xd6cdb8",
+  "feature:administrative.country|element:geometry.stroke|color:0x9c917f",
+  "feature:administrative.locality|element:labels.text.fill|color:0x3a342c",
+  "feature:administrative.neighborhood|element:labels|visibility:off",
+];
+
+// Minimal: just desaturate, no POI/transit hiding. Useful when we want a
+// map-of-record (e.g. customer site context) and don't want surprises.
+const MINIMAL_STYLE = [
+  "feature:all|element:labels.text.fill|color:0x5f5a52",
+  "feature:all|element:labels.text.stroke|color:0xfbf8f1",
+  "feature:landscape|element:geometry|color:0xf4f0e7",
+  "feature:road|element:geometry.fill|color:0xfbf8f1",
+  "feature:road|element:geometry.stroke|color:0xe4ddcd",
+  "feature:water|element:geometry|color:0xd6cdb8",
+  "feature:poi|element:geometry|color:0xede7d8",
+  "feature:poi|element:labels|visibility:simplified",
+  "feature:administrative|element:geometry.stroke|color:0xd6cdb8",
+];
 
 export function buildStaticMapUrl(args: {
   markers?: StaticMapMarker[];
@@ -219,7 +322,7 @@ export function buildStaticMapUrl(args: {
   zoom?: number;
   center?: LatLng;
   mapType?: "roadmap" | "satellite" | "hybrid" | "terrain";
-  style?: "minimal" | "default";
+  style?: MapStyle;
 }): string | null {
   const key = mapsApiKey();
   if (!key) return null;
@@ -235,25 +338,22 @@ export function buildStaticMapUrl(args: {
   if (args.zoom) url.searchParams.set("zoom", String(args.zoom));
   url.searchParams.set("maptype", args.mapType ?? "roadmap");
 
-  // Subtle desaturated style to match the warm paper palette.
-  if (args.style !== "minimal") {
-    const desat = [
-      "feature:all|element:labels.text.fill|color:0x5f5a52",
-      "feature:all|element:labels.text.stroke|color:0xfbf8f1",
-      "feature:landscape|element:geometry|color:0xf4f0e7",
-      "feature:road|element:geometry.fill|color:0xfbf8f1",
-      "feature:road|element:geometry.stroke|color:0xe4ddcd",
-      "feature:water|element:geometry|color:0xd6cdb8",
-      "feature:poi|element:geometry|color:0xede7d8",
-      "feature:poi|element:labels|visibility:simplified",
-      "feature:administrative|element:geometry.stroke|color:0xd6cdb8",
-    ];
-    for (const s of desat) url.searchParams.append("style", s);
+  const style = args.style ?? "journies";
+  const styleRules =
+    style === "journies"
+      ? JOURNIES_STYLE
+      : style === "minimal"
+        ? MINIMAL_STYLE
+        : null;
+  if (styleRules) {
+    for (const s of styleRules) url.searchParams.append("style", s);
   }
 
   for (const m of args.markers ?? []) {
+    const hex = MARKER_HEX[m.color ?? "terra"];
     const parts = [
-      `color:${m.color ?? "red"}`,
+      `color:0x${hex}`,
+      m.size && m.size !== "normal" ? `size:${m.size}` : "",
       m.label ? `label:${m.label}` : "",
       `${m.lat},${m.lng}`,
     ].filter(Boolean);


### PR DESCRIPTION
This PR introduces a cohesive editorial design language to the app by porting the Journeys story deck's visual vocabulary into reusable React components. The changes unify the dashboard, itineraries list, and landing page around a consistent serif-italic, warm-palette aesthetic.

## Summary
Replaced ad-hoc page layouts with a new editorial component system (`Masthead`, `StatGroup`, `Stat`, `FlankEyebrow`, `ChapterNumber`) that mirrors the deck's design language. Updated the Google Maps styling to support a hand-tuned "Journies" palette that matches the warm paper editorial theme, and refactored several key pages to use these new atoms.

## Key Changes

- **New editorial component library** (`src/components/ui/editorial.tsx`):
  - `Masthead`: Large serif-italic title with optional chapter number, standfirst, and action buttons
  - `StatGroup` / `Stat`: Responsive grid layout for numeric stats with labels
  - `FlankEyebrow`: Uppercase label with flanking hairline rules
  - `ChapterNumber`: Giant serif-italic numerals for story section kickoffs
  - All components are server-safe with no client hooks

- **Dashboard redesign** (`src/app/(app)/dashboard/page.tsx`):
  - Replaced `PageShell` wrapper with direct layout div
  - Converted `NextItineraryHero` to use `Masthead` component
  - Refactored stat cards to use new `StatGroup`/`Stat` atoms
  - Added `splitTitleForMasthead()` utility to intelligently emphasize destination names
  - Updated `NoNext()` fallback to use `Masthead`

- **Itineraries list redesign** (`src/app/(app)/itineraries/page.tsx`):
  - Replaced `PageShell` with `Masthead` header
  - Updated section headers to use `FlankEyebrow`

- **Landing page refresh** (`src/app/page.tsx`):
  - Converted to use `Masthead` and `StatGroup` components
  - Maintains consistent editorial voice with app pages

- **Enhanced Google Maps styling** (`src/lib/google/maps.ts`):
  - Added `JOURNIES_STYLE`: Hand-tuned map style hiding commercial POIs, using sage water and terra highway accents, ink-dim labels
  - Added `MINIMAL_STYLE`: Desaturated alternative for reference maps
  - Introduced `MarkerColor` type with brand palette (terra, sage, amber, rust, ink) and legacy aliases
  - Added `MARKER_HEX` mapping for consistent pin colors
  - Extended `StaticMapMarker` with optional `size` parameter

- **CSS additions** (`src/app/globals.css`):
  - New `.chapter-number`, `.flank-eyebrow`, `.stat-grid`, `.stat-col` classes
  - `.editorial-dark` variant for ink-background hero blocks with inverted text
  - Responsive grid layouts for 2-up/3-up/4-up stat displays

- **StaticMap component update** (`src/components/static-map.tsx`):
  - Added `style` prop to support different map themes
  - Wrapped in `<figure>` with subtle inner ring for editorial framing
  - Defaults to "journies" style

## Implementation Details

The new editorial system maintains the warm paper palette (cream backgrounds, terra accents, ink text) consistently across all pages. The `Masthead` component intelligently handles optional chapter numbers, emphasized fragments (rendered in terra italic), and action buttons, reducing boilerplate across feature pages. The map styling system is extensible—new styles can be added by defining style rule arrays without touching component code.

https://claude.ai/code/session_01GM9oEFdRc293cabnhrnDLw