### PR TITLE
Add Gmail booking import: OAuth flow, email parsing, and import UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,15 @@ GOOGLE_CLIENT_SECRET=
 # Optional: explicit override if your callback host differs from NEXT_PUBLIC_APP_URL
 # GOOGLE_OAUTH_REDIRECT_URL=
 
+# Gmail import — same Google Cloud OAuth client as Calendar. Add this redirect URI:
+#   https://<your-domain>/api/auth/gmail/callback
+#   http://localhost:3000/api/auth/gmail/callback
+# Enable the "Gmail API" in the same project. Scope used:
+#   gmail.readonly (set at runtime, not in console)
+# No extra env vars needed — reuses GOOGLE_CLIENT_ID + GOOGLE_CLIENT_SECRET above.
+# Optional: explicit override for the Gmail callback URI
+# GOOGLE_GMAIL_REDIRECT_URL=
+
 # Maps / routing — same Google Cloud project as Calendar above. Enable:
 #   - Geocoding API     (auto-geocodes addresses on save)
 #   - Directions API    (real drive times + polyline for the route map)

--- a/src/app/(app)/itineraries/[id]/gmail-import-panel.tsx
+++ b/src/app/(app)/itineraries/[id]/gmail-import-panel.tsx
@@ -261,106 +261,135 @@ export function GmailImportPanel({
     });
   };
 
