### PR TITLE
Brand book Edition I — palette, type, mark, wordmark + theme picker

### DIFF
--- a/src/app/(app)/bookings/page.tsx
+++ b/src/app/(app)/bookings/page.tsx
@@ -466,9 +466,10 @@ function BookingCard({
             <span
               style={{
                 fontFamily: "var(--display)",
-                fontStyle: "italic",
+                fontWeight: 500,
                 fontSize: 20,
                 color: "var(--ink)",
+                letterSpacing: "-0.02em",
               }}
             >
               {fmtMoney(Number(booking.actual_price), booking.currency)}

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -4,6 +4,7 @@ import { createClient } from "@/lib/supabase/server";
 import { requireUserContext } from "@/lib/auth";
 import { TravelProfileForm } from "./travel-profile-form";
 import { CalendarSection } from "./calendar-section";
+import { ThemePicker } from "@/components/theme-picker";
 
 export default async function SettingsPage({
   searchParams,
@@ -150,6 +151,25 @@ export default async function SettingsPage({
           />
         </div>
       </section>
+
+      {ctx.isStaff ? (
+        <section className="j-card p-5">
+          <div className="mb-1 flex items-baseline justify-between gap-3 flex-wrap">
+            <h2 className="h3">Palette</h2>
+            {/* TODO(brand): remove the staff guard once the alternate
+                palettes are signed off for all users. */}
+            <span className="tiny" style={{ color: "var(--gold-2)" }}>
+              Visible to staff only · TODO open to all users
+            </span>
+          </div>
+          <p className="small mb-4" style={{ color: "var(--ink-dim)" }}>
+            The three sanctioned Khonsera palettes from the brand book.
+            Selection persists in this browser; the rest of the workspace
+            isn&rsquo;t affected.
+          </p>
+          <ThemePicker />
+        </section>
+      ) : null}
 
       <ComingSoon
         feature="Notifications · working hours · Outlook calendar"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,53 +2,77 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Khonsera — design tokens & atoms, exact match to the reference identity
- * sheet. The canonical five-colour palette is:
+/* Khonsera — design tokens & atoms, aligned to the Visual Identity brand
+ * book (Edition I · MMXXVI). The canonical "dusk" palette is the default;
+ * "sahara" (sun-up) and "dark" (midnight) are the two sanctioned alternates.
  *
- *   #1C1C1C  ink            primary text, brand black
- *   #C89D4D  gold           the moon, the accent, the lead
- *   #E9DFC6  sand           secondary surface, dividers
- *   #F6F1E6  paper          primary app ground
- *   #475569  slate          cool foil for chips / links
+ *   Khonsera Gold      #B8893F   the moon, the accent, the lead
+ *   Walnut Ink         #1E1812   primary text, brand black
+ *   Dusk Paper         #EFE6D0   primary app ground
+ *   Bone               #F7EED7   secondary paper / card highlight
+ *   Terracotta         #C25C3A   rare salt — celebratory, alerts
+ *   Dusk Plum          #5C3A48   evening depth — overnight contexts
+ *   Khorasan Sage      #687856   quiet success
  *
- * Themes: [data-theme="light"] (default) | [data-theme="dark"]
- * The legacy --terra / --rule-2 / --plum tokens stay so existing screens
- * keep resolving; they alias onto the canonical palette where it makes
- * sense (terra → gold for hot accents, plum → slate for cool ones). */
+ * Gold ramp:  100 #EFDFB1 · 200 #D4AE6A · 400 #B8893F · 600 #936820 · 800 #5C3F10
+ *
+ * Themes:
+ *   [data-theme="light"]   — Dusk (default, candlelit warm)
+ *   [data-theme="sahara"]  — Sun-up (papyrus + ochre)
+ *   [data-theme="dark"]    — Midnight (aubergine ground, brass moon)
+ *
+ * Per the composition rule (p. 11), paper dominates, ink frames, gold is
+ * the punctuation. Terracotta and plum are rare salts — one per composition,
+ * never both. */
 @layer base {
   :root,
   [data-theme="light"] {
-    /* canonical paper + ink */
-    --paper: #f6f1e6;
-    --paper-2: #ece4d2;
-    --sand: #e9dfc6;
-    --sand-2: #d9cdb1;
-    --card: #fbf7ec;
-    --card-2: #f2ead6;
+    /* Dusk — the canonical palette */
+    --paper: #efe6d0;        /* Dusk Paper */
+    --paper-2: #e6dabf;
+    --sand: #f7eed7;         /* Bone */
+    --sand-2: #e8d9b5;
+    --card: #f4ecd6;
+    --card-2: #ece0bd;
 
-    --ink: #1c1c1c;
-    --ink-2: #2a2620;
-    --ink-dim: #6e6557;
-    --ink-faint: #a39681;
+    --ink: #1e1812;          /* Walnut Ink */
+    --ink-2: #2c241a;
+    --ink-dim: #6b5c46;
+    --ink-faint: #a2917a;
 
-    --rule: #decfab;
-    --rule-2: #c9b989;
+    --rule: #ddc99e;
+    --rule-2: #c8b074;
 
-    /* gold — the moon */
-    --gold: #c89d4d;
-    --gold-2: #a77e2f;
-    --gold-soft: #f0e1b7;
-    --gold-tint: rgba(200, 157, 77, 0.10);
+    /* Gold — the moon. Khonsera Gold #B8893F is the 400 step. */
+    --gold-100: #efdfb1;
+    --gold-200: #d4ae6a;
+    --gold: #b8893f;         /* 400 */
+    --gold-2: #936820;       /* 600 */
+    --gold-800: #5c3f10;
+    --gold-soft: #efdfb1;
+    --gold-tint: rgba(184, 137, 63, 0.10);
 
-    /* cool foil — slate (kept for non-warm accents like links/chips) */
+    /* Terracotta — celebratory salt; also the notification badge per
+       p. 20. Not a primary palette colour; use sparingly. */
+    --terra: #c25c3a;
+    --terra-2: #a14c2c;
+    --terra-deep: #7d3a1e;
+
+    /* Plum — overnight, ceremony. Rare. */
+    --plum: #5c3a48;
+    --plum-soft: #e3d5db;
+
+    /* Cool foil — slate, retained for non-warm chips and links. Not on
+       the canonical six but used inside the app for state contrast. */
     --slate: #475569;
     --slate-2: #334155;
     --slate-soft: #dde3ea;
 
-    /* status families */
-    --sage: #6b7a4e;
-    --sage-2: #dce2c8;
-    --sage-soft: #dce2c8;
+    /* Status families — sage for success, amber for caution, rust for
+       danger. Sage = Khorasan Sage. */
+    --sage: #687856;
+    --sage-2: #dce0cd;
+    --sage-soft: #dce0cd;
     --amber: #a87526;
     --amber-2: #f0e0b5;
     --amber-soft: #f0e0b5;
@@ -56,56 +80,115 @@
     --rust-2: #f0d6cf;
     --rust-soft: #f0d6cf;
 
-    /* legacy aliases — old code referred to these; route them onto the
-       canonical palette so the visual language stays unified. */
-    --terra: var(--gold);
-    --terra-2: var(--gold-2);
-    --terra-deep: var(--gold-2);
-    --plum: var(--slate);
-    --plum-soft: var(--slate-soft);
+    --ink-soft: rgba(30, 24, 18, 0.06);
+    --gold-soft-alpha: rgba(184, 137, 63, 0.16);
+    --shadow-sm: 0 1px 3px rgba(30, 24, 18, 0.06);
+    --shadow: 0 4px 16px rgba(30, 24, 18, 0.09);
+    --shadow-lg: 0 16px 40px rgba(30, 24, 18, 0.14);
 
-    --ink-soft: rgba(28, 28, 28, 0.06);
-    --gold-soft-alpha: rgba(200, 157, 77, 0.16);
-    --shadow-sm: 0 1px 3px rgba(28, 28, 28, 0.06);
-    --shadow: 0 4px 16px rgba(28, 28, 28, 0.08);
-    --shadow-lg: 0 16px 40px rgba(28, 28, 28, 0.12);
-
-    --display: var(--font-display), "Playfair Display", "Lora", Georgia, serif;
-    --serif: var(--font-serif), "Lora", Georgia, serif;
+    /* Type stack — Satoshi for display + wordmark + headlines, Inter for
+       body & UI, JetBrains Mono for codes & eyebrows, Cormorant Garamond
+       for decorative serif italic. (Brand book pp. 13–15.) */
+    --display: "Satoshi", var(--font-sans), -apple-system, system-ui, sans-serif;
+    --serif: var(--font-serif), "Cormorant Garamond", Georgia, serif;
     --sans: var(--font-sans), "Inter", -apple-system, system-ui, sans-serif;
     --mono: var(--font-mono), "JetBrains Mono", ui-monospace, monospace;
   }
 
-  /* Night theme — kept for the profile-page palette toggle. Same gold +
-     slate, deep walnut paper, paper-as-ink. */
+  /* Sun-up — for daylight contexts: in-flight magazines, beach hotels,
+     white-walled studio shoots. Gold deepens to ochre; paper bleaches to
+     papyrus. (Brand book p. 12.) */
+  [data-theme="sahara"] {
+    --paper: #f3e8c8;
+    --paper-2: #ecdeb1;
+    --sand: #fbf1d4;
+    --sand-2: #ecdeb1;
+    --card: #f8ecc4;
+    --card-2: #ecdeb1;
+
+    --ink: #20180e;
+    --ink-2: #483a23;
+    --ink-dim: #816f48;
+    --ink-faint: #b6a576;
+
+    --rule: #d8c184;
+    --rule-2: #b89c52;
+
+    --gold-100: #f4e2a2;
+    --gold-200: #d4ae6a;
+    --gold: #a87826;
+    --gold-2: #7f5618;
+    --gold-800: #533710;
+    --gold-soft: #f0dca1;
+    --gold-tint: rgba(168, 120, 38, 0.10);
+
+    --terra: #b85a31;
+    --terra-2: #94431f;
+    --terra-deep: #732f12;
+    --plum: #5a3540;
+    --plum-soft: #e6d0d0;
+
+    --slate: #6b7a8c;
+    --slate-2: #4f5d6e;
+    --slate-soft: #d6dee6;
+
+    --sage: #6b7449;
+    --sage-2: #e1ddb6;
+    --sage-soft: #e1ddb6;
+    --amber: #a87526;
+    --amber-2: #f0e0b5;
+    --amber-soft: #f0e0b5;
+    --rust: #94431f;
+    --rust-2: #f0d6cf;
+    --rust-soft: #f0d6cf;
+
+    --ink-soft: rgba(32, 24, 14, 0.07);
+    --gold-soft-alpha: rgba(168, 120, 38, 0.16);
+    --shadow-sm: 0 1px 3px rgba(32, 24, 14, 0.07);
+    --shadow: 0 4px 16px rgba(32, 24, 14, 0.10);
+    --shadow-lg: 0 16px 40px rgba(32, 24, 14, 0.15);
+  }
+
+  /* Midnight — overnight flights, premium tickets, hotel keycards, the
+     after-hours newsletter. Aubergine ground, brass moon. Reserved.
+     (Brand book p. 12.) */
   [data-theme="dark"] {
-    --paper: #14110d;
-    --paper-2: #0c0a07;
-    --sand: #1f1a12;
-    --sand-2: #2a2318;
-    --card: #1b170f;
-    --card-2: #221c13;
+    --paper: #1f1825;
+    --paper-2: #15101a;
+    --sand: #2a2032;
+    --sand-2: #362841;
+    --card: #251c2d;
+    --card-2: #2d2236;
 
-    --ink: #f5eedc;
-    --ink-2: #e2d6bb;
-    --ink-dim: #98876a;
-    --ink-faint: #5d5340;
+    --ink: #f4e8cf;
+    --ink-2: #ddd0b6;
+    --ink-dim: #97896e;
+    --ink-faint: #6c5e47;
 
-    --rule: #2e2618;
-    --rule-2: #3e331f;
+    --rule: #38293d;
+    --rule-2: #4a3850;
 
-    --gold: #d9b065;
-    --gold-2: #bd9748;
-    --gold-soft: #2d2418;
-    --gold-tint: rgba(217, 176, 101, 0.10);
+    --gold-100: #3a2c1c;
+    --gold-200: #6e521f;
+    --gold: #d4a04d;
+    --gold-2: #b07b2a;
+    --gold-800: #f0c87a;
+    --gold-soft: #3b2f1c;
+    --gold-tint: rgba(212, 160, 77, 0.12);
+
+    --terra: #d77450;
+    --terra-2: #c25c3a;
+    --terra-deep: #9d4225;
+    --plum: #905d72;
+    --plum-soft: #392332;
 
     --slate: #8b9bb0;
     --slate-2: #6f7e92;
     --slate-soft: #2a3140;
 
-    --sage: #a7b385;
-    --sage-2: #28301b;
-    --sage-soft: #28301b;
+    --sage: #93a07a;
+    --sage-2: #2f3a2a;
+    --sage-soft: #2f3a2a;
     --amber: #d9a85a;
     --amber-2: #3a2f15;
     --amber-soft: #3a2f15;
@@ -113,14 +196,8 @@
     --rust-2: #3a1f18;
     --rust-soft: #3a1f18;
 
-    --terra: var(--gold);
-    --terra-2: var(--gold-2);
-    --terra-deep: var(--gold-2);
-    --plum: var(--slate);
-    --plum-soft: var(--slate-soft);
-
-    --ink-soft: rgba(245, 238, 220, 0.06);
-    --gold-soft-alpha: rgba(217, 176, 101, 0.18);
+    --ink-soft: rgba(244, 232, 207, 0.07);
+    --gold-soft-alpha: rgba(212, 160, 77, 0.18);
     --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.5);
     --shadow: 0 4px 18px rgba(0, 0, 0, 0.55);
     --shadow-lg: 0 18px 44px rgba(0, 0, 0, 0.65);
@@ -421,17 +498,21 @@
     font-style: normal;
   }
 
-  /* Khonsera brand lockup — moon + wordmark, gold "a" tail. */
+  /* Khonsera brand lockup — moon + KHONSERA wordmark. Set in Satoshi 500,
+     uppercase, tracked, monocolour ink. The mark is the only gold element
+     (brand book p. 9 — "Don't recolour. Gold or ink only; never invent
+     palettes."). The KhonseraBrand React component overrides per-size
+     letter-spacing for true brand-book tracking values. */
   .brand-lockup {
     display: inline-flex;
     align-items: center;
-    gap: 9px;
+    gap: 10px;
     font-family: var(--display);
-    font-style: italic;
     font-weight: 500;
-    font-size: 22px;
+    font-size: 15px;
     line-height: 1;
-    letter-spacing: -0.015em;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
     color: var(--ink);
   }
   .brand-lockup svg {
@@ -509,31 +590,42 @@
   }
   .display {
     font-family: var(--display);
-    font-style: italic;
+    font-weight: 500;
+    letter-spacing: -0.02em;
   }
-
-  /* Wordmark sizes for hero/marketing surfaces */
-  .wordmark {
+  .display-i {
     font-family: var(--display);
     font-style: italic;
     font-weight: 500;
-    font-size: 72px;
-    line-height: 0.95;
-    letter-spacing: -0.025em;
+  }
+
+  /* Wordmark — Satoshi 500, uppercase, tracked. Monocolour ink. The .em
+     span used to receive a gold tint; per the brand book wordmark rule
+     ("Don't recolour. Gold or ink only; never invent palettes.") it now
+     resolves to ink as well. The mark is the only gold element. */
+  .wordmark {
+    font-family: var(--display);
+    font-weight: 500;
+    font-size: 56px;
+    line-height: 0.98;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
     color: var(--ink);
   }
   .wordmark .em {
-    color: var(--gold);
-    font-style: italic;
+    color: inherit;
   }
   .wordmark.sm {
-    font-size: 28px;
+    font-size: 22px;
+    letter-spacing: 0.18em;
   }
   .wordmark.md {
-    font-size: 44px;
+    font-size: 34px;
+    letter-spacing: 0.08em;
   }
   .wordmark.lg {
-    font-size: 96px;
+    font-size: 88px;
+    letter-spacing: 0.02em;
   }
 
   /* Luxe ornamental rule — a hairline with a gold dot in the middle, used

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -273,30 +273,27 @@
   }
 
   .h0 {
-    font-family: var(--serif);
-    font-style: italic;
+    font-family: var(--display);
     font-weight: 500;
     font-size: 56px;
     line-height: 1.02;
-    letter-spacing: -0.02em;
+    letter-spacing: -0.035em;
     color: var(--ink);
   }
   .h1 {
-    font-family: var(--serif);
-    font-style: italic;
+    font-family: var(--display);
     font-weight: 500;
     font-size: 40px;
     line-height: 1.05;
-    letter-spacing: -0.02em;
+    letter-spacing: -0.03em;
     color: var(--ink);
   }
   .h2 {
-    font-family: var(--serif);
-    font-style: italic;
+    font-family: var(--display);
     font-weight: 500;
     font-size: 28px;
     line-height: 1.1;
-    letter-spacing: -0.015em;
+    letter-spacing: -0.025em;
     color: var(--ink);
   }
   .h3 {
@@ -481,22 +478,8 @@
     color: var(--ink-faint);
   }
 
-  .brand-glyph {
-    font-family: var(--serif);
-    font-style: italic;
-    font-weight: 500;
-    font-size: 18px;
-    letter-spacing: -0.02em;
-    color: var(--ink);
-    display: inline-flex;
-    align-items: center;
-  }
-  .brand-glyph::before {
-    content: "∗";
-    color: var(--terra);
-    margin-right: 6px;
-    font-style: normal;
-  }
+  /* Legacy .brand-glyph removed — superseded by .brand-lockup +
+     KhonseraBrand component (waxing-crescent mark + Satoshi wordmark). */
 
   /* Khonsera brand lockup — moon + KHONSERA wordmark. Set in Satoshi 500,
      uppercase, tracked, monocolour ink. The mark is the only gold element
@@ -820,18 +803,18 @@
 
   /* Magazine-style title */
   .masthead-title {
-    font-family: var(--serif);
+    font-family: var(--display);
     font-weight: 500;
     font-size: 50px;
     line-height: 1.02;
-    letter-spacing: -0.025em;
+    letter-spacing: -0.035em;
     color: var(--ink);
     margin: 0;
     text-wrap: pretty;
   }
   .masthead-title em,
   .masthead-title .em {
-    font-style: italic;
+    font-style: normal;
     color: var(--gold);
     font-weight: 500;
   }
@@ -864,13 +847,12 @@
     min-width: 0;
   }
   .stat-col .v {
-    font-family: var(--serif);
-    font-style: italic;
+    font-family: var(--display);
     font-weight: 500;
     font-size: 30px;
     line-height: 1;
     color: var(--ink);
-    letter-spacing: -0.02em;
+    letter-spacing: -0.025em;
   }
   .stat-col .l {
     font-size: 10px;
@@ -1009,13 +991,12 @@
     margin-bottom: 4px;
   }
   .tl-title {
-    font-family: var(--serif);
-    font-style: italic;
+    font-family: var(--display);
     font-weight: 500;
     font-size: 19px;
     line-height: 1.25;
     color: var(--ink);
-    letter-spacing: -0.01em;
+    letter-spacing: -0.02em;
     margin: 0;
   }
   .tl-sub {
@@ -1145,9 +1126,10 @@
     color: var(--ink);
   }
   .digest-panel .row.total .v {
-    font-family: var(--serif);
-    font-style: italic;
+    font-family: var(--display);
+    font-weight: 500;
     font-size: 20px;
+    letter-spacing: -0.02em;
     color: var(--ink);
   }
 
@@ -1173,13 +1155,12 @@
   /* Giant serif italic chapter numeral — used as the kickoff for a story
      block ("01", "02", "03" in the deck). Terra so the eye finds it first. */
   .chapter-number {
-    font-family: var(--serif);
-    font-style: italic;
+    font-family: var(--display);
     font-weight: 500;
     font-size: 64px;
     line-height: 0.95;
-    letter-spacing: -0.03em;
-    color: var(--terra);
+    letter-spacing: -0.04em;
+    color: var(--gold);
     display: inline-block;
   }
   .chapter-number.lg {
@@ -1315,11 +1296,10 @@
     color: var(--ink-dim);
   }
   .day-header .title {
-    font-family: var(--serif);
-    font-style: italic;
+    font-family: var(--display);
     font-weight: 500;
     font-size: 24px;
-    letter-spacing: -0.01em;
+    letter-spacing: -0.025em;
     color: var(--ink);
   }
   .day-header .meta {
@@ -1747,14 +1727,14 @@
   }
   .anchor-stat .v {
     font-family: var(--display);
-    font-style: italic;
     font-weight: 500;
     font-size: 36px;
     line-height: 1;
-    letter-spacing: -0.025em;
+    letter-spacing: -0.03em;
     color: var(--ink);
   }
   .anchor-stat .v em {
+    font-style: normal;
     color: var(--gold);
     font-weight: 500;
   }
@@ -1778,11 +1758,10 @@
   }
   .kpi .v {
     font-family: var(--display);
-    font-style: italic;
     font-weight: 500;
     font-size: 28px;
     line-height: 1;
-    letter-spacing: -0.02em;
+    letter-spacing: -0.025em;
     color: var(--ink);
   }
   .kpi .l {
@@ -1843,15 +1822,15 @@
   }
   .app-header .title {
     font-family: var(--display);
-    font-style: italic;
     font-weight: 500;
     font-size: 32px;
     line-height: 1.04;
-    letter-spacing: -0.025em;
+    letter-spacing: -0.03em;
     color: var(--ink);
     margin: 0;
   }
   .app-header .title em {
+    font-style: normal;
     color: var(--gold);
   }
   .app-header .sub {
@@ -1957,12 +1936,11 @@
   }
   .trip-row-day {
     font-family: var(--display);
-    font-style: italic;
     font-weight: 500;
     font-size: 44px;
     line-height: 1;
     color: var(--ink);
-    letter-spacing: -0.025em;
+    letter-spacing: -0.035em;
     margin-top: 2px;
   }
   .trip-row-live .trip-row-day {
@@ -1988,13 +1966,12 @@
   }
   .trip-row-title {
     font-family: var(--display);
-    font-style: italic;
     font-weight: 500;
     font-size: 26px;
     line-height: 1.15;
     color: var(--ink);
     margin: 0;
-    letter-spacing: -0.02em;
+    letter-spacing: -0.025em;
     overflow: hidden;
     text-overflow: ellipsis;
     display: -webkit-box;
@@ -2002,6 +1979,7 @@
     -webkit-box-orient: vertical;
   }
   .trip-row-title em {
+    font-style: normal;
     color: var(--gold);
     font-weight: 500;
   }
@@ -2114,10 +2092,10 @@
     background: var(--gold);
     color: #fff;
     font-family: var(--display);
-    font-style: italic;
     font-weight: 600;
     font-size: 13px;
     line-height: 1;
+    letter-spacing: 0.02em;
   }
   .brief-helper {
     margin: 0 0 12px;
@@ -2367,12 +2345,11 @@
   }
   .anchor-summary-title {
     font-family: var(--display);
-    font-style: italic;
     font-size: 20px;
     font-weight: 500;
     color: var(--ink);
     margin: 2px 0 0;
-    letter-spacing: -0.01em;
+    letter-spacing: -0.02em;
   }
   .anchor-summary-meta {
     font-family: var(--serif);
@@ -2543,12 +2520,11 @@
   }
   .home-header-title {
     font-family: var(--display);
-    font-style: italic;
     font-size: 18px;
     font-weight: 500;
     color: var(--ink);
     margin: 2px 0 0;
-    letter-spacing: -0.005em;
+    letter-spacing: -0.015em;
   }
   .home-header-meta {
     font-family: var(--serif);
@@ -2675,12 +2651,11 @@
   }
   .transit-stop-title {
     font-family: var(--display);
-    font-style: italic;
     font-size: 16px;
     font-weight: 500;
     color: var(--ink);
     margin: 2px 0 0;
-    letter-spacing: -0.005em;
+    letter-spacing: -0.01em;
   }
   .transit-stop-remove {
     position: absolute;
@@ -3087,7 +3062,7 @@
   }
   .transition-chip > span:first-child {
     font-family: var(--display);
-    font-style: italic;
+    font-weight: 500;
     font-size: 14px;
     line-height: 1;
   }
@@ -3319,9 +3294,10 @@
   }
   .around-then-blurb > span:first-child {
     font-family: var(--display);
-    font-style: italic;
+    font-weight: 500;
     font-size: 18px;
     line-height: 1;
+    letter-spacing: -0.015em;
   }
 
   /* Anchor kind badge + sub-role badge — the primary classification
@@ -3506,7 +3482,6 @@
   }
   .brief-between-btn span:first-child {
     font-family: var(--display);
-    font-style: italic;
     font-weight: 600;
     color: var(--gold-2);
     font-size: 16px;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1695,30 +1695,30 @@
   /* Display heads inside the desktop shell */
   .desk-h1 {
     font-family: var(--display);
-    font-style: italic;
     font-weight: 500;
     font-size: 42px;
     line-height: 1.05;
-    letter-spacing: -0.025em;
+    letter-spacing: -0.035em;
     color: var(--ink);
     margin: 0;
   }
   .desk-h1 em {
     color: var(--gold);
+    font-style: normal;
     font-weight: 500;
   }
   .desk-h2 {
     font-family: var(--display);
-    font-style: italic;
     font-weight: 500;
     font-size: 26px;
     line-height: 1.1;
-    letter-spacing: -0.02em;
+    letter-spacing: -0.03em;
     color: var(--ink);
     margin: 0;
   }
   .desk-h2 em {
     color: var(--gold);
+    font-style: normal;
     font-weight: 500;
   }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -49,6 +49,14 @@ export default function RootLayout({
           rel="stylesheet"
           href="https://api.fontshare.com/v2/css?f[]=satoshi@300,400,500,700,900,300i,400i,500i,700i,900i&display=swap"
         />
+        {/* No-FOUC theme init — applies the persisted palette (dusk /
+            sahara / midnight) before first paint. Settings → Palette
+            sets the key. Currently only staff can change it. */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `try{var t=localStorage.getItem('khonsera:theme');if(t==='sahara'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}`,
+          }}
+        />
       </head>
       <body>{children}</body>
     </html>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,42 +1,34 @@
 import type { Metadata, Viewport } from "next";
-import {
-  Inter,
-  JetBrains_Mono,
-  Lora,
-  Playfair_Display,
-} from "next/font/google";
+import { Cormorant_Garamond, Inter, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 
-// Canonical Khonsera type stack:
-//   • Inter           — sans / UI
-//   • Lora            — serif body italic
-//   • Playfair Display — display italic (wordmark + chapter heads)
-//   • JetBrains Mono  — mono numerals + labels
+// Canonical Khonsera type stack, per the Visual Identity brand book
+// (Edition I · MMXXVI):
+//
+//   • Satoshi         — display + wordmark + headlines. Loaded from
+//                       Fontshare via a <link>; not on Google Fonts.
+//   • Inter           — body, UI, captions, standfirst
+//   • JetBrains Mono  — codes, times, eyebrows
+//   • Cormorant Garamond — editorial serif italic (decorative use only)
 const sans = Inter({ subsets: ["latin"], variable: "--font-sans" });
 const mono = JetBrains_Mono({ subsets: ["latin"], variable: "--font-mono" });
-const serif = Lora({
+const serif = Cormorant_Garamond({
   subsets: ["latin"],
   style: ["italic", "normal"],
   weight: ["400", "500", "600"],
   variable: "--font-serif",
 });
-const display = Playfair_Display({
-  subsets: ["latin"],
-  style: ["italic", "normal"],
-  weight: ["400", "500", "600", "700"],
-  variable: "--font-display",
-});
 
 export const metadata: Metadata = {
-  title: "Khonsera — quietly luxe travel planning",
+  title: "Khonsera — travel days, considered.",
   description:
-    "Khonsera plans, confirms and executes your trips. The traveller's evening — calm, considered, confident.",
+    "A quiet concierge for the slow blue hour. Plan the in-between hours of your travel — the train that might not be running, the taxi at dusk, the careful arithmetic of getting there.",
 };
 
 export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
-  themeColor: "#f6f1e6",
+  themeColor: "#efe6d0",
 };
 
 export default function RootLayout({
@@ -48,8 +40,16 @@ export default function RootLayout({
     <html
       lang="en"
       data-theme="light"
-      className={`${sans.variable} ${mono.variable} ${serif.variable} ${display.variable}`}
+      className={`${sans.variable} ${mono.variable} ${serif.variable}`}
     >
+      <head>
+        {/* Satoshi — display face per the brand book. Self-served via
+            Fontshare; Satoshi is not on Google Fonts. */}
+        <link
+          rel="stylesheet"
+          href="https://api.fontshare.com/v2/css?f[]=satoshi@300,400,500,700,900,300i,400i,500i,700i,900i&display=swap"
+        />
+      </head>
       <body>{children}</body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -55,8 +55,9 @@ export default function LandingPage() {
           className="standfirst"
           style={{ maxWidth: 520, fontSize: 18, color: "var(--ink-2)" }}
         >
-          The traveller&rsquo;s evening — <em>plan, book and keep</em> the
-          days a working life is built of.
+          A quiet concierge for the slow blue hour. <em>Plan the in-between
+          hours</em> — the train that might not be running, the taxi at
+          dusk, the careful arithmetic of getting there.
         </p>
       </div>
 
@@ -110,7 +111,7 @@ export default function LandingPage() {
             letterSpacing: 0.02,
           }}
         >
-          Calm. Considered. Confident.
+          Calm. Considered. Precise. Premium.
         </p>
       </div>
     </main>

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -93,8 +93,9 @@ export function AppSidebar({
               alignItems: "center",
               justifyContent: "center",
               fontFamily: "var(--display)",
-              fontStyle: "italic",
-              fontSize: 15,
+              fontWeight: 600,
+              fontSize: 14,
+              letterSpacing: "0.04em",
             }}
           >
             {initial}

--- a/src/components/khonsera-brand.tsx
+++ b/src/components/khonsera-brand.tsx
@@ -1,71 +1,166 @@
 import Link from "next/link";
 
 type Size = "xs" | "sm" | "md" | "lg" | "xl";
+export type MarkVariant = "crescent" | "hairline" | "crescent-star" | "seal";
 
-// Mark + wordmark sizing per the brand book's lockup system. The mark
-// reads optically smaller than the cap-height, so the wordmark font-size
-// is a touch larger than the mark size for visual parity.
 const SIZES: Record<Size, { glyph: number; font: number; track: number }> = {
-  xs: { glyph: 14, font: 11, track: 0.18 },
-  sm: { glyph: 18, font: 13, track: 0.2 },
-  md: { glyph: 22, font: 15, track: 0.22 },
-  lg: { glyph: 36, font: 26, track: 0.18 },
-  xl: { glyph: 56, font: 44, track: 0.14 },
+  xs: { glyph: 16, font: 11, track: 0.18 },
+  sm: { glyph: 22, font: 13, track: 0.2 },
+  md: { glyph: 28, font: 15, track: 0.22 },
+  lg: { glyph: 44, font: 26, track: 0.18 },
+  xl: { glyph: 72, font: 44, track: 0.14 },
 };
 
-// The Khonsera mark — a waxing crescent, drawn as the negative space
-// between two perfect circles. Construction (per the brand book, p. 5):
+// Crescent construction: outer disc R, inner disc r offset by (dx, dy)
+// from the viewbox centre. The path traces the boundary of outer ∩ ¬inner —
+// the visible waxing-crescent body. Ported from the canonical moon-mark.js.
+function crescentPath(
+  s: number,
+  R: number,
+  r: number,
+  dx: number,
+  dy: number,
+): string {
+  const cx1 = s * 0.5;
+  const cy1 = s * 0.5;
+  const d = Math.hypot(dx, dy);
+  const a = (d * d + R * R - r * r) / (2 * d);
+  const h = Math.sqrt(Math.max(0, R * R - a * a));
+  const ux = dx / d;
+  const uy = dy / d;
+  const px = cx1 + a * ux;
+  const py = cy1 + a * uy;
+  const i1x = px + h * -uy;
+  const i1y = py + h * ux;
+  const i2x = px - h * -uy;
+  const i2y = py - h * ux;
+  return (
+    `M ${i1x.toFixed(2)} ${i1y.toFixed(2)} ` +
+    `A ${R} ${R} 0 1 1 ${i2x.toFixed(2)} ${i2y.toFixed(2)} ` +
+    `A ${r} ${r} 0 0 0 ${i1x.toFixed(2)} ${i1y.toFixed(2)} Z`
+  );
+}
+
+// The Khonsera mark. Four sanctioned variants per the brand book (p. 6):
 //
-//   bounding box  100 × 100
-//   outer disc    R₁ = 42, centred (50, 50)
-//   inner cut     R₂ = 39, centred (62, 42)   — offset +12 right, 8 up
+//   crescent       — solid waxing crescent. The workhorse.
+//   hairline       — outline of the same. Seals & stationery.
+//   crescent-star  — submark with a tiny accompanying star. Ceremony.
+//   seal           — concentric rings + tiny crescent. Crest, invitations,
+//                    app icon, favicon, wax seal. (Default.)
 //
-// The resulting asymmetric crescent leans into the upper-right, suggesting
-// motion. Rendered as an explicit two-arc path so it composites cleanly
-// (no SVG masks) for screenshots, exports and embeddings. Intersection
-// points are pre-computed in the 100-unit space.
+// Geometry mirrors moon-mark.js: a dynamic viewBox so stroke widths scale
+// with display size and stay visually consistent at any render dimension.
 export function MoonMark({
-  size = 22,
+  size = 28,
   color = "var(--gold)",
+  variant = "seal",
   title,
 }: {
   size?: number;
   color?: string;
+  variant?: MarkVariant;
   title?: string;
 }) {
+  const s = size;
+  const stroke = Math.max(1.2, s / 36);
+
+  let body: React.ReactNode;
+  switch (variant) {
+    case "hairline": {
+      const d = crescentPath(s, s * 0.42, s * 0.39, s * 0.12, -s * 0.08);
+      body = (
+        <path
+          d={d}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={stroke}
+          strokeLinejoin="round"
+        />
+      );
+      break;
+    }
+    case "crescent-star": {
+      const d = crescentPath(s, s * 0.34, s * 0.31, s * 0.1, -s * 0.06);
+      const star = `M0 ${-s * 0.06} L${s * 0.018} ${-s * 0.018} L${s * 0.06} 0 ` +
+        `L${s * 0.018} ${s * 0.018} L0 ${s * 0.06} ` +
+        `L${-s * 0.018} ${s * 0.018} L${-s * 0.06} 0 ` +
+        `L${-s * 0.018} ${-s * 0.018} Z`;
+      body = (
+        <>
+          <path d={d} fill="currentColor" />
+          <g transform={`translate(${s * 0.82} ${s * 0.18})`} fill="currentColor">
+            <path d={star} />
+          </g>
+        </>
+      );
+      break;
+    }
+    case "seal": {
+      const d = crescentPath(s, s * 0.2, s * 0.185, s * 0.06, -s * 0.04);
+      body = (
+        <>
+          <circle
+            cx={s * 0.5}
+            cy={s * 0.5}
+            r={s * 0.46}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={stroke * 0.8}
+          />
+          <circle
+            cx={s * 0.5}
+            cy={s * 0.5}
+            r={s * 0.38}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={stroke * 0.4}
+            opacity={0.55}
+          />
+          <path d={d} fill="currentColor" />
+        </>
+      );
+      break;
+    }
+    case "crescent":
+    default: {
+      const d = crescentPath(s, s * 0.42, s * 0.39, s * 0.12, -s * 0.08);
+      body = <path d={d} fill="currentColor" />;
+      break;
+    }
+  }
+
   return (
     <svg
-      width={size}
-      height={size}
-      viewBox="0 0 100 100"
+      width={s}
+      height={s}
+      viewBox={`0 0 ${s} ${s}`}
       role={title ? "img" : undefined}
       aria-hidden={title ? undefined : true}
       aria-label={title}
       style={{ color, flexShrink: 0, display: "block" }}
     >
       {title ? <title>{title}</title> : null}
-      <path
-        d="M 84.63 73.76 A 42 42 0 1 0 41.39 8.89 A 39 39 0 0 0 84.63 73.76 Z"
-        fill="currentColor"
-      />
+      {body}
     </svg>
   );
 }
 
-// The wordmark — set in Satoshi 500, uppercase, tracked. Monocolour ink
-// (brand book p. 9: "Don't recolour. Gold or ink only; never invent
-// palettes."). The mark sits to the left per the primary horizontal
-// lockup (p. 7).
+// The wordmark — Satoshi 500, uppercase, tracked. Monocolour ink (brand
+// book p. 9: "Don't recolour. Gold or ink only; never invent palettes.").
+// Horizontal lockup per p. 7.
 export function KhonseraBrand({
   size = "md",
   href = "/dashboard",
   asLink = true,
   markColor,
+  variant = "seal",
 }: {
   size?: Size;
   href?: string;
   asLink?: boolean;
   markColor?: string;
+  variant?: MarkVariant;
 }) {
   const { glyph, font, track } = SIZES[size];
   const Tag = (asLink ? Link : "span") as React.ElementType;
@@ -76,14 +171,18 @@ export function KhonseraBrand({
       className="brand-lockup"
       style={{
         fontSize: font,
-        gap: Math.max(8, glyph / 2.2),
+        gap: Math.max(8, glyph / 2.8),
         lineHeight: 1,
         textDecoration: "none",
         alignItems: "center",
       }}
       aria-label="Khonsera home"
     >
-      <MoonMark size={glyph} color={markColor ?? "var(--gold)"} />
+      <MoonMark
+        size={glyph}
+        color={markColor ?? "var(--gold)"}
+        variant={variant}
+      />
       <span
         style={{
           fontFamily: "var(--display)",

--- a/src/components/khonsera-brand.tsx
+++ b/src/components/khonsera-brand.tsx
@@ -1,49 +1,73 @@
 import Link from "next/link";
 
 type Size = "xs" | "sm" | "md" | "lg" | "xl";
-const SIZES: Record<Size, { glyph: number; font: number }> = {
-  xs: { glyph: 16, font: 16 },
-  sm: { glyph: 18, font: 18 },
-  md: { glyph: 22, font: 22 },
-  lg: { glyph: 32, font: 38 },
-  xl: { glyph: 48, font: 64 },
+
+// Mark + wordmark sizing per the brand book's lockup system. The mark
+// reads optically smaller than the cap-height, so the wordmark font-size
+// is a touch larger than the mark size for visual parity.
+const SIZES: Record<Size, { glyph: number; font: number; track: number }> = {
+  xs: { glyph: 14, font: 11, track: 0.18 },
+  sm: { glyph: 18, font: 13, track: 0.2 },
+  md: { glyph: 22, font: 15, track: 0.22 },
+  lg: { glyph: 36, font: 26, track: 0.18 },
+  xl: { glyph: 56, font: 44, track: 0.14 },
 };
 
+// The Khonsera mark — a waxing crescent, drawn as the negative space
+// between two perfect circles. Construction (per the brand book, p. 5):
+//
+//   bounding box  100 × 100
+//   outer disc    R₁ = 42, centred (50, 50)
+//   inner cut     R₂ = 39, centred (62, 42)   — offset +12 right, 8 up
+//
+// The resulting asymmetric crescent leans into the upper-right, suggesting
+// motion. Rendered as an explicit two-arc path so it composites cleanly
+// (no SVG masks) for screenshots, exports and embeddings. Intersection
+// points are pre-computed in the 100-unit space.
 export function MoonMark({
   size = 22,
   color = "var(--gold)",
+  title,
 }: {
   size?: number;
   color?: string;
+  title?: string;
 }) {
-  // The Khonsera moon glyph — a half-disc crescent, the silhouette of the
-  // god Khonsu's lunar disc. Rendered as the difference of two circles.
   return (
     <svg
       width={size}
       height={size}
-      viewBox="0 0 24 24"
-      aria-hidden
-      style={{ color, flexShrink: 0 }}
+      viewBox="0 0 100 100"
+      role={title ? "img" : undefined}
+      aria-hidden={title ? undefined : true}
+      aria-label={title}
+      style={{ color, flexShrink: 0, display: "block" }}
     >
+      {title ? <title>{title}</title> : null}
       <path
-        d="M14.5 3.3a9 9 0 1 0 6.2 12.1A7 7 0 0 1 14.5 3.3Z"
+        d="M 84.63 73.76 A 42 42 0 1 0 41.39 8.89 A 39 39 0 0 0 84.63 73.76 Z"
         fill="currentColor"
       />
     </svg>
   );
 }
 
+// The wordmark — set in Satoshi 500, uppercase, tracked. Monocolour ink
+// (brand book p. 9: "Don't recolour. Gold or ink only; never invent
+// palettes."). The mark sits to the left per the primary horizontal
+// lockup (p. 7).
 export function KhonseraBrand({
   size = "md",
   href = "/dashboard",
   asLink = true,
+  markColor,
 }: {
   size?: Size;
   href?: string;
   asLink?: boolean;
+  markColor?: string;
 }) {
-  const { glyph, font } = SIZES[size];
+  const { glyph, font, track } = SIZES[size];
   const Tag = (asLink ? Link : "span") as React.ElementType;
 
   return (
@@ -52,16 +76,24 @@ export function KhonseraBrand({
       className="brand-lockup"
       style={{
         fontSize: font,
-        gap: Math.max(6, glyph / 3),
+        gap: Math.max(8, glyph / 2.2),
         lineHeight: 1,
         textDecoration: "none",
+        alignItems: "center",
       }}
       aria-label="Khonsera home"
     >
-      <MoonMark size={glyph} />
-      <span style={{ fontFamily: "var(--display)", fontStyle: "italic" }}>
-        Khon
-        <span style={{ color: "var(--gold)" }}>sera</span>
+      <MoonMark size={glyph} color={markColor ?? "var(--gold)"} />
+      <span
+        style={{
+          fontFamily: "var(--display)",
+          fontWeight: 500,
+          textTransform: "uppercase",
+          letterSpacing: `${track}em`,
+          color: "var(--ink)",
+        }}
+      >
+        Khonsera
       </span>
     </Tag>
   );

--- a/src/components/mobile-nav.tsx
+++ b/src/components/mobile-nav.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 import type { Route } from "next";
 import { signOut } from "@/app/login/actions";
+import { KhonseraBrand } from "./khonsera-brand";
 
 export function MobileNav({
   items,
@@ -66,18 +67,7 @@ export function MobileNav({
             onClick={(e) => e.stopPropagation()}
           >
             <div className="flex items-center justify-between border-b border-rule px-4 py-3">
-              <span className="brand-lockup" style={{ fontSize: 18 }}>
-                <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden>
-                  <path
-                    d="M14.5 3.3a9 9 0 1 0 6.2 12.1A7 7 0 0 1 14.5 3.3Z"
-                    fill="currentColor"
-                    style={{ color: "var(--gold)" }}
-                  />
-                </svg>
-                <span>
-                  Khonser<span style={{ color: "var(--gold)" }}>a</span>
-                </span>
-              </span>
+              <KhonseraBrand size="sm" asLink={false} />
               <button
                 type="button"
                 aria-label="Close menu"

--- a/src/components/place-picker.tsx
+++ b/src/components/place-picker.tsx
@@ -489,10 +489,10 @@ export function PlacePicker({
                 style={{
                   color: "var(--gold-2)",
                   fontFamily: "var(--display)",
-                  fontStyle: "italic",
                   fontWeight: 600,
                   fontSize: 16,
                   lineHeight: 1,
+                  letterSpacing: "-0.01em",
                 }}
               >
                 +

--- a/src/components/theme-picker.tsx
+++ b/src/components/theme-picker.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+// Theme picker — toggles the canonical Khonsera palettes from the brand
+// book (Edition I · MMXXVI · p. 10–12):
+//
+//   • Dusk     — default; warm, candlelit
+//   • Sahara   — sun-up; papyrus + ochre
+//   • Midnight — overnight; aubergine + brass moon
+//
+// The selection writes data-theme on <html> and persists to localStorage.
+// The companion init script in src/app/layout.tsx applies the saved value
+// before first paint so the page never flashes the wrong palette.
+//
+// STAFF-ONLY for now (gated by isStaff in the settings page). When the
+// alternate palettes are ready for everyone, remove the staff guard.
+
+export type Theme = "light" | "sahara" | "dark";
+
+const THEMES: ReadonlyArray<{
+  value: Theme;
+  label: string;
+  blurb: string;
+  swatch: [string, string, string];
+}> = [
+  {
+    value: "light",
+    label: "Dusk",
+    blurb: "Default. Warm, candlelit. Nine of ten surfaces.",
+    swatch: ["#efe6d0", "#1e1812", "#b8893f"],
+  },
+  {
+    value: "sahara",
+    label: "Sahara",
+    blurb: "Sun-up. Papyrus + ochre. Daylight contexts.",
+    swatch: ["#f3e8c8", "#20180e", "#a87826"],
+  },
+  {
+    value: "dark",
+    label: "Midnight",
+    blurb: "Aubergine ground, brass moon. Reserved for after hours.",
+    swatch: ["#1f1825", "#f4e8cf", "#d4a04d"],
+  },
+];
+
+const STORAGE_KEY = "khonsera:theme";
+
+function readStored(): Theme {
+  if (typeof window === "undefined") return "light";
+  const v = window.localStorage.getItem(STORAGE_KEY);
+  return v === "sahara" || v === "dark" ? v : "light";
+}
+
+export function ThemePicker() {
+  const [theme, setTheme] = useState<Theme>("light");
+
+  // Sync from <html data-theme> on mount so the picker reflects what the
+  // init script applied. Avoids a flash where the picker says "Dusk" but
+  // the page is actually in Midnight.
+  useEffect(() => {
+    const current = document.documentElement.getAttribute("data-theme");
+    if (current === "sahara" || current === "dark") setTheme(current);
+    else setTheme(readStored());
+  }, []);
+
+  function apply(next: Theme) {
+    setTheme(next);
+    document.documentElement.setAttribute("data-theme", next);
+    try {
+      window.localStorage.setItem(STORAGE_KEY, next);
+    } catch {
+      // Storage may be denied (private mode, etc.) — the runtime swap
+      // still works for the session.
+    }
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+      <div
+        role="radiogroup"
+        aria-label="Palette"
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+          gap: 10,
+        }}
+      >
+        {THEMES.map((opt) => {
+          const active = theme === opt.value;
+          return (
+            <button
+              key={opt.value}
+              type="button"
+              role="radio"
+              aria-checked={active}
+              onClick={() => apply(opt.value)}
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "flex-start",
+                gap: 10,
+                padding: "12px 14px",
+                borderRadius: 12,
+                border: `1px solid ${active ? "var(--gold)" : "var(--rule)"}`,
+                background: active ? "var(--card)" : "var(--card-2)",
+                boxShadow: active
+                  ? "0 1px 0 var(--gold-tint), 0 6px 16px rgba(184, 137, 63, 0.10)"
+                  : "none",
+                cursor: "pointer",
+                textAlign: "left",
+                transition: "border-color 0.12s, background 0.12s, box-shadow 0.12s",
+              }}
+            >
+              <Swatches colors={opt.swatch} />
+              <div
+                style={{
+                  fontFamily: "var(--display)",
+                  fontWeight: 500,
+                  fontSize: 16,
+                  letterSpacing: "-0.01em",
+                  color: "var(--ink)",
+                }}
+              >
+                {opt.label}
+              </div>
+              <div
+                style={{
+                  fontFamily: "var(--serif)",
+                  fontStyle: "italic",
+                  fontSize: 12.5,
+                  color: "var(--ink-dim)",
+                  lineHeight: 1.4,
+                }}
+              >
+                {opt.blurb}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function Swatches({ colors }: { colors: [string, string, string] }) {
+  return (
+    <div style={{ display: "flex", gap: 4 }}>
+      {colors.map((c, i) => (
+        <span
+          key={i}
+          style={{
+            width: 18,
+            height: 18,
+            borderRadius: 999,
+            background: c,
+            border: "1px solid rgba(0,0,0,0.06)",
+          }}
+          aria-hidden
+        />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Aligns the app with the **Khonsera Visual Identity brand book (Edition I · MMXXVI)**. Four commits, all on the brand surface — no behavioural changes, no schema, no integration touches.

- **Palette** — canonical "dusk" tokens (Khonsera Gold #B8893F, Walnut Ink #1E1812, Dusk Paper #EFE6D0, Bone, Terracotta, Dusk Plum, Khorasan Sage) plus the full gold ramp. Added `data-theme="sahara"` (sun-up, papyrus + ochre) and rebuilt `data-theme="dark"` as Midnight (aubergine ground, brass moon) per p. 12.
- **Type** — dropped Playfair + Lora; loaded Satoshi via Fontshare for display/wordmark/headlines, Cormorant Garamond for editorial serif italic, kept Inter + JetBrains Mono. Every display heading (`.h0–.h2`, `.masthead-title`, `.app-header .title`, `.trip-row-day/title`, `.anchor-stat .v`, `.kpi .v`, `.stat-col .v`, `.tl-title`, `.day-header .title`, `.chapter-number`, etc.) now Satoshi 500 non-italic with negative tracking per the type scale on p. 15. Small editorial helpers (`.standfirst`, `.home-header-meta`, `.brief-helper`, `.trip-row-notes`) keep their Cormorant italic.
- **Mark** — `MoonMark` ported faithfully from the canonical `moon-mark.js` (two-circle waxing crescent, dynamic viewBox, sweep=1 outer arc). Four variants exposed: `crescent`, `hairline`, `crescent-star`, `seal`. **Default is `seal`** (concentric rings + tiny crescent) per the active-mark choice.
- **Wordmark** — `.brand-lockup` and `KhonseraBrand` now render monocolour ink KHONSERA in uppercase tracked Satoshi 500. The mark is the only gold element, per p. 9 ("Gold or ink only; never invent palettes"). Mobile sidebar slide-out now uses `KhonseraBrand` instead of the inline Journies-era crescent + "Khonser·a" wordmark.
- **Metadata / voice** — title/description/themeColor updated to the "Travel days, considered." voice. Landing standfirst + four virtues line aligned to the brand book.
- **Theme picker** — Settings → Palette · Dusk / Sahara / Midnight, persisted to `localStorage` with a no-FOUC init script in `<head>`. **Gated behind `ctx.isStaff` with an on-screen "visible to staff only" note and a `TODO(brand)` comment** so the guard is easy to lift once the alternates are signed off for all users.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 34 tests passing across 6 files
- [x] `npm run build` — 24 routes built, no warnings
- [ ] Eyeball the preview URL — landing, dashboard headline, mobile slide-out, sidebar lockup, settings palette picker
- [ ] Toggle each palette in Settings → Palette and confirm no FOUC on reload
- [ ] Confirm the staff-only note is visible and the picker hides for non-staff accounts

---
_Generated by [Claude Code](https://claude.ai/code/session_017aLt4E3WEBiSdQRLXa8rHy)_