-  const handleImportTransport = (booking: ParsedTransportBooking) => {
-    if (!lastStopId) {
-      setError("Add at least one stop to the itinerary before importing bookings.");
+  const doImportTransport = async (
+    booking: ParsedTransportBooking,
+    stopId: string,
+  ): Promise<boolean> => {
+    const first = booking.segments[0];
+    const last = booking.segments[booking.segments.length - 1];
+
+    const segments = booking.segments.map((seg) => ({
+      from_location_name: seg.from_station,
+      to_location_name: seg.to_station,
+      departure_at: new Date(
+        `${seg.departure_date}T${seg.departure_time}:00`,
+      ).toISOString(),
+      arrival_at: new Date(
+        `${seg.arrival_date}T${seg.arrival_time}:00`,
+      ).toISOString(),
+      service_number: seg.service_number ?? null,
+      platform_dep: seg.platform_dep ?? null,
+      platform_arr: seg.platform_arr ?? null,
+    }));
+
+    const result = await attachTransportBookingToStop({
+      from_stop_id: stopId,
+      mode: booking.mode,
+      provider: booking.provider,
+      arrival_location_id: null,
+      arrival_location_name: last?.to_station ?? "Unknown",
+      arrival_location_type: "station",
+      booking_reference: booking.booking_reference,
+      actual_price: booking.price,
+      currency: booking.currency,
+      seat_reservation: first?.seat ?? null,
+      segments,
+    });
+
+    if (!result.ok) {
+      setError(feedbackFromError(result.error).message);
+      return false;
+    }
+
+    await markBookingImported({
+      gmail_message_id: booking.gmail_message_id,
+      booking_type: "transport",
+      travel_booking_id: result.value.travel_booking_id,
+    });
+
+    setImportedIds((prev) => new Set(prev).add(booking.gmail_message_id));
+    return true;
+  };
+
+  const doImportAccommodation = async (
+    booking: ParsedAccommodationBooking,
+  ): Promise<boolean> => {
+    const checkIn = booking.check_in_time
+      ? new Date(
+          `${booking.check_in_date}T${booking.check_in_time}:00`,
+        ).toISOString()
+      : new Date(`${booking.check_in_date}T15:00:00`).toISOString();
+    const checkOut = booking.check_out_time
+      ? new Date(
+          `${booking.check_out_date}T${booking.check_out_time}:00`,
+        ).toISOString()
+      : new Date(`${booking.check_out_date}T11:00:00`).toISOString();
+
+    const result = await attachAccommodationBooking({
+      stop_id: null,
+      after_stop_id: lastStopId,
+      hotel_location_id: null,
+      hotel_name: booking.hotel_name,
+      check_in: checkIn,
+      check_out: checkOut,
+      provider: booking.provider,
+      booking_reference: booking.booking_reference,
+      actual_price: booking.price,
+      currency: booking.currency,
+      room_details: booking.room_details,
+    });
+
+    if (!result.ok) {
+      setError(feedbackFromError(result.error).message);
+      return false;
+    }
+
+    await markBookingImported({
+      gmail_message_id: booking.gmail_message_id,
+      booking_type: "accommodation",
+      travel_booking_id: result.value.travel_booking_id,
+    });
+
+    setImportedIds((prev) => new Set(prev).add(booking.gmail_message_id));
+    return true;
+  };
+
+  const handleImportOne = (booking: ParsedBooking) => {
+    if (booking.type === "transport" && !lastStopId) {
+      setError("Add at least one stop to the itinerary before importing transport bookings.");
       return;
     }
     setImportingId(booking.gmail_message_id);
     startImport(async () => {
-      const first = booking.segments[0];
-      const last = booking.segments[booking.segments.length - 1];
-
-      const segments = booking.segments.map((seg) => ({
-        from_location_name: seg.from_station,
-        to_location_name: seg.to_station,
-        departure_at: new Date(
-          `${seg.departure_date}T${seg.departure_time}:00`,
-        ).toISOString(),
-        arrival_at: new Date(
-          `${seg.arrival_date}T${seg.arrival_time}:00`,
-        ).toISOString(),
-        service_number: seg.service_number ?? null,
-        platform_dep: seg.platform_dep ?? null,
-        platform_arr: seg.platform_arr ?? null,
-      }));
-
-      const result = await attachTransportBookingToStop({
-        from_stop_id: lastStopId,
-        mode: booking.mode,
-        provider: booking.provider,
-        arrival_location_id: null,
-        arrival_location_name: last?.to_station ?? "Unknown",
-        arrival_location_type:
-          booking.mode === "flight" ? "station" : "station",
-        booking_reference: booking.booking_reference,
-        actual_price: booking.price,
-        currency: booking.currency,
-        seat_reservation: first?.seat ?? null,
-        segments,
-      });
-
-      if (!result.ok) {
-        setError(feedbackFromError(result.error).message);
-        setImportingId(null);
-        return;
-      }
-
-      await markBookingImported({
-        gmail_message_id: booking.gmail_message_id,
-        booking_type: "transport",
-        travel_booking_id: result.value.travel_booking_id,
-      });
-
-      setImportedIds((prev) => new Set(prev).add(booking.gmail_message_id));
+      const ok =
+        booking.type === "transport"
+          ? await doImportTransport(booking, lastStopId!)
+          : await doImportAccommodation(booking);
       setImportingId(null);
-      onImported();
+      if (ok) onImported();
     });
   };
 
-  const handleImportAccommodation = (booking: ParsedAccommodationBooking) => {
-    setImportingId(booking.gmail_message_id);
+  const handleImportAll = () => {
+    if (!pending || pending.length === 0) return;
+    const hasTransport = pending.some((b) => b.type === "transport");
+    if (hasTransport && !lastStopId) {
+      setError("Add at least one stop to the itinerary before importing transport bookings.");
+      return;
+    }
+    setImportingId("__all__");
     startImport(async () => {
-      const checkIn = booking.check_in_time
-        ? new Date(
-            `${booking.check_in_date}T${booking.check_in_time}:00`,
-          ).toISOString()
-        : new Date(`${booking.check_in_date}T15:00:00`).toISOString();
-      const checkOut = booking.check_out_time
-        ? new Date(
-            `${booking.check_out_date}T${booking.check_out_time}:00`,
-          ).toISOString()
-        : new Date(`${booking.check_out_date}T11:00:00`).toISOString();
-
-      const result = await attachAccommodationBooking({
-        stop_id: null,
-        after_stop_id: lastStopId,
-        hotel_location_id: null,
-        hotel_name: booking.hotel_name,
-        check_in: checkIn,
-        check_out: checkOut,
-        provider: booking.provider,
-        booking_reference: booking.booking_reference,
-        actual_price: booking.price,
-        currency: booking.currency,
-        room_details: booking.room_details,
-      });
-
-      if (!result.ok) {
-        setError(feedbackFromError(result.error).message);
-        setImportingId(null);
-        return;
+      let imported = 0;
+      for (const booking of pending) {
+        const ok =
+          booking.type === "transport"
+            ? await doImportTransport(booking, lastStopId!)
+            : await doImportAccommodation(booking);
+        if (ok) imported++;
+        else break;
       }
-
-      await markBookingImported({
-        gmail_message_id: booking.gmail_message_id,
-        booking_type: "accommodation",
-        travel_booking_id: result.value.travel_booking_id,
-      });
-
-      setImportedIds((prev) => new Set(prev).add(booking.gmail_message_id));
       setImportingId(null);
-      onImported();
+      if (imported > 0) onImported();
     });
   };
 
@@ -383,7 +412,7 @@ export function GmailImportPanel({
           <div>
             <h2 className="h3">Import from Gmail</h2>
             <p className="small mt-0.5" style={{ color: "var(--ink-dim)" }}>
-              Scan for booking confirmations from the last 6 months
+              Scan for upcoming booking confirmations
             </p>
           </div>
           <button
@@ -400,9 +429,9 @@ export function GmailImportPanel({
           {!bookings ? (
             <div className="flex flex-col items-center gap-3 py-8">
               <p className="small text-center" style={{ color: "var(--ink-dim)" }}>
-                Scans your Gmail for confirmation emails from Trainline, LNER,
-                Avanti, GWR, airlines, Booking.com, Hotels.com, Airbnb, and
-                more.
+                Scans your Gmail for upcoming booking confirmations from
+                Trainline, LNER, Avanti, GWR, airlines, Booking.com,
+                Hotels.com, Airbnb, and more. Past trips are excluded.
               </p>
               <SubmitButton
                 pending={scanning}
@@ -414,48 +443,65 @@ export function GmailImportPanel({
             </div>
           ) : pending && pending.length > 0 ? (
             <>
-              <p className="small" style={{ color: "var(--ink-dim)" }}>
-                Found {bookings.length} booking
-                {bookings.length !== 1 ? "s" : ""} across{" "}
-                {scannedCount} email{scannedCount !== 1 ? "s" : ""}
-                {importedIds.size > 0
-                  ? ` · ${importedIds.size} imported`
-                  : ""}
-              </p>
+              <div className="flex items-center justify-between">
+                <p className="small" style={{ color: "var(--ink-dim)" }}>
+                  {pending.length} upcoming booking
+                  {pending.length !== 1 ? "s" : ""} found
+                  {importedIds.size > 0
+                    ? ` · ${importedIds.size} imported`
+                    : ""}
+                </p>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    className="btn-ghost"
+                    style={{ padding: "4px 10px", fontSize: 12 }}
+                    onClick={doScan}
+                    disabled={scanning || importing}
+                  >
+                    {scanning ? "Rescanning..." : "Rescan"}
+                  </button>
+                  <button
+                    type="button"
+                    className="btn-terra"
+                    style={{ padding: "4px 12px", fontSize: 12 }}
+                    onClick={handleImportAll}
+                    disabled={importing || pending.length === 0}
+                  >
+                    {importingId === "__all__"
+                      ? "Importing..."
+                      : `Import all (${pending.length})`}
+                  </button>
+                </div>
+              </div>
               {pending.map((booking) => {
-                const isImporting = importingId === booking.gmail_message_id;
+                const isImporting =
+                  importingId === booking.gmail_message_id ||
+                  importingId === "__all__";
                 return booking.type === "transport" ? (
                   <TransportBookingCard
                     key={booking.gmail_message_id}
                     booking={booking}
-                    onImport={() => handleImportTransport(booking)}
+                    onImport={() => handleImportOne(booking)}
                     importing={isImporting}
                   />
                 ) : (
                   <AccommodationBookingCard
                     key={booking.gmail_message_id}
                     booking={booking}
-                    onImport={() => handleImportAccommodation(booking)}
+                    onImport={() => handleImportOne(booking)}
                     importing={isImporting}
                   />
                 );
               })}
-              <button
-                type="button"
-                className="btn-ghost self-center"
-                style={{ fontSize: 12 }}
-                onClick={doScan}
-                disabled={scanning}
-              >
-                {scanning ? "Rescanning..." : "Rescan"}
-              </button>
             </>
           ) : (
             <div className="flex flex-col items-center gap-3 py-8">
               {bookings.length === 0 ? (
                 <p className="small text-center" style={{ color: "var(--ink-dim)" }}>
-                  No booking emails found in the last 6 months. Make sure
-                  your booking confirmations are in the connected Gmail account.
+                  No upcoming bookings found. Past trips are excluded
+                  automatically. Make sure your booking confirmations are in
+                  the connected Gmail account.
                 </p>
               ) : (
                 <p className="small text-center" style={{ color: "var(--sage)" }}>

--- a/src/app/(app)/itineraries/[id]/gmail-import-panel.tsx
+++ b/src/app/(app)/itineraries/[id]/gmail-import-panel.tsx
@@ -1,0 +1,479 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { scanGmailForBookings, markBookingImported } from "@/lib/actions/gmail";
+import { attachTransportBookingToStop } from "@/lib/actions/bookings";
+import { attachAccommodationBooking } from "@/lib/actions/bookings";
+import { feedbackFromError } from "@/lib/actions/_form";
+import { SubmitButton } from "@/components/ui/form";
+import type {
+  ParsedBooking,
+  ParsedTransportBooking,
+  ParsedAccommodationBooking,
+} from "@/lib/gmail/types";
+
+function TransportBookingCard({
+  booking,
+  onImport,
+  importing,
+}: {
+  booking: ParsedTransportBooking;
+  onImport: () => void;
+  importing: boolean;
+}) {
+  const first = booking.segments[0];
+  const last = booking.segments[booking.segments.length - 1];
+  const modeLabel =
+    booking.mode === "train"
+      ? "Train"
+      : booking.mode === "flight"
+        ? "Flight"
+        : "Bus";
+  const modeColor =
+    booking.mode === "train"
+      ? "var(--gold-2)"
+      : booking.mode === "flight"
+        ? "var(--terra)"
+        : "var(--sage)";
+
+  return (
+    <div className="j-card flex flex-col gap-2 p-4">
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <span
+            className="rounded-sm px-1.5 py-0.5 text-[10px] font-semibold uppercase"
+            style={{ background: modeColor, color: "var(--card)" }}
+          >
+            {modeLabel}
+          </span>
+          <span className="text-xs" style={{ color: "var(--ink-dim)" }}>
+            {booking.provider}
+          </span>
+        </div>
+        <span className="text-xs" style={{ color: "var(--ink-dim)" }}>
+          {new Date(booking.email_date).toLocaleDateString("en-GB", {
+            day: "numeric",
+            month: "short",
+          })}
+        </span>
+      </div>
+
+      <div>
+        <p className="text-sm font-medium" style={{ color: "var(--ink)" }}>
+          {first?.from_station ?? "?"} {"→"} {last?.to_station ?? "?"}
+        </p>
+        <p className="text-xs" style={{ color: "var(--ink-dim)" }}>
+          {first?.departure_date} {first?.departure_time}
+          {" – "}
+          {last?.arrival_time}
+          {booking.segments.length > 1
+            ? ` (${booking.segments.length} segments)`
+            : ""}
+        </p>
+      </div>
+
+      {booking.segments.length > 1 ? (
+        <div
+          className="flex flex-col gap-1 rounded border border-rule/50 p-2"
+          style={{ background: "var(--card-2)", fontSize: 11 }}
+        >
+          {booking.segments.map((seg, i) => (
+            <div key={i} className="flex justify-between gap-2">
+              <span>
+                {seg.from_station} {"→"} {seg.to_station}
+              </span>
+              <span style={{ color: "var(--ink-dim)" }}>
+                {seg.departure_time} {"–"} {seg.arrival_time}
+                {seg.service_number ? ` (${seg.service_number})` : ""}
+              </span>
+            </div>
+          ))}
+        </div>
+      ) : first?.service_number ? (
+        <p className="text-xs" style={{ color: "var(--ink-dim)" }}>
+          Service: {first.service_number}
+          {first.seat ? ` · Seat: ${first.seat}` : ""}
+        </p>
+      ) : null}
+
+      <div className="flex items-center justify-between">
+        <div className="flex gap-3 text-xs" style={{ color: "var(--ink-dim)" }}>
+          {booking.booking_reference ? (
+            <span>Ref: {booking.booking_reference}</span>
+          ) : null}
+          {booking.price != null ? (
+            <span>
+              {booking.currency === "GBP"
+                ? "£"
+                : booking.currency === "EUR"
+                  ? "€"
+                  : "$"}
+              {booking.price.toFixed(2)}
+            </span>
+          ) : null}
+        </div>
+        <button
+          type="button"
+          className="btn-terra"
+          style={{ padding: "4px 12px", fontSize: 12 }}
+          onClick={onImport}
+          disabled={importing}
+        >
+          {importing ? "Importing..." : "Import"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function AccommodationBookingCard({
+  booking,
+  onImport,
+  importing,
+}: {
+  booking: ParsedAccommodationBooking;
+  onImport: () => void;
+  importing: boolean;
+}) {
+  return (
+    <div className="j-card flex flex-col gap-2 p-4">
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <span
+            className="rounded-sm px-1.5 py-0.5 text-[10px] font-semibold uppercase"
+            style={{ background: "var(--sage)", color: "var(--card)" }}
+          >
+            Hotel
+          </span>
+          <span className="text-xs" style={{ color: "var(--ink-dim)" }}>
+            {booking.provider}
+          </span>
+        </div>
+        <span className="text-xs" style={{ color: "var(--ink-dim)" }}>
+          {new Date(booking.email_date).toLocaleDateString("en-GB", {
+            day: "numeric",
+            month: "short",
+          })}
+        </span>
+      </div>
+
+      <p className="text-sm font-medium" style={{ color: "var(--ink)" }}>
+        {booking.hotel_name}
+      </p>
+
+      <p className="text-xs" style={{ color: "var(--ink-dim)" }}>
+        Check-in: {booking.check_in_date}
+        {booking.check_in_time ? ` from ${booking.check_in_time}` : ""}
+        {" · "}
+        Check-out: {booking.check_out_date}
+        {booking.check_out_time ? ` by ${booking.check_out_time}` : ""}
+      </p>
+
+      {booking.room_details ? (
+        <p className="text-xs" style={{ color: "var(--ink-dim)" }}>
+          Room: {booking.room_details}
+        </p>
+      ) : null}
+
+      <div className="flex items-center justify-between">
+        <div className="flex gap-3 text-xs" style={{ color: "var(--ink-dim)" }}>
+          {booking.booking_reference ? (
+            <span>Ref: {booking.booking_reference}</span>
+          ) : null}
+          {booking.price != null ? (
+            <span>
+              {booking.currency === "GBP"
+                ? "£"
+                : booking.currency === "EUR"
+                  ? "€"
+                  : "$"}
+              {booking.price.toFixed(2)}
+            </span>
+          ) : null}
+        </div>
+        <button
+          type="button"
+          className="btn-terra"
+          style={{ padding: "4px 12px", fontSize: 12 }}
+          onClick={onImport}
+          disabled={importing}
+        >
+          {importing ? "Importing..." : "Import"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function GmailImportPanel({
+  itineraryId,
+  lastStopId,
+  lastStopLabel,
+  onClose,
+  onImported,
+}: {
+  itineraryId: string;
+  lastStopId: string | null;
+  lastStopLabel: string;
+  onClose: () => void;
+  onImported: () => void;
+}) {
+  const router = useRouter();
+  const [scanning, startScan] = useTransition();
+  const [importing, startImport] = useTransition();
+  const [bookings, setBookings] = useState<ParsedBooking[] | null>(null);
+  const [scannedCount, setScannedCount] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [importingId, setImportingId] = useState<string | null>(null);
+  const [importedIds, setImportedIds] = useState<Set<string>>(new Set());
+
+  const doScan = () => {
+    setError(null);
+    startScan(async () => {
+      const result = await scanGmailForBookings();
+      if (!result.ok) {
+        setError(
+          result.error.kind === "integration"
+            ? result.error.reason
+            : "Failed to scan Gmail",
+        );
+        return;
+      }
+      setBookings(result.value.bookings);
+      setScannedCount(result.value.scanned_count);
+    });
+  };
+
+  const handleImportTransport = (booking: ParsedTransportBooking) => {
+    if (!lastStopId) {
+      setError("Add at least one stop to the itinerary before importing bookings.");
+      return;
+    }
+    setImportingId(booking.gmail_message_id);
+    startImport(async () => {
+      const first = booking.segments[0];
+      const last = booking.segments[booking.segments.length - 1];
+
+      const segments = booking.segments.map((seg) => ({
+        from_location_name: seg.from_station,
+        to_location_name: seg.to_station,
+        departure_at: new Date(
+          `${seg.departure_date}T${seg.departure_time}:00`,
+        ).toISOString(),
+        arrival_at: new Date(
+          `${seg.arrival_date}T${seg.arrival_time}:00`,
+        ).toISOString(),
+        service_number: seg.service_number ?? null,
+        platform_dep: seg.platform_dep ?? null,
+        platform_arr: seg.platform_arr ?? null,
+      }));
+
+      const result = await attachTransportBookingToStop({
+        from_stop_id: lastStopId,
+        mode: booking.mode,
+        provider: booking.provider,
+        arrival_location_id: null,
+        arrival_location_name: last?.to_station ?? "Unknown",
+        arrival_location_type:
+          booking.mode === "flight" ? "station" : "station",
+        booking_reference: booking.booking_reference,
+        actual_price: booking.price,
+        currency: booking.currency,
+        seat_reservation: first?.seat ?? null,
+        segments,
+      });
+
+      if (!result.ok) {
+        setError(feedbackFromError(result.error).message);
+        setImportingId(null);
+        return;
+      }
+
+      await markBookingImported({
+        gmail_message_id: booking.gmail_message_id,
+        booking_type: "transport",
+        travel_booking_id: result.value.travel_booking_id,
+      });
+
+      setImportedIds((prev) => new Set(prev).add(booking.gmail_message_id));
+      setImportingId(null);
+      onImported();
+    });
+  };
+
+  const handleImportAccommodation = (booking: ParsedAccommodationBooking) => {
+    setImportingId(booking.gmail_message_id);
+    startImport(async () => {
+      const checkIn = booking.check_in_time
+        ? new Date(
+            `${booking.check_in_date}T${booking.check_in_time}:00`,
+          ).toISOString()
+        : new Date(`${booking.check_in_date}T15:00:00`).toISOString();
+      const checkOut = booking.check_out_time
+        ? new Date(
+            `${booking.check_out_date}T${booking.check_out_time}:00`,
+          ).toISOString()
+        : new Date(`${booking.check_out_date}T11:00:00`).toISOString();
+
+      const result = await attachAccommodationBooking({
+        stop_id: null,
+        after_stop_id: lastStopId,
+        hotel_location_id: null,
+        hotel_name: booking.hotel_name,
+        check_in: checkIn,
+        check_out: checkOut,
+        provider: booking.provider,
+        booking_reference: booking.booking_reference,
+        actual_price: booking.price,
+        currency: booking.currency,
+        room_details: booking.room_details,
+      });
+
+      if (!result.ok) {
+        setError(feedbackFromError(result.error).message);
+        setImportingId(null);
+        return;
+      }
+
+      await markBookingImported({
+        gmail_message_id: booking.gmail_message_id,
+        booking_type: "accommodation",
+        travel_booking_id: result.value.travel_booking_id,
+      });
+
+      setImportedIds((prev) => new Set(prev).add(booking.gmail_message_id));
+      setImportingId(null);
+      onImported();
+    });
+  };
+
+  const pending = bookings?.filter(
+    (b) => !importedIds.has(b.gmail_message_id),
+  );
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/40"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        className="mt-12 w-full max-w-xl overflow-y-auto rounded-lg border border-rule bg-card shadow-xl"
+        style={{ maxHeight: "calc(100vh - 6rem)" }}
+      >
+        <div className="flex items-center justify-between border-b border-rule px-5 py-4">
+          <div>
+            <h2 className="h3">Import from Gmail</h2>
+            <p className="small mt-0.5" style={{ color: "var(--ink-dim)" }}>
+              Scan for booking confirmations from the last 6 months
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-xs hover:underline"
+            style={{ color: "var(--ink-dim)" }}
+          >
+            Close
+          </button>
+        </div>
+
+        <div className="flex flex-col gap-4 p-5">
+          {!bookings ? (
+            <div className="flex flex-col items-center gap-3 py-8">
+              <p className="small text-center" style={{ color: "var(--ink-dim)" }}>
+                Scans your Gmail for confirmation emails from Trainline, LNER,
+                Avanti, GWR, airlines, Booking.com, Hotels.com, Airbnb, and
+                more.
+              </p>
+              <SubmitButton
+                pending={scanning}
+                onClick={doScan}
+                type="button"
+              >
+                Scan Gmail
+              </SubmitButton>
+            </div>
+          ) : pending && pending.length > 0 ? (
+            <>
+              <p className="small" style={{ color: "var(--ink-dim)" }}>
+                Found {bookings.length} booking
+                {bookings.length !== 1 ? "s" : ""} across{" "}
+                {scannedCount} email{scannedCount !== 1 ? "s" : ""}
+                {importedIds.size > 0
+                  ? ` · ${importedIds.size} imported`
+                  : ""}
+              </p>
+              {pending.map((booking) => {
+                const isImporting = importingId === booking.gmail_message_id;
+                return booking.type === "transport" ? (
+                  <TransportBookingCard
+                    key={booking.gmail_message_id}
+                    booking={booking}
+                    onImport={() => handleImportTransport(booking)}
+                    importing={isImporting}
+                  />
+                ) : (
+                  <AccommodationBookingCard
+                    key={booking.gmail_message_id}
+                    booking={booking}
+                    onImport={() => handleImportAccommodation(booking)}
+                    importing={isImporting}
+                  />
+                );
+              })}
+              <button
+                type="button"
+                className="btn-ghost self-center"
+                style={{ fontSize: 12 }}
+                onClick={doScan}
+                disabled={scanning}
+              >
+                {scanning ? "Rescanning..." : "Rescan"}
+              </button>
+            </>
+          ) : (
+            <div className="flex flex-col items-center gap-3 py-8">
+              {bookings.length === 0 ? (
+                <p className="small text-center" style={{ color: "var(--ink-dim)" }}>
+                  No booking emails found in the last 6 months. Make sure
+                  your booking confirmations are in the connected Gmail account.
+                </p>
+              ) : (
+                <p className="small text-center" style={{ color: "var(--sage)" }}>
+                  All {bookings.length} booking
+                  {bookings.length !== 1 ? "s" : ""} imported.
+                </p>
+              )}
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  className="btn-ghost"
+                  style={{ fontSize: 12 }}
+                  onClick={doScan}
+                  disabled={scanning}
+                >
+                  {scanning ? "Rescanning..." : "Rescan"}
+                </button>
+                <button
+                  type="button"
+                  className="btn-terra"
+                  style={{ fontSize: 12 }}
+                  onClick={onClose}
+                >
+                  Done
+                </button>
+              </div>
+            </div>
+          )}
+
+          {error ? (
+            <p className="text-xs text-rust">{error}</p>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/itineraries/[id]/gmail-import-panel.tsx
+++ b/src/app/(app)/itineraries/[id]/gmail-import-panel.tsx
@@ -50,6 +50,14 @@ function TransportBookingCard({
           <span className="text-xs" style={{ color: "var(--ink-dim)" }}>
             {booking.provider}
           </span>
+          {booking.is_amendment ? (
+            <span
+              className="rounded-sm px-1.5 py-0.5 text-[10px] font-semibold uppercase"
+              style={{ background: "var(--rust)", color: "var(--card)" }}
+            >
+              Amendment
+            </span>
+          ) : null}
         </div>
         <span className="text-xs" style={{ color: "var(--ink-dim)" }}>
           {new Date(booking.email_date).toLocaleDateString("en-GB", {
@@ -149,6 +157,14 @@ function AccommodationBookingCard({
           <span className="text-xs" style={{ color: "var(--ink-dim)" }}>
             {booking.provider}
           </span>
+          {booking.is_amendment ? (
+            <span
+              className="rounded-sm px-1.5 py-0.5 text-[10px] font-semibold uppercase"
+              style={{ background: "var(--rust)", color: "var(--card)" }}
+            >
+              Amendment
+            </span>
+          ) : null}
         </div>
         <span className="text-xs" style={{ color: "var(--ink-dim)" }}>
           {new Date(booking.email_date).toLocaleDateString("en-GB", {

--- a/src/app/(app)/itineraries/[id]/itinerary-editor.tsx
+++ b/src/app/(app)/itineraries/[id]/itinerary-editor.tsx
@@ -32,6 +32,7 @@ import {
   type TransportBookingMode,
 } from "./add-transport-booking-form";
 import { AddAccommodationBookingForm } from "./add-accommodation-booking-form";
+import { GmailImportPanel } from "./gmail-import-panel";
 import { DeleteItineraryButton } from "@/components/delete-itinerary-button";
 import { TransportIcon, StopIcon } from "@/components/icons";
 import {
@@ -233,6 +234,7 @@ export function ItineraryEditor({
   timezone,
   totals,
   initialPreviewCache,
+  gmailConnected,
 }: {
   itinerary: {
     id: string;
@@ -256,6 +258,7 @@ export function ItineraryEditor({
   // mode). Seeded into the route-preview hook on mount so the picker
   // renders resolved pills on first paint instead of grey-pending.
   initialPreviewCache: InitialPreviewSeed[];
+  gmailConnected?: boolean;
 }) {
   const router = useRouter();
   const [pending, startTransition] = useTransition();
@@ -271,6 +274,7 @@ export function ItineraryEditor({
     afterStopLabel?: string;
     existingStopId?: string;
   } | null>(null);
+  const [gmailImportOpen, setGmailImportOpen] = useState(false);
 
   // Transitions keyed by from_stop_id for fast lookup.
   const transitionByFrom = useMemo(() => {
@@ -1084,6 +1088,18 @@ export function ItineraryEditor({
           <span className={`sb ${STATUS_SB[itinerary.status]}`}>
             {STATUS_LABEL[itinerary.status]}
           </span>
+          {gmailConnected ? (
+            <button
+              type="button"
+              className="btn-ghost"
+              style={{ fontSize: 12, display: "inline-flex", alignItems: "center", gap: 6 }}
+              onClick={() => setGmailImportOpen(true)}
+              disabled={pending}
+            >
+              {Icon.ticket}
+              Import from Gmail
+            </button>
+          ) : null}
           <span style={{ marginLeft: "auto" }}>
             <DeleteItineraryButton
               id={itinerary.id}
@@ -1774,6 +1790,25 @@ export function ItineraryEditor({
               />
             </div>
           </div>
+        ) : null}
+
+        {/* Gmail import panel */}
+        {gmailImportOpen ? (
+          <GmailImportPanel
+            itineraryId={itinerary.id}
+            lastStopId={
+              stops.length > 0 ? stops[stops.length - 1].id : null
+            }
+            lastStopLabel={
+              stops.length > 0
+                ? (stops[stops.length - 1].location?.name ??
+                  stops[stops.length - 1].title ??
+                  "last stop")
+                : "itinerary"
+            }
+            onClose={() => setGmailImportOpen(false)}
+            onImported={() => router.refresh()}
+          />
         ) : null}
       </div>
     </div>

--- a/src/app/(app)/itineraries/[id]/page.tsx
+++ b/src/app/(app)/itineraries/[id]/page.tsx
@@ -57,6 +57,14 @@ export default async function ItineraryDetailPage({
     }
   }
 
+  const { data: gmailConn } = await supabase
+    .from("gmail_connections")
+    .select("id")
+    .eq("user_id", ctx.userId)
+    .eq("workspace_id", ctx.workspaceId)
+    .eq("status", "active")
+    .maybeSingle();
+
   const [
     { data: stops },
     { data: transitions },
@@ -182,6 +190,7 @@ export default async function ItineraryDetailPage({
         durationMinutes: row.duration_minutes,
         distanceMiles: row.distance_miles,
       }))}
+      gmailConnected={!!gmailConn}
     />
   );
 }

--- a/src/app/(app)/settings/gmail-section.tsx
+++ b/src/app/(app)/settings/gmail-section.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import { disconnectGmail } from "@/lib/actions/gmail";
+import { feedbackFromError } from "@/lib/actions/_form";
+import { FormError } from "@/components/ui/form";
+
+export function GmailSection({
+  connection,
+}: {
+  connection: {
+    id: string;
+    provider_account_email: string | null;
+    last_scan_at: string | null;
+  } | null;
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const handleDisconnect = () => {
+    if (!window.confirm("Disconnect Gmail? Imported bookings won't be removed.")) return;
+    startTransition(async () => {
+      setError(null);
+      const result = await disconnectGmail();
+      if (!result.ok) {
+        setError(feedbackFromError(result.error).message);
+        return;
+      }
+      router.refresh();
+    });
+  };
+
+  return (
+    <div className="j-card p-5">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h2 className="h3 mb-1">Gmail Import</h2>
+          {connection ? (
+            <>
+              <p className="small">
+                Connected as{" "}
+                <span className="text-ink-2">
+                  {connection.provider_account_email ?? "google account"}
+                </span>
+                . Scan for booking confirmation emails from Trainline, LNER,
+                airlines, Booking.com, and more.
+              </p>
+              {connection.last_scan_at ? (
+                <p className="tiny mt-1" style={{ color: "var(--ink-dim)" }}>
+                  Last scanned{" "}
+                  {new Date(connection.last_scan_at).toLocaleDateString("en-GB", {
+                    day: "numeric",
+                    month: "short",
+                    hour: "2-digit",
+                    minute: "2-digit",
+                  })}
+                </p>
+              ) : null}
+            </>
+          ) : (
+            <p className="small">
+              Connect your Gmail to automatically find booking confirmations
+              from Trainline, LNER, Avanti, airlines, Booking.com, and other
+              providers. Read-only access — Khonsera never sends or modifies
+              your email.
+            </p>
+          )}
+        </div>
+        {connection ? (
+          <button
+            type="button"
+            onClick={handleDisconnect}
+            disabled={pending}
+            className="btn-destructive"
+          >
+            {pending ? "Disconnecting..." : "Disconnect"}
+          </button>
+        ) : (
+          <a href="/api/auth/gmail/connect" className="btn-terra">
+            Connect Gmail
+          </a>
+        )}
+      </div>
+      <FormError message={error ?? undefined} />
+    </div>
+  );
+}

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -4,6 +4,7 @@ import { createClient } from "@/lib/supabase/server";
 import { requireUserContext } from "@/lib/auth";
 import { TravelProfileForm } from "./travel-profile-form";
 import { CalendarSection } from "./calendar-section";
+import { GmailSection } from "./gmail-section";
 import { ThemePicker } from "@/components/theme-picker";
 
 export default async function SettingsPage({
@@ -15,31 +16,42 @@ export default async function SettingsPage({
   const sp = await searchParams;
   const supabase = await createClient();
 
-  const [{ data: profile }, { data: locations }, { data: calendarConn }] =
-    await Promise.all([
-      supabase
-        .from("travel_profiles")
-        .select(
-          "default_drive_origin_location_id, default_rail_origin_location_id, default_return_location_id, default_rail_origin_transport_hub_id, default_flight_origin_transport_hub_id, preferred_mode, default_arrival_buffer_minutes, default_return_buffer_minutes, mileage_rate, walking_threshold_minutes, minimum_buffer_minutes, max_taxi_fare_pence, luggage_default",
-        )
-        .eq("user_id", ctx.userId)
-        .eq("workspace_id", ctx.workspaceId)
-        .maybeSingle(),
-      supabase
-        .from("locations")
-        .select("id, name, type")
-        .eq("workspace_id", ctx.workspaceId)
-        .order("type")
-        .order("name"),
-      supabase
-        .from("calendar_connections")
-        .select("id, provider_account_email")
-        .eq("user_id", ctx.userId)
-        .eq("workspace_id", ctx.workspaceId)
-        .eq("provider", "google")
-        .eq("status", "active")
-        .maybeSingle(),
-    ]);
+  const [
+    { data: profile },
+    { data: locations },
+    { data: calendarConn },
+    { data: gmailConn },
+  ] = await Promise.all([
+    supabase
+      .from("travel_profiles")
+      .select(
+        "default_drive_origin_location_id, default_rail_origin_location_id, default_return_location_id, default_rail_origin_transport_hub_id, default_flight_origin_transport_hub_id, preferred_mode, default_arrival_buffer_minutes, default_return_buffer_minutes, mileage_rate, walking_threshold_minutes, minimum_buffer_minutes, max_taxi_fare_pence, luggage_default",
+      )
+      .eq("user_id", ctx.userId)
+      .eq("workspace_id", ctx.workspaceId)
+      .maybeSingle(),
+    supabase
+      .from("locations")
+      .select("id, name, type")
+      .eq("workspace_id", ctx.workspaceId)
+      .order("type")
+      .order("name"),
+    supabase
+      .from("calendar_connections")
+      .select("id, provider_account_email")
+      .eq("user_id", ctx.userId)
+      .eq("workspace_id", ctx.workspaceId)
+      .eq("provider", "google")
+      .eq("status", "active")
+      .maybeSingle(),
+    supabase
+      .from("gmail_connections")
+      .select("id, provider_account_email, last_scan_at")
+      .eq("user_id", ctx.userId)
+      .eq("workspace_id", ctx.workspaceId)
+      .eq("status", "active")
+      .maybeSingle(),
+  ]);
 
   // Resolve the two hub defaults to their friendly labels so the
   // picker shows "Wellingborough (WLB)" on first paint rather than
@@ -82,6 +94,11 @@ export default async function SettingsPage({
           Google Calendar connected.
         </div>
       ) : null}
+      {sp.connected === "gmail" ? (
+        <div className="rounded-md border border-sage-2 bg-sage-2 px-3 py-2 text-sm text-sage">
+          Gmail connected. You can now scan for booking emails.
+        </div>
+      ) : null}
 
       <section className="grid gap-5 md:grid-cols-2">
         <div className="j-card p-5">
@@ -100,6 +117,18 @@ export default async function SettingsPage({
               ? {
                   id: calendarConn.id,
                   provider_account_email: calendarConn.provider_account_email,
+                }
+              : null
+          }
+        />
+
+        <GmailSection
+          connection={
+            gmailConn
+              ? {
+                  id: gmailConn.id,
+                  provider_account_email: gmailConn.provider_account_email,
+                  last_scan_at: gmailConn.last_scan_at,
                 }
               : null
           }

--- a/src/app/api/auth/gmail/callback/route.ts
+++ b/src/app/api/auth/gmail/callback/route.ts
@@ -1,0 +1,84 @@
+// Handles the redirect back from Google for Gmail OAuth.
+// Verifies state, exchanges code for tokens, persists to gmail_connections.
+
+import { NextResponse, type NextRequest } from "next/server";
+import { requireUserContext } from "@/lib/auth";
+import { createClient } from "@/lib/supabase/server";
+import { exchangeAuthCode, fetchUserInfo } from "@/lib/google/oauth";
+import { buildGmailRedirectUri } from "@/lib/google/gmail-config";
+
+export async function GET(request: NextRequest) {
+  const ctx = await requireUserContext();
+  const url = request.nextUrl;
+  const code = url.searchParams.get("code");
+  const state = url.searchParams.get("state");
+  const errorParam = url.searchParams.get("error");
+
+  const cookieState = request.cookies.get("gmail_oauth_state")?.value;
+
+  const back = (errorMessage?: string) => {
+    const target = errorMessage
+      ? new URL(`/settings?error=${encodeURIComponent(errorMessage)}`, url)
+      : new URL("/settings?connected=gmail", url);
+    const r = NextResponse.redirect(target);
+    r.cookies.set("gmail_oauth_state", "", { maxAge: 0, path: "/" });
+    return r;
+  };
+
+  if (errorParam) return back(`Google denied: ${errorParam}`);
+  if (!code || !state) return back("Missing code or state from Google callback");
+  if (!cookieState || cookieState !== state) {
+    return back("OAuth state mismatch (possible CSRF). Try connecting again.");
+  }
+
+  const origin =
+    process.env.NEXT_PUBLIC_APP_URL ?? `${url.protocol}//${url.host}`;
+  const redirectUri = buildGmailRedirectUri(origin);
+
+  let tokens;
+  let email: string | null = null;
+  try {
+    tokens = await exchangeAuthCode({ code, redirectUri });
+    if (tokens.accessToken) {
+      try {
+        email = (await fetchUserInfo(tokens.accessToken)).email;
+      } catch {
+        email = null;
+      }
+    }
+  } catch (e) {
+    console.error("gmail callback exchange failed", e);
+    return back(
+      "Token exchange failed. Check the redirect URI in Google Cloud matches this app.",
+    );
+  }
+
+  const supabase = await createClient();
+
+  const { data: existing } = await supabase
+    .from("gmail_connections")
+    .select("id, refresh_token")
+    .eq("user_id", ctx.userId)
+    .eq("workspace_id", ctx.workspaceId)
+    .maybeSingle();
+
+  const payload = {
+    user_id: ctx.userId,
+    workspace_id: ctx.workspaceId,
+    provider_account_email: email,
+    access_token: tokens.accessToken,
+    refresh_token: tokens.refreshToken ?? existing?.refresh_token ?? null,
+    expires_at: tokens.expiresAt.toISOString(),
+    status: "active",
+  };
+
+  const { error } = existing
+    ? await supabase.from("gmail_connections").update(payload).eq("id", existing.id)
+    : await supabase.from("gmail_connections").insert(payload);
+  if (error) {
+    console.error("gmail_connections write failed", error);
+    return back(`Couldn't store connection: ${error.message}`);
+  }
+
+  return back();
+}

--- a/src/app/api/auth/gmail/connect/route.ts
+++ b/src/app/api/auth/gmail/connect/route.ts
@@ -1,0 +1,55 @@
+// Initiates the Gmail OAuth flow. Same pattern as calendar connect, but
+// requests gmail.readonly scope and redirects to the Gmail callback.
+
+import { NextResponse, type NextRequest } from "next/server";
+import { requireUser } from "@/lib/auth";
+import { GMAIL_SCOPES, buildGmailRedirectUri } from "@/lib/google/gmail-config";
+import {
+  GOOGLE_AUTH_ENDPOINT,
+  googleCredentials,
+} from "@/lib/google/config";
+
+export async function GET(request: NextRequest) {
+  await requireUser();
+
+  if (!googleCredentials()) {
+    return NextResponse.redirect(
+      new URL(
+        `/settings?error=${encodeURIComponent(
+          "Google OAuth not configured. Set GOOGLE_CLIENT_ID + GOOGLE_CLIENT_SECRET.",
+        )}`,
+        request.nextUrl,
+      ),
+    );
+  }
+
+  const creds = googleCredentials()!;
+  const origin =
+    process.env.NEXT_PUBLIC_APP_URL ??
+    `${request.nextUrl.protocol}//${request.nextUrl.host}`;
+  const redirectUri = buildGmailRedirectUri(origin);
+  const state = crypto.randomUUID().replace(/-/g, "");
+
+  const params = new URLSearchParams({
+    client_id: creds.clientId,
+    redirect_uri: redirectUri,
+    response_type: "code",
+    scope: GMAIL_SCOPES,
+    access_type: "offline",
+    prompt: "consent",
+    state,
+    include_granted_scopes: "true",
+  });
+
+  const authUrl = `${GOOGLE_AUTH_ENDPOINT}?${params.toString()}`;
+
+  const response = NextResponse.redirect(authUrl);
+  response.cookies.set("gmail_oauth_state", state, {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: 600,
+  });
+  return response;
+}

--- a/src/lib/actions/gmail.ts
+++ b/src/lib/actions/gmail.ts
@@ -42,10 +42,10 @@ function buildSearchQuery(): string {
   const senderClauses = BOOKING_SENDERS.map((s) => `from:${s}`).join(" OR ");
   const subjectTerms =
     "(subject:confirmation OR subject:booking OR subject:ticket OR subject:e-ticket OR subject:itinerary OR subject:reservation OR subject:amended OR subject:changed OR subject:updated OR subject:modification)";
-  // Search emails from the last 5 weeks only. Most bookings are confirmed
-  // days-to-weeks before travel, so this window catches upcoming trips
-  // without fetching months of historical confirmations.
-  const cutoff = new Date(Date.now() - 35 * 24 * 60 * 60 * 1000);
+  // Search the last 3 months — flights and hotels are often booked well
+  // in advance. The post-parse date filter drops anything where the
+  // travel/check-in date has already passed.
+  const cutoff = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000);
   const after = `${cutoff.getFullYear()}/${String(cutoff.getMonth() + 1).padStart(2, "0")}/${String(cutoff.getDate()).padStart(2, "0")}`;
   return `(${senderClauses}) ${subjectTerms} after:${after}`;
 }
@@ -76,7 +76,7 @@ export async function scanGmailForBookings(): Promise<
     messageRefs = await gmailSearchMessages({
       accessToken: gmail.accessToken,
       query: buildSearchQuery(),
-      maxResults: 30,
+      maxResults: 50,
     });
   } catch (e) {
     console.error("gmail scan failed", e);

--- a/src/lib/actions/gmail.ts
+++ b/src/lib/actions/gmail.ts
@@ -11,7 +11,7 @@ import {
   extractMessageBody,
 } from "@/lib/google/gmail";
 import { detectAndParse } from "@/lib/gmail/parsers";
-import type { ParsedBooking } from "@/lib/gmail/types";
+import { type ParsedBooking, getTravelDate } from "@/lib/gmail/types";
 
 const BOOKING_SENDERS = [
   "trainline",
@@ -131,13 +131,21 @@ export async function scanGmailForBookings(): Promise<
     }
   }
 
+  // Drop bookings where the travel date is in the past — users want
+  // present/future bookings, not historical trips.
+  const today = new Date().toISOString().slice(0, 10);
+  const futureBookings = bookings.filter((b) => {
+    const travelDate = getTravelDate(b);
+    return !travelDate || travelDate >= today;
+  });
+
   // Update last_scan_at
   await supabase
     .from("gmail_connections")
     .update({ last_scan_at: new Date().toISOString() })
     .eq("id", gmail.connectionId);
 
-  return ok({ bookings, scanned_count: scannedCount });
+  return ok({ bookings: futureBookings, scanned_count: scannedCount });
 }
 
 export async function markBookingImported(args: {

--- a/src/lib/actions/gmail.ts
+++ b/src/lib/actions/gmail.ts
@@ -42,7 +42,12 @@ function buildSearchQuery(): string {
   const senderClauses = BOOKING_SENDERS.map((s) => `from:${s}`).join(" OR ");
   const subjectTerms =
     "(subject:confirmation OR subject:booking OR subject:ticket OR subject:e-ticket OR subject:itinerary OR subject:reservation OR subject:amended OR subject:changed OR subject:updated OR subject:modification)";
-  return `(${senderClauses}) ${subjectTerms} newer_than:6m`;
+  // Search emails from the last 5 weeks only. Most bookings are confirmed
+  // days-to-weeks before travel, so this window catches upcoming trips
+  // without fetching months of historical confirmations.
+  const cutoff = new Date(Date.now() - 35 * 24 * 60 * 60 * 1000);
+  const after = `${cutoff.getFullYear()}/${String(cutoff.getMonth() + 1).padStart(2, "0")}/${String(cutoff.getDate()).padStart(2, "0")}`;
+  return `(${senderClauses}) ${subjectTerms} after:${after}`;
 }
 
 export async function scanGmailForBookings(): Promise<
@@ -71,7 +76,7 @@ export async function scanGmailForBookings(): Promise<
     messageRefs = await gmailSearchMessages({
       accessToken: gmail.accessToken,
       query: buildSearchQuery(),
-      maxResults: 100,
+      maxResults: 30,
     });
   } catch (e) {
     console.error("gmail scan failed", e);

--- a/src/lib/actions/gmail.ts
+++ b/src/lib/actions/gmail.ts
@@ -1,0 +1,182 @@
+"use server";
+
+import { createClient } from "@/lib/supabase/server";
+import { requireUserContext } from "@/lib/auth";
+import { err, errors, ok, type Result } from "@/lib/errors";
+import { getValidGmailAccessToken } from "@/lib/google/gmail-client";
+import {
+  gmailSearchMessages,
+  gmailGetMessage,
+  getHeader,
+  extractMessageBody,
+} from "@/lib/google/gmail";
+import { detectAndParse } from "@/lib/gmail/parsers";
+import type { ParsedBooking } from "@/lib/gmail/types";
+
+const BOOKING_SENDERS = [
+  "trainline",
+  "lner",
+  "avanti",
+  "gwr",
+  "crosscountry",
+  "scotrail",
+  "southeastern",
+  "british airways",
+  "easyjet",
+  "ryanair",
+  "jet2",
+  "booking.com",
+  "hotels.com",
+  "expedia",
+  "airbnb",
+  "tui",
+  "wizz air",
+  "vueling",
+  "klm",
+  "lufthansa",
+  "emirates",
+  "virgin atlantic",
+];
+
+function buildSearchQuery(): string {
+  const senderClauses = BOOKING_SENDERS.map((s) => `from:${s}`).join(" OR ");
+  const subjectTerms =
+    "(subject:confirmation OR subject:booking OR subject:ticket OR subject:e-ticket OR subject:itinerary OR subject:reservation)";
+  return `(${senderClauses}) ${subjectTerms} newer_than:6m`;
+}
+
+export async function scanGmailForBookings(): Promise<
+  Result<{ bookings: ParsedBooking[]; scanned_count: number }>
+> {
+  const ctx = await requireUserContext();
+  const gmail = await getValidGmailAccessToken();
+  if (!gmail) {
+    return err(
+      errors.integration("gmail", "Gmail not connected. Connect in Settings."),
+    );
+  }
+
+  const supabase = await createClient();
+
+  // Get already-imported message IDs to exclude
+  const { data: imported } = await supabase
+    .from("gmail_imported_messages")
+    .select("gmail_message_id")
+    .eq("workspace_id", ctx.workspaceId)
+    .eq("user_id", ctx.userId);
+  const importedIds = new Set((imported ?? []).map((r) => r.gmail_message_id));
+
+  let messageRefs;
+  try {
+    messageRefs = await gmailSearchMessages({
+      accessToken: gmail.accessToken,
+      query: buildSearchQuery(),
+      maxResults: 100,
+    });
+  } catch (e) {
+    console.error("gmail scan failed", e);
+    return err(
+      errors.integration(
+        "gmail",
+        "Failed to search Gmail. The connection may have expired — try reconnecting.",
+      ),
+    );
+  }
+
+  const bookings: ParsedBooking[] = [];
+  let scannedCount = 0;
+
+  for (const ref of messageRefs) {
+    if (importedIds.has(ref.id)) continue;
+
+    try {
+      const msg = await gmailGetMessage({
+        accessToken: gmail.accessToken,
+        messageId: ref.id,
+      });
+      scannedCount++;
+
+      const from = getHeader(msg.payload.headers, "From") ?? "";
+      const subject = getHeader(msg.payload.headers, "Subject") ?? "";
+      const date = getHeader(msg.payload.headers, "Date") ?? "";
+      const { html, text } = extractMessageBody(msg);
+
+      const parsed = detectAndParse(from, subject, html, text);
+      if (!parsed) continue;
+
+      const emailDate =
+        date && !isNaN(Date.parse(date))
+          ? new Date(date).toISOString()
+          : new Date(parseInt(msg.internalDate)).toISOString();
+
+      const booking: ParsedBooking = {
+        ...parsed,
+        raw_subject: subject,
+        gmail_message_id: ref.id,
+        email_date: emailDate,
+      } as ParsedBooking;
+
+      bookings.push(booking);
+    } catch (e) {
+      console.warn(`gmail: failed to fetch/parse message ${ref.id}`, e);
+    }
+  }
+
+  // Update last_scan_at
+  await supabase
+    .from("gmail_connections")
+    .update({ last_scan_at: new Date().toISOString() })
+    .eq("id", gmail.connectionId);
+
+  return ok({ bookings, scanned_count: scannedCount });
+}
+
+export async function markBookingImported(args: {
+  gmail_message_id: string;
+  booking_type: "transport" | "accommodation";
+  travel_booking_id: string | null;
+}): Promise<Result<{ id: string }>> {
+  const ctx = await requireUserContext();
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from("gmail_imported_messages")
+    .insert({
+      workspace_id: ctx.workspaceId,
+      user_id: ctx.userId,
+      gmail_message_id: args.gmail_message_id,
+      booking_type: args.booking_type,
+      travel_booking_id: args.travel_booking_id,
+    })
+    .select("id")
+    .single();
+
+  if (error) {
+    if (error.code === "23505") {
+      return ok({ id: "already_imported" });
+    }
+    return err(errors.unexpected(error.message));
+  }
+  return ok({ id: data.id });
+}
+
+export async function disconnectGmail(): Promise<Result<{ id: string }>> {
+  const ctx = await requireUserContext();
+  const supabase = await createClient();
+
+  const { data: existing } = await supabase
+    .from("gmail_connections")
+    .select("id")
+    .eq("user_id", ctx.userId)
+    .eq("workspace_id", ctx.workspaceId)
+    .maybeSingle();
+  if (!existing) return err(errors.notFound("gmail_connection"));
+
+  const { error } = await supabase
+    .from("gmail_connections")
+    .delete()
+    .eq("id", existing.id);
+  if (error) return err(errors.unexpected(error.message));
+
+  return ok({ id: existing.id });
+}

--- a/src/lib/actions/gmail.ts
+++ b/src/lib/actions/gmail.ts
@@ -41,7 +41,7 @@ const BOOKING_SENDERS = [
 function buildSearchQuery(): string {
   const senderClauses = BOOKING_SENDERS.map((s) => `from:${s}`).join(" OR ");
   const subjectTerms =
-    "(subject:confirmation OR subject:booking OR subject:ticket OR subject:e-ticket OR subject:itinerary OR subject:reservation)";
+    "(subject:confirmation OR subject:booking OR subject:ticket OR subject:e-ticket OR subject:itinerary OR subject:reservation OR subject:amended OR subject:changed OR subject:updated OR subject:modification)";
   return `(${senderClauses}) ${subjectTerms} newer_than:6m`;
 }
 
@@ -83,42 +83,51 @@ export async function scanGmailForBookings(): Promise<
     );
   }
 
+  const toFetch = messageRefs.filter((ref) => !importedIds.has(ref.id));
+
+  // Fetch messages in parallel batches of 10 to stay well under Gmail rate limits.
+  const BATCH_SIZE = 10;
   const bookings: ParsedBooking[] = [];
   let scannedCount = 0;
 
-  for (const ref of messageRefs) {
-    if (importedIds.has(ref.id)) continue;
+  for (let i = 0; i < toFetch.length; i += BATCH_SIZE) {
+    const batch = toFetch.slice(i, i + BATCH_SIZE);
+    const results = await Promise.allSettled(
+      batch.map(async (ref) => {
+        const msg = await gmailGetMessage({
+          accessToken: gmail.accessToken,
+          messageId: ref.id,
+        });
 
-    try {
-      const msg = await gmailGetMessage({
-        accessToken: gmail.accessToken,
-        messageId: ref.id,
-      });
+        const from = getHeader(msg.payload.headers, "From") ?? "";
+        const subject = getHeader(msg.payload.headers, "Subject") ?? "";
+        const date = getHeader(msg.payload.headers, "Date") ?? "";
+        const { html, text } = extractMessageBody(msg);
+
+        const parsed = detectAndParse(from, subject, html, text);
+        if (!parsed) return null;
+
+        const emailDate =
+          date && !isNaN(Date.parse(date))
+            ? new Date(date).toISOString()
+            : new Date(parseInt(msg.internalDate)).toISOString();
+
+        return {
+          ...parsed,
+          raw_subject: subject,
+          gmail_message_id: ref.id,
+          email_date: emailDate,
+        } as ParsedBooking;
+      }),
+    );
+
+    for (const r of results) {
       scannedCount++;
-
-      const from = getHeader(msg.payload.headers, "From") ?? "";
-      const subject = getHeader(msg.payload.headers, "Subject") ?? "";
-      const date = getHeader(msg.payload.headers, "Date") ?? "";
-      const { html, text } = extractMessageBody(msg);
-
-      const parsed = detectAndParse(from, subject, html, text);
-      if (!parsed) continue;
-
-      const emailDate =
-        date && !isNaN(Date.parse(date))
-          ? new Date(date).toISOString()
-          : new Date(parseInt(msg.internalDate)).toISOString();
-
-      const booking: ParsedBooking = {
-        ...parsed,
-        raw_subject: subject,
-        gmail_message_id: ref.id,
-        email_date: emailDate,
-      } as ParsedBooking;
-
-      bookings.push(booking);
-    } catch (e) {
-      console.warn(`gmail: failed to fetch/parse message ${ref.id}`, e);
+      if (r.status === "fulfilled" && r.value) {
+        bookings.push(r.value);
+      } else if (r.status === "rejected") {
+        console.warn("gmail: failed to fetch/parse message", r.reason);
+      }
     }
   }
 

--- a/src/lib/gmail/parsers.ts
+++ b/src/lib/gmail/parsers.ts
@@ -49,6 +49,12 @@ function findPrice(text: string): { amount: number; currency: "GBP" | "EUR" | "U
   return null;
 }
 
+function isAmendmentEmail(subject: string, text: string): boolean {
+  return /amend|changed|updated|modification|revised|new\s*time|rescheduled|altered/i.test(
+    subject + " " + text.slice(0, 300),
+  );
+}
+
 function findBookingRef(text: string): string | null {
   const patterns = [
     /(?:booking\s*(?:ref(?:erence)?|ID|number|#)|confirmation\s*(?:number|#|code)|ref(?:erence)?\s*(?:number|#)?)\s*[:.]?\s*([A-Z0-9][-A-Z0-9]{3,20})/i,
@@ -553,32 +559,40 @@ export function detectAndParse(
   const text = plainText ?? (html ? stripHtml(html) : "");
   const htmlContent = html ?? "";
 
-  // Only process confirmation-like emails
-  const isConfirmation =
-    /confirm|booking|ticket|itinerary|receipt|reservation|e-?ticket/i.test(
+  // Only process confirmation-like or amendment emails
+  const isRelevant =
+    /confirm|booking|ticket|itinerary|receipt|reservation|e-?ticket|amend|changed|updated|modification|revised|rescheduled/i.test(
       subject,
     ) ||
     /confirm|booking\s*(?:confirm|detail)|your\s*ticket|e-?ticket|reservation/i.test(
       text.slice(0, 500),
     );
-  if (!isConfirmation) return null;
+  if (!isRelevant) return null;
+
+  const amendment = isAmendmentEmail(subject, text);
+
+  let result: Partial<ParsedBooking> | null = null;
 
   for (const config of SENDER_CONFIGS) {
     if (config.match(senderEmail, subject)) {
-      return config.parse(htmlContent, text);
+      result = config.parse(htmlContent, text);
+      break;
     }
   }
 
-  // Generic fallback: if subject mentions train/flight + confirmation
-  if (/train|rail/i.test(subject)) {
-    return parseUkRail(htmlContent, text, "Rail");
-  }
-  if (/flight|air/i.test(subject)) {
-    return parseFlightBooking(htmlContent, text, "Airline");
-  }
-  if (/hotel|accommodation|stay|check[\s-]?in/i.test(subject)) {
-    return parseAccommodation(htmlContent, text, "Hotel");
+  if (!result) {
+    if (/train|rail/i.test(subject)) {
+      result = parseUkRail(htmlContent, text, "Rail");
+    } else if (/flight|air/i.test(subject)) {
+      result = parseFlightBooking(htmlContent, text, "Airline");
+    } else if (/hotel|accommodation|stay|check[\s-]?in/i.test(subject)) {
+      result = parseAccommodation(htmlContent, text, "Hotel");
+    }
   }
 
-  return null;
+  if (result) {
+    (result as { is_amendment: boolean }).is_amendment = amendment;
+  }
+
+  return result;
 }

--- a/src/lib/gmail/parsers.ts
+++ b/src/lib/gmail/parsers.ts
@@ -1,0 +1,584 @@
+// Email HTML parsers for extracting booking data from confirmation emails.
+// Each sender has distinctive HTML patterns we match with regex. The parsers
+// are deliberately lenient — they extract what they can and leave nulls for
+// fields they can't find.
+
+import type {
+  ParsedBooking,
+  ParsedTransportBooking,
+  ParsedTransportSegment,
+  ParsedAccommodationBooking,
+} from "./types";
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+function stripHtml(html: string): string {
+  return html
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<\/?(p|div|tr|li|h\d)[^>]*>/gi, "\n")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(Number(n)))
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function findPrice(text: string): { amount: number; currency: "GBP" | "EUR" | "USD" } | null {
+  const m =
+    text.match(/[£](\d+(?:\.\d{2})?)/) ??
+    text.match(/(\d+(?:\.\d{2})?)\s*GBP/) ??
+    text.match(/GBP\s*(\d+(?:\.\d{2})?)/) ??
+    text.match(/Total[:\s]*[£]?(\d+(?:\.\d{2})?)/i);
+  if (m) return { amount: parseFloat(m[1]), currency: "GBP" };
+
+  const eur =
+    text.match(/[€](\d+(?:\.\d{2})?)/) ??
+    text.match(/(\d+(?:\.\d{2})?)\s*EUR/) ??
+    text.match(/EUR\s*(\d+(?:\.\d{2})?)/);
+  if (eur) return { amount: parseFloat(eur[1]), currency: "EUR" };
+
+  const usd =
+    text.match(/\$(\d+(?:\.\d{2})?)/) ??
+    text.match(/(\d+(?:\.\d{2})?)\s*USD/) ??
+    text.match(/USD\s*(\d+(?:\.\d{2})?)/);
+  if (usd) return { amount: parseFloat(usd[1]), currency: "USD" };
+
+  return null;
+}
+
+function findBookingRef(text: string): string | null {
+  const patterns = [
+    /(?:booking\s*(?:ref(?:erence)?|ID|number|#)|confirmation\s*(?:number|#|code)|ref(?:erence)?\s*(?:number|#)?)\s*[:.]?\s*([A-Z0-9][-A-Z0-9]{3,20})/i,
+    /\b([A-Z]{2,4}\d{4,10})\b/,
+  ];
+  for (const p of patterns) {
+    const m = text.match(p);
+    if (m) return m[1].trim();
+  }
+  return null;
+}
+
+// Parse dates like "Mon 26 May", "26 May 2025", "2025-05-26", "26/05/2025"
+const MONTHS: Record<string, string> = {
+  jan: "01", feb: "02", mar: "03", apr: "04", may: "05", jun: "06",
+  jul: "07", aug: "08", sep: "09", oct: "10", nov: "11", dec: "12",
+  january: "01", february: "02", march: "03", april: "04",
+  june: "06", july: "07", august: "08", september: "09",
+  october: "10", november: "11", december: "12",
+};
+
+function parseDate(dateStr: string): string | null {
+  const isoMatch = dateStr.match(/(\d{4})-(\d{2})-(\d{2})/);
+  if (isoMatch) return `${isoMatch[1]}-${isoMatch[2]}-${isoMatch[3]}`;
+
+  const ukMatch = dateStr.match(/(\d{1,2})\/(\d{1,2})\/(\d{4})/);
+  if (ukMatch) return `${ukMatch[3]}-${ukMatch[2].padStart(2, "0")}-${ukMatch[1].padStart(2, "0")}`;
+
+  const namedMatch = dateStr.match(
+    /(\d{1,2})\s+(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\s*(\d{4})?/i,
+  );
+  if (namedMatch) {
+    const day = namedMatch[1].padStart(2, "0");
+    const month = MONTHS[namedMatch[2].toLowerCase()];
+    const year = namedMatch[3] ?? new Date().getFullYear().toString();
+    if (month) return `${year}-${month}-${day}`;
+  }
+
+  const namedReversed = dateStr.match(
+    /(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\s+(\d{1,2})(?:\s*,?\s*(\d{4}))?/i,
+  );
+  if (namedReversed) {
+    const month = MONTHS[namedReversed[1].toLowerCase()];
+    const day = namedReversed[2].padStart(2, "0");
+    const year = namedReversed[3] ?? new Date().getFullYear().toString();
+    if (month) return `${year}-${month}-${day}`;
+  }
+
+  return null;
+}
+
+function parseTime(timeStr: string): string | null {
+  const m = timeStr.match(/(\d{1,2}):(\d{2})/);
+  if (m) return `${m[1].padStart(2, "0")}:${m[2]}`;
+  return null;
+}
+
+// ── Trainline ──────────────────────────────────────────────────────────
+
+function parseTrainline(html: string, text: string): Partial<ParsedTransportBooking> | null {
+  const segments: ParsedTransportSegment[] = [];
+
+  // Trainline typically has patterns like:
+  // "London Euston" → "Manchester Piccadilly"
+  // "Departs: 14:30" / "Arrives: 16:45"
+  const stationPairPattern =
+    /(?:from|depart(?:s|ing)?(?:\s+from)?)\s*:?\s*([A-Za-z\s&'.()-]+?)(?:\s+to\s+|\s*→\s*|\s*->\s*|\s*➔\s*)([A-Za-z\s&'.()-]+?)(?:\n|<|,|\s{2})/gi;
+
+  const timeBlockPattern =
+    /(\d{1,2}:\d{2})\s*(?:→|->|to|–|-|➔)\s*(\d{1,2}:\d{2})/g;
+
+  const datePattern =
+    /(?:(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)\w*\s+)?(\d{1,2}\s+(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\s*\d{0,4})/gi;
+
+  const stations: Array<[string, string]> = [];
+  let m;
+  while ((m = stationPairPattern.exec(text)) !== null) {
+    stations.push([m[1].trim(), m[2].trim()]);
+  }
+
+  if (stations.length === 0) {
+    // Fallback: look for station names on separate lines
+    const lines = text.split("\n").map((l) => l.trim()).filter(Boolean);
+    for (let i = 0; i < lines.length - 1; i++) {
+      if (/depart/i.test(lines[i]) && /arriv/i.test(lines[i + 1])) {
+        const from = lines[i].replace(/^.*?:\s*/, "").trim();
+        const to = lines[i + 1].replace(/^.*?:\s*/, "").trim();
+        if (from.length > 2 && to.length > 2) {
+          stations.push([from, to]);
+        }
+      }
+    }
+  }
+
+  const times: Array<[string, string]> = [];
+  while ((m = timeBlockPattern.exec(text)) !== null) {
+    const dep = parseTime(m[1]);
+    const arr = parseTime(m[2]);
+    if (dep && arr) times.push([dep, arr]);
+  }
+
+  const dates: string[] = [];
+  while ((m = datePattern.exec(text)) !== null) {
+    const d = parseDate(m[1]);
+    if (d) dates.push(d);
+  }
+  const travelDate = dates[0] ?? new Date().toISOString().slice(0, 10);
+
+  const trainNumbers: string[] = [];
+  const trainPattern = /(?:train|service)\s*(?:no\.?|number|#)?\s*:?\s*([A-Z0-9]{2,8})/gi;
+  while ((m = trainPattern.exec(text)) !== null) {
+    trainNumbers.push(m[1]);
+  }
+
+  const seatMatch = text.match(
+    /(?:seat|coach\s*[&+]?\s*seat)\s*:?\s*(?:coach\s+)?([A-Z0-9]+(?:\s*,?\s*seat\s*\d+[A-Z]?)?)/i,
+  );
+  const seat = seatMatch ? seatMatch[1].trim() : null;
+
+  const count = Math.max(stations.length, times.length, 1);
+  for (let i = 0; i < count; i++) {
+    segments.push({
+      from_station: stations[i]?.[0] ?? "Unknown",
+      to_station: stations[i]?.[1] ?? "Unknown",
+      departure_date: travelDate,
+      departure_time: times[i]?.[0] ?? "00:00",
+      arrival_date: dates[i + 1] ?? travelDate,
+      arrival_time: times[i]?.[1] ?? "00:00",
+      service_number: trainNumbers[i] ?? null,
+      platform_dep: null,
+      platform_arr: null,
+      seat: i === 0 ? seat : null,
+    });
+  }
+
+  if (segments.length === 0) return null;
+
+  const price = findPrice(text);
+  const ref = findBookingRef(text);
+
+  return {
+    type: "transport",
+    mode: "train",
+    provider: "Trainline",
+    booking_reference: ref,
+    price: price?.amount ?? null,
+    currency: price?.currency ?? "GBP",
+    segments,
+  };
+}
+
+// ── UK Rail operators (LNER, Avanti, GWR, etc.) ────────────────────────
+
+function parseUkRail(
+  html: string,
+  text: string,
+  provider: string,
+): Partial<ParsedTransportBooking> | null {
+  const segments: ParsedTransportSegment[] = [];
+
+  // UK rail operators typically show journey details in structured blocks
+  const journeyPattern =
+    /(\d{1,2}:\d{2})\s+([A-Za-z\s&'.()-]+?)\s*(?:→|->|to|–|-|➔|→)\s*(\d{1,2}:\d{2})\s+([A-Za-z\s&'.()-]+?)(?:\n|$)/gm;
+
+  let m;
+  const datePattern =
+    /(?:(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)\w*\s+)?(\d{1,2}\s+(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\s*\d{0,4})/gi;
+
+  const dates: string[] = [];
+  while ((m = datePattern.exec(text)) !== null) {
+    const d = parseDate(m[1]);
+    if (d) dates.push(d);
+  }
+  const travelDate = dates[0] ?? new Date().toISOString().slice(0, 10);
+
+  while ((m = journeyPattern.exec(text)) !== null) {
+    const depTime = parseTime(m[1]);
+    const from = m[2].trim();
+    const arrTime = parseTime(m[3]);
+    const to = m[4].trim();
+    if (depTime && arrTime && from.length > 2 && to.length > 2) {
+      segments.push({
+        from_station: from,
+        to_station: to,
+        departure_date: travelDate,
+        departure_time: depTime,
+        arrival_date: travelDate,
+        arrival_time: arrTime,
+        service_number: null,
+        platform_dep: null,
+        platform_arr: null,
+        seat: null,
+      });
+    }
+  }
+
+  if (segments.length === 0) {
+    // Simpler fallback: look for station names and times separately
+    const stationNames: string[] = [];
+    const stationPattern =
+      /(?:from|depart|origin|board\s+at)\s*:?\s*([A-Za-z\s&'.()-]{3,40})/gi;
+    while ((m = stationPattern.exec(text)) !== null) {
+      stationNames.push(m[1].trim());
+    }
+    const destPattern =
+      /(?:to|arriv(?:e|al|ing)|destination)\s*:?\s*([A-Za-z\s&'.()-]{3,40})/gi;
+    const destNames: string[] = [];
+    while ((m = destPattern.exec(text)) !== null) {
+      destNames.push(m[1].trim());
+    }
+
+    const allTimes: string[] = [];
+    const allTimesPattern = /\b(\d{1,2}:\d{2})\b/g;
+    while ((m = allTimesPattern.exec(text)) !== null) {
+      const t = parseTime(m[1]);
+      if (t) allTimes.push(t);
+    }
+
+    if (stationNames.length > 0 && destNames.length > 0 && allTimes.length >= 2) {
+      segments.push({
+        from_station: stationNames[0],
+        to_station: destNames[0],
+        departure_date: travelDate,
+        departure_time: allTimes[0],
+        arrival_date: travelDate,
+        arrival_time: allTimes[1],
+        service_number: null,
+        platform_dep: null,
+        platform_arr: null,
+        seat: null,
+      });
+    }
+  }
+
+  if (segments.length === 0) return null;
+
+  const seatMatch = text.match(
+    /(?:seat|coach\s*[&+]?\s*seat)\s*:?\s*(?:coach\s+)?([A-Z0-9]+(?:\s*,?\s*seat\s*\d+[A-Z]?)?)/i,
+  );
+  if (seatMatch && segments[0]) segments[0].seat = seatMatch[1].trim();
+
+  const trainMatch = text.match(
+    /(?:train|service)\s*(?:no\.?|number|#)?\s*:?\s*([A-Z0-9]{2,8})/i,
+  );
+  if (trainMatch && segments[0]) segments[0].service_number = trainMatch[1];
+
+  const price = findPrice(text);
+  const ref = findBookingRef(text);
+
+  return {
+    type: "transport",
+    mode: "train",
+    provider,
+    booking_reference: ref,
+    price: price?.amount ?? null,
+    currency: price?.currency ?? "GBP",
+    segments,
+  };
+}
+
+// ── Airlines ───────────────────────────────────────────────────────────
+
+function parseFlightBooking(
+  html: string,
+  text: string,
+  provider: string,
+): Partial<ParsedTransportBooking> | null {
+  const segments: ParsedTransportSegment[] = [];
+
+  // Look for airport codes (3 uppercase letters)
+  const routePattern =
+    /([A-Z]{3})\s*(?:→|->|to|–|-|➔)\s*([A-Z]{3})/g;
+  const routes: Array<[string, string]> = [];
+  let m;
+  while ((m = routePattern.exec(text)) !== null) {
+    routes.push([m[1], m[2]]);
+  }
+
+  // Look for flight numbers
+  const flightPattern = /\b([A-Z]{2}\d{1,4})\b/g;
+  const flights: string[] = [];
+  while ((m = flightPattern.exec(text)) !== null) {
+    flights.push(m[1]);
+  }
+
+  const datePattern =
+    /(?:(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)\w*\s+)?(\d{1,2}\s+(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\s*\d{0,4})/gi;
+  const dates: string[] = [];
+  while ((m = datePattern.exec(text)) !== null) {
+    const d = parseDate(m[1]);
+    if (d) dates.push(d);
+  }
+  const travelDate = dates[0] ?? new Date().toISOString().slice(0, 10);
+
+  const allTimes: string[] = [];
+  const timePattern = /\b(\d{1,2}:\d{2})\b/g;
+  while ((m = timePattern.exec(text)) !== null) {
+    const t = parseTime(m[1]);
+    if (t) allTimes.push(t);
+  }
+
+  const terminalMatch = text.match(
+    /(?:terminal|term\.?)\s*:?\s*([A-Z0-9]{1,3})/gi,
+  );
+  const terminals = terminalMatch
+    ? terminalMatch.map((t) => t.replace(/(?:terminal|term\.?)\s*:?\s*/i, "").trim())
+    : [];
+
+  const seatMatch = text.match(/(?:seat)\s*:?\s*(\d{1,3}[A-Z])/i);
+
+  const count = Math.max(routes.length, 1);
+  for (let i = 0; i < count; i++) {
+    segments.push({
+      from_station: routes[i]?.[0] ?? "Unknown",
+      to_station: routes[i]?.[1] ?? "Unknown",
+      departure_date: dates[i] ?? travelDate,
+      departure_time: allTimes[i * 2] ?? "00:00",
+      arrival_date: dates[i] ?? travelDate,
+      arrival_time: allTimes[i * 2 + 1] ?? "00:00",
+      service_number: flights[i] ?? null,
+      platform_dep: terminals[0] ?? null,
+      platform_arr: terminals[1] ?? null,
+      seat: i === 0 ? seatMatch?.[1] ?? null : null,
+    });
+  }
+
+  if (segments.length === 0) return null;
+
+  const price = findPrice(text);
+  const ref = findBookingRef(text);
+
+  return {
+    type: "transport",
+    mode: "flight",
+    provider,
+    booking_reference: ref,
+    price: price?.amount ?? null,
+    currency: price?.currency ?? "GBP",
+    segments,
+  };
+}
+
+// ── Accommodation (Booking.com, Hotels.com, etc.) ──────────────────────
+
+function parseAccommodation(
+  html: string,
+  text: string,
+  provider: string,
+): Partial<ParsedAccommodationBooking> | null {
+  // Hotel name — usually the most prominent heading
+  const hotelPatterns = [
+    /(?:hotel|property|accommodation)\s*(?:name)?\s*:?\s*([^\n]{3,60})/i,
+    /(?:your\s+(?:stay|reservation)\s+(?:at|in))\s+([^\n]{3,60})/i,
+    /(?:you'?re\s+(?:staying|booked)\s+at)\s+([^\n]{3,60})/i,
+  ];
+
+  let hotelName: string | null = null;
+  for (const p of hotelPatterns) {
+    const m = text.match(p);
+    if (m) {
+      hotelName = m[1].trim().replace(/[.,;]+$/, "");
+      break;
+    }
+  }
+
+  // Check-in / check-out dates
+  const checkInMatch = text.match(
+    /check[\s-]*in\s*:?\s*(?:(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)\w*\s*,?\s*)?([^\n]{5,30})/i,
+  );
+  const checkOutMatch = text.match(
+    /check[\s-]*out\s*:?\s*(?:(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)\w*\s*,?\s*)?([^\n]{5,30})/i,
+  );
+
+  const checkInDate = checkInMatch ? parseDate(checkInMatch[1]) : null;
+  const checkOutDate = checkOutMatch ? parseDate(checkOutMatch[1]) : null;
+
+  if (!checkInDate || !checkOutDate) return null;
+
+  // Check-in/out times
+  const checkInTimeMatch = checkInMatch?.[1]
+    ? checkInMatch[1].match(/(\d{1,2}:\d{2})/)
+    : null;
+  const checkOutTimeMatch = checkOutMatch?.[1]
+    ? checkOutMatch[1].match(/(\d{1,2}:\d{2})/)
+    : null;
+
+  // Also look for "from HH:MM" / "until HH:MM" patterns
+  const fromTimeMatch = text.match(
+    /check[\s-]*in\s*(?:from|after)\s*:?\s*(\d{1,2}:\d{2})/i,
+  );
+  const untilTimeMatch = text.match(
+    /check[\s-]*out\s*(?:before|by|until)\s*:?\s*(\d{1,2}:\d{2})/i,
+  );
+
+  const checkInTime = parseTime(
+    checkInTimeMatch?.[1] ?? fromTimeMatch?.[1] ?? "",
+  );
+  const checkOutTime = parseTime(
+    checkOutTimeMatch?.[1] ?? untilTimeMatch?.[1] ?? "",
+  );
+
+  // Room type
+  const roomMatch = text.match(
+    /(?:room\s*(?:type)?|accommodation\s*type)\s*:?\s*([^\n]{3,60})/i,
+  );
+
+  const price = findPrice(text);
+  const ref = findBookingRef(text);
+
+  return {
+    type: "accommodation",
+    hotel_name: hotelName ?? "Unknown hotel",
+    provider,
+    booking_reference: ref,
+    check_in_date: checkInDate,
+    check_in_time: checkInTime,
+    check_out_date: checkOutDate,
+    check_out_time: checkOutTime,
+    price: price?.amount ?? null,
+    currency: price?.currency ?? "GBP",
+    room_details: roomMatch ? roomMatch[1].trim() : null,
+  };
+}
+
+// ── Sender detection ───────────────────────────────────────────────────
+
+type SenderConfig = {
+  match: (from: string, subject: string) => boolean;
+  parse: (html: string, text: string) => Partial<ParsedBooking> | null;
+};
+
+const SENDER_CONFIGS: SenderConfig[] = [
+  {
+    match: (from) => /trainline/i.test(from),
+    parse: (html, text) => parseTrainline(html, text),
+  },
+  {
+    match: (from) => /lner/i.test(from),
+    parse: (html, text) => parseUkRail(html, text, "LNER"),
+  },
+  {
+    match: (from) => /avanti\s*west\s*coast/i.test(from),
+    parse: (html, text) => parseUkRail(html, text, "Avanti West Coast"),
+  },
+  {
+    match: (from) => /great\s*western|gwr/i.test(from),
+    parse: (html, text) => parseUkRail(html, text, "GWR"),
+  },
+  {
+    match: (from) => /crosscountry|cross\s*country/i.test(from),
+    parse: (html, text) => parseUkRail(html, text, "CrossCountry"),
+  },
+  {
+    match: (from) => /scotrail/i.test(from),
+    parse: (html, text) => parseUkRail(html, text, "ScotRail"),
+  },
+  {
+    match: (from) => /southeastern/i.test(from),
+    parse: (html, text) => parseUkRail(html, text, "Southeastern"),
+  },
+  {
+    match: (from) =>
+      /british\s*airways|easyjet|ryanair|jet2|tui\s*airways|wizz\s*air|vueling|klm|lufthansa|emirates|virgin\s*atlantic|aer\s*lingus/i.test(
+        from,
+      ),
+    parse: (html, text) => {
+      const providerMatch = from.match(
+        /british\s*airways|easyjet|ryanair|jet2|tui\s*airways|wizz\s*air|vueling|klm|lufthansa|emirates|virgin\s*atlantic|aer\s*lingus/i,
+      );
+      return parseFlightBooking(
+        html,
+        text,
+        providerMatch?.[0] ?? "Airline",
+      );
+    },
+  },
+  {
+    match: (from, subject) =>
+      /booking\.com/i.test(from) ||
+      /hotels\.com/i.test(from) ||
+      /expedia/i.test(from) ||
+      /airbnb/i.test(from) ||
+      (/confirmation/i.test(subject) && /hotel|stay|accommodation|check[\s-]?in/i.test(subject)),
+    parse: (html, text) => {
+      const providerMatch = from.match(
+        /booking\.com|hotels\.com|expedia|airbnb/i,
+      );
+      return parseAccommodation(html, text, providerMatch?.[0] ?? "Hotel");
+    },
+  },
+];
+
+let from = ""; // closure var for airline sender config
+
+export function detectAndParse(
+  senderEmail: string,
+  subject: string,
+  html: string | null,
+  plainText: string | null,
+): Partial<ParsedBooking> | null {
+  from = senderEmail;
+  const text = plainText ?? (html ? stripHtml(html) : "");
+  const htmlContent = html ?? "";
+
+  // Only process confirmation-like emails
+  const isConfirmation =
+    /confirm|booking|ticket|itinerary|receipt|reservation|e-?ticket/i.test(
+      subject,
+    ) ||
+    /confirm|booking\s*(?:confirm|detail)|your\s*ticket|e-?ticket|reservation/i.test(
+      text.slice(0, 500),
+    );
+  if (!isConfirmation) return null;
+
+  for (const config of SENDER_CONFIGS) {
+    if (config.match(senderEmail, subject)) {
+      return config.parse(htmlContent, text);
+    }
+  }
+
+  // Generic fallback: if subject mentions train/flight + confirmation
+  if (/train|rail/i.test(subject)) {
+    return parseUkRail(htmlContent, text, "Rail");
+  }
+  if (/flight|air/i.test(subject)) {
+    return parseFlightBooking(htmlContent, text, "Airline");
+  }
+  if (/hotel|accommodation|stay|check[\s-]?in/i.test(subject)) {
+    return parseAccommodation(htmlContent, text, "Hotel");
+  }
+
+  return null;
+}

--- a/src/lib/gmail/parsers.ts
+++ b/src/lib/gmail/parsers.ts
@@ -21,30 +21,44 @@ function stripHtml(html: string): string {
     .replace(/&amp;/g, "&")
     .replace(/&lt;/g, "<")
     .replace(/&gt;/g, ">")
+    .replace(/&pound;/gi, "£")
+    .replace(/&euro;/gi, "€")
+    .replace(/&#163;/g, "£")
+    .replace(/&#8364;/g, "€")
+    .replace(/&#36;/g, "$")
     .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(Number(n)))
     .replace(/\n{3,}/g, "\n\n")
     .trim();
 }
 
+function parseAmount(raw: string): number {
+  return parseFloat(raw.replace(/,/g, ""));
+}
+
 function findPrice(text: string): { amount: number; currency: "GBP" | "EUR" | "USD" } | null {
-  const m =
-    text.match(/[£](\d+(?:\.\d{2})?)/) ??
-    text.match(/(\d+(?:\.\d{2})?)\s*GBP/) ??
-    text.match(/GBP\s*(\d+(?:\.\d{2})?)/) ??
-    text.match(/Total[:\s]*[£]?(\d+(?:\.\d{2})?)/i);
-  if (m) return { amount: parseFloat(m[1]), currency: "GBP" };
+  // Try total/amount lines first — most reliable (avoids grabbing per-item prices)
+  const totalLine =
+    text.match(/(?:total|amount|order\s*total|grand\s*total|you\s*paid|charge)[:\s]*[£]?([\d,]+(?:\.\d{2})?)/i) ??
+    text.match(/(?:total|amount|order\s*total|grand\s*total|you\s*paid|charge)[:\s]*[€]?([\d,]+(?:\.\d{2})?)/i);
+
+  const gbp =
+    totalLine ??
+    text.match(/[£]([\d,]+(?:\.\d{2})?)/) ??
+    text.match(/([\d,]+(?:\.\d{2})?)\s*GBP/i) ??
+    text.match(/GBP\s*([\d,]+(?:\.\d{2})?)/i);
+  if (gbp) return { amount: parseAmount(gbp[1]), currency: "GBP" };
 
   const eur =
-    text.match(/[€](\d+(?:\.\d{2})?)/) ??
-    text.match(/(\d+(?:\.\d{2})?)\s*EUR/) ??
-    text.match(/EUR\s*(\d+(?:\.\d{2})?)/);
-  if (eur) return { amount: parseFloat(eur[1]), currency: "EUR" };
+    text.match(/[€]([\d,]+(?:\.\d{2})?)/) ??
+    text.match(/([\d,]+(?:\.\d{2})?)\s*EUR/i) ??
+    text.match(/EUR\s*([\d,]+(?:\.\d{2})?)/i);
+  if (eur) return { amount: parseAmount(eur[1]), currency: "EUR" };
 
   const usd =
-    text.match(/\$(\d+(?:\.\d{2})?)/) ??
-    text.match(/(\d+(?:\.\d{2})?)\s*USD/) ??
-    text.match(/USD\s*(\d+(?:\.\d{2})?)/);
-  if (usd) return { amount: parseFloat(usd[1]), currency: "USD" };
+    text.match(/\$([\d,]+(?:\.\d{2})?)/) ??
+    text.match(/([\d,]+(?:\.\d{2})?)\s*USD/i) ??
+    text.match(/USD\s*([\d,]+(?:\.\d{2})?)/i);
+  if (usd) return { amount: parseAmount(usd[1]), currency: "USD" };
 
   return null;
 }

--- a/src/lib/gmail/types.ts
+++ b/src/lib/gmail/types.ts
@@ -21,6 +21,7 @@ export type ParsedTransportBooking = {
   price: number | null;
   currency: "GBP" | "EUR" | "USD";
   segments: ParsedTransportSegment[];
+  is_amendment: boolean;
   raw_subject: string;
   gmail_message_id: string;
   email_date: string;
@@ -38,6 +39,7 @@ export type ParsedAccommodationBooking = {
   price: number | null;
   currency: "GBP" | "EUR" | "USD";
   room_details: string | null;
+  is_amendment: boolean;
   raw_subject: string;
   gmail_message_id: string;
   email_date: string;

--- a/src/lib/gmail/types.ts
+++ b/src/lib/gmail/types.ts
@@ -1,0 +1,46 @@
+// Shared types for Gmail booking import.
+
+export type ParsedTransportSegment = {
+  from_station: string;
+  to_station: string;
+  departure_date: string; // YYYY-MM-DD
+  departure_time: string; // HH:MM
+  arrival_date: string; // YYYY-MM-DD
+  arrival_time: string; // HH:MM
+  service_number: string | null;
+  platform_dep: string | null;
+  platform_arr: string | null;
+  seat: string | null;
+};
+
+export type ParsedTransportBooking = {
+  type: "transport";
+  mode: "train" | "flight" | "bus";
+  provider: string;
+  booking_reference: string | null;
+  price: number | null;
+  currency: "GBP" | "EUR" | "USD";
+  segments: ParsedTransportSegment[];
+  raw_subject: string;
+  gmail_message_id: string;
+  email_date: string;
+};
+
+export type ParsedAccommodationBooking = {
+  type: "accommodation";
+  hotel_name: string;
+  provider: string;
+  booking_reference: string | null;
+  check_in_date: string; // YYYY-MM-DD
+  check_in_time: string | null; // HH:MM
+  check_out_date: string; // YYYY-MM-DD
+  check_out_time: string | null; // HH:MM
+  price: number | null;
+  currency: "GBP" | "EUR" | "USD";
+  room_details: string | null;
+  raw_subject: string;
+  gmail_message_id: string;
+  email_date: string;
+};
+
+export type ParsedBooking = ParsedTransportBooking | ParsedAccommodationBooking;

--- a/src/lib/gmail/types.ts
+++ b/src/lib/gmail/types.ts
@@ -46,3 +46,10 @@ export type ParsedAccommodationBooking = {
 };
 
 export type ParsedBooking = ParsedTransportBooking | ParsedAccommodationBooking;
+
+export function getTravelDate(booking: ParsedBooking): string | null {
+  if (booking.type === "transport") {
+    return booking.segments[0]?.departure_date ?? null;
+  }
+  return booking.check_in_date ?? null;
+}

--- a/src/lib/google/gmail-client.ts
+++ b/src/lib/google/gmail-client.ts
@@ -1,0 +1,76 @@
+// Token management for Gmail connections. Mirrors the Calendar client
+// pattern — fetches the stored token, refreshes proactively if near expiry.
+
+import { createClient } from "@/lib/supabase/server";
+import { requireUserContext } from "@/lib/auth";
+import { refreshAccessToken } from "./oauth";
+
+export type GmailConnection = {
+  id: string;
+  user_id: string;
+  workspace_id: string;
+  provider_account_email: string | null;
+  access_token: string;
+  refresh_token: string | null;
+  expires_at: string | null;
+  last_scan_at: string | null;
+};
+
+export async function getGmailConnection(): Promise<GmailConnection | null> {
+  const ctx = await requireUserContext();
+  const supabase = await createClient();
+  const { data } = await supabase
+    .from("gmail_connections")
+    .select(
+      "id, user_id, workspace_id, provider_account_email, access_token, refresh_token, expires_at, last_scan_at",
+    )
+    .eq("user_id", ctx.userId)
+    .eq("workspace_id", ctx.workspaceId)
+    .eq("status", "active")
+    .maybeSingle();
+  return (data as GmailConnection | null) ?? null;
+}
+
+export async function getValidGmailAccessToken(): Promise<{
+  accessToken: string;
+  email: string | null;
+  connectionId: string;
+} | null> {
+  const conn = await getGmailConnection();
+  if (!conn) return null;
+
+  const now = Date.now();
+  const expiresAt = conn.expires_at ? Date.parse(conn.expires_at) : 0;
+  if (expiresAt > now + 60_000) {
+    return {
+      accessToken: conn.access_token,
+      email: conn.provider_account_email,
+      connectionId: conn.id,
+    };
+  }
+
+  if (!conn.refresh_token) {
+    console.warn("gmail: token expired and no refresh_token; user must reconnect");
+    return null;
+  }
+
+  try {
+    const refreshed = await refreshAccessToken(conn.refresh_token);
+    const supabase = await createClient();
+    await supabase
+      .from("gmail_connections")
+      .update({
+        access_token: refreshed.accessToken,
+        expires_at: refreshed.expiresAt.toISOString(),
+      })
+      .eq("id", conn.id);
+    return {
+      accessToken: refreshed.accessToken,
+      email: conn.provider_account_email,
+      connectionId: conn.id,
+    };
+  } catch (e) {
+    console.error("gmail: refresh failed", e);
+    return null;
+  }
+}

--- a/src/lib/google/gmail-config.ts
+++ b/src/lib/google/gmail-config.ts
@@ -1,0 +1,14 @@
+// Gmail OAuth scopes. Reuses the same Google Cloud OAuth client as Calendar
+// (GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET) but requests gmail.readonly.
+
+export const GMAIL_SCOPES = [
+  "openid",
+  "email",
+  "https://www.googleapis.com/auth/gmail.readonly",
+].join(" ");
+
+export function buildGmailRedirectUri(origin: string): string {
+  const explicit = process.env.GOOGLE_GMAIL_REDIRECT_URL;
+  if (explicit) return explicit;
+  return `${origin}/api/auth/gmail/callback`;
+}

--- a/src/lib/google/gmail.ts
+++ b/src/lib/google/gmail.ts
@@ -1,0 +1,129 @@
+// Gmail API REST helpers. Same pattern as calendar.ts — plain fetch + Bearer token.
+
+const BASE = "https://gmail.googleapis.com/gmail/v1/users/me";
+
+type GmailMessageHeader = {
+  name: string;
+  value: string;
+};
+
+type GmailMessagePart = {
+  mimeType: string;
+  headers?: GmailMessageHeader[];
+  body?: { data?: string; size?: number };
+  parts?: GmailMessagePart[];
+};
+
+export type GmailMessage = {
+  id: string;
+  threadId: string;
+  internalDate: string;
+  snippet: string;
+  payload: {
+    headers: GmailMessageHeader[];
+    mimeType: string;
+    body?: { data?: string; size?: number };
+    parts?: GmailMessagePart[];
+  };
+};
+
+type GmailListResponse = {
+  messages?: Array<{ id: string; threadId: string }>;
+  nextPageToken?: string;
+  resultSizeEstimate?: number;
+};
+
+export async function gmailSearchMessages(args: {
+  accessToken: string;
+  query: string;
+  maxResults?: number;
+}): Promise<Array<{ id: string; threadId: string }>> {
+  const params = new URLSearchParams({
+    q: args.query,
+    maxResults: String(args.maxResults ?? 50),
+  });
+  const res = await fetch(`${BASE}/messages?${params}`, {
+    headers: { Authorization: `Bearer ${args.accessToken}` },
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Gmail search failed: ${res.status} ${text}`);
+  }
+  const data = (await res.json()) as GmailListResponse;
+  return data.messages ?? [];
+}
+
+export async function gmailGetMessage(args: {
+  accessToken: string;
+  messageId: string;
+  format?: "full" | "metadata" | "minimal";
+}): Promise<GmailMessage> {
+  const params = new URLSearchParams({
+    format: args.format ?? "full",
+  });
+  const res = await fetch(`${BASE}/messages/${args.messageId}?${params}`, {
+    headers: { Authorization: `Bearer ${args.accessToken}` },
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Gmail get message failed: ${res.status} ${text}`);
+  }
+  return (await res.json()) as GmailMessage;
+}
+
+export function getHeader(
+  headers: GmailMessageHeader[],
+  name: string,
+): string | null {
+  const h = headers.find(
+    (h) => h.name.toLowerCase() === name.toLowerCase(),
+  );
+  return h?.value ?? null;
+}
+
+function decodeBase64Url(data: string): string {
+  const base64 = data.replace(/-/g, "+").replace(/_/g, "/");
+  return Buffer.from(base64, "base64").toString("utf-8");
+}
+
+function extractPartsRecursive(
+  part: GmailMessagePart,
+  mimeType: string,
+): string[] {
+  const results: string[] = [];
+  if (part.mimeType === mimeType && part.body?.data) {
+    results.push(decodeBase64Url(part.body.data));
+  }
+  if (part.parts) {
+    for (const child of part.parts) {
+      results.push(...extractPartsRecursive(child, mimeType));
+    }
+  }
+  return results;
+}
+
+export function extractMessageBody(msg: GmailMessage): {
+  html: string | null;
+  text: string | null;
+} {
+  const payload = msg.payload;
+  let html: string | null = null;
+  let text: string | null = null;
+
+  if (payload.body?.data) {
+    const decoded = decodeBase64Url(payload.body.data);
+    if (payload.mimeType === "text/html") html = decoded;
+    else text = decoded;
+  }
+
+  if (payload.parts) {
+    for (const part of payload.parts) {
+      const htmlParts = extractPartsRecursive(part, "text/html");
+      if (htmlParts.length > 0 && !html) html = htmlParts[0];
+      const textParts = extractPartsRecursive(part, "text/plain");
+      if (textParts.length > 0 && !text) text = textParts[0];
+    }
+  }
+
+  return { html, text };
+}

--- a/supabase/migrations/0019_gmail_connections.sql
+++ b/supabase/migrations/0019_gmail_connections.sql
@@ -1,0 +1,60 @@
+-- Gmail connections: separate from calendar_connections so users can
+-- independently connect/disconnect Gmail vs Google Calendar. Same
+-- OAuth client credentials, different scopes.
+
+create table gmail_connections (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references profiles(id) on delete cascade,
+  workspace_id uuid not null references workspaces(id) on delete cascade,
+  provider_account_email text,
+  access_token text not null,
+  refresh_token text,
+  expires_at timestamptz,
+  status text not null default 'active',
+  last_scan_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (user_id, workspace_id)
+);
+
+alter table gmail_connections enable row level security;
+
+create policy "gmail_connections_select" on gmail_connections
+  for select using (is_workspace_member(workspace_id));
+
+create policy "gmail_connections_insert" on gmail_connections
+  for insert with check (
+    user_id = auth.uid() and is_workspace_member(workspace_id)
+  );
+
+create policy "gmail_connections_update" on gmail_connections
+  for update using (
+    user_id = auth.uid() and is_workspace_member(workspace_id)
+  );
+
+create policy "gmail_connections_delete" on gmail_connections
+  for delete using (
+    user_id = auth.uid() and is_workspace_member(workspace_id)
+  );
+
+-- Track which emails have already been imported so we don't show duplicates.
+create table gmail_imported_messages (
+  id uuid primary key default gen_random_uuid(),
+  workspace_id uuid not null references workspaces(id) on delete cascade,
+  user_id uuid not null references profiles(id) on delete cascade,
+  gmail_message_id text not null,
+  booking_type text not null,
+  travel_booking_id uuid references travel_bookings(id) on delete set null,
+  imported_at timestamptz not null default now(),
+  unique (workspace_id, user_id, gmail_message_id)
+);
+
+alter table gmail_imported_messages enable row level security;
+
+create policy "gmail_imported_select" on gmail_imported_messages
+  for select using (is_workspace_member(workspace_id));
+
+create policy "gmail_imported_insert" on gmail_imported_messages
+  for insert with check (
+    user_id = auth.uid() and is_workspace_member(workspace_id)
+  );


### PR DESCRIPTION
Adds end-to-end Gmail integration for automatically importing booking
confirmations from known travel providers (Trainline, LNER, Avanti, GWR,
airlines, Booking.com, Hotels.com, Airbnb) into itineraries as transport
or accommodation booking cards.

Infrastructure:
- gmail_connections + gmail_imported_messages tables with RLS
- Gmail OAuth flow (connect/callback routes) reusing Google client creds
- Gmail API helpers (search, get message, extract HTML/text body)
- Token management with proactive refresh (mirrors calendar pattern)

Email parsing:
- Sender-specific parsers for Trainline, UK rail operators, airlines
- Accommodation parser for hotel providers
- Extracts stations, times, service numbers, seats, prices, booking refs
- Date/time parsing handles UK, ISO, and named month formats

UI:
- Settings page: Gmail connect/disconnect section with last-scan timestamp
- Itinerary editor: "Import from Gmail" button (visible when connected)
- Import panel: scan → review found bookings → import individually
- Cards show route, segments, changeovers, price, ref for review
- Imported bookings tracked to avoid duplicates on rescan

https://claude.ai/code/session_01PnNY6sDjsoy55Bv17m3iav