### PR TITLE
Refine Trainline parser: extract from subject + URLs, filter marketing, deduplicate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,13 @@
       "dependencies": {
         "@supabase/ssr": "^0.5.2",
         "@supabase/supabase-js": "^2.45.4",
+        "@types/qrcode": "^1.5.6",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "lucide-react": "^0.451.0",
         "next": "^15.5.18",
+        "pdf-parse": "^2.4.5",
+        "qrcode": "^1.5.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "tailwind-merge": "^2.5.4",
@@ -1198,6 +1201,190 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.80.tgz",
+      "integrity": "sha512-DxuT1ClnIPts1kQx8FBmkk4BQDTfI5kIzywAaMjQSXfNnra5UFU9PwurXrl+Je3bJ6BGsp/zmshVVFbCmyI+ww==",
+      "license": "MIT",
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.80",
+        "@napi-rs/canvas-darwin-arm64": "0.1.80",
+        "@napi-rs/canvas-darwin-x64": "0.1.80",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.80",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.80",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.80",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.80"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.80.tgz",
+      "integrity": "sha512-sk7xhN/MoXeuExlggf91pNziBxLPVUqF2CAVnB57KLG/pz7+U5TKG8eXdc3pm0d7Od0WreB6ZKLj37sX9muGOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.80.tgz",
+      "integrity": "sha512-O64APRTXRUiAz0P8gErkfEr3lipLJgM6pjATwavZ22ebhjYl/SUbpgM0xcWPQBNMP1n29afAC/Us5PX1vg+JNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.80.tgz",
+      "integrity": "sha512-FqqSU7qFce0Cp3pwnTjVkKjjOtxMqRe6lmINxpIZYaZNnVI0H5FtsaraZJ36SiTHNjZlUB69/HhxNDT1Aaa9vA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.80.tgz",
+      "integrity": "sha512-eyWz0ddBDQc7/JbAtY4OtZ5SpK8tR4JsCYEZjCE3dI8pqoWUC8oMwYSBGCYfsx2w47cQgQCgMVRVTFiiO38hHQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.80.tgz",
+      "integrity": "sha512-qwA63t8A86bnxhuA/GwOkK3jvb+XTQaTiVML0vAWoHyoZYTjNs7BzoOONDgTnNtr8/yHrq64XXzUoLqDzU+Uuw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.80.tgz",
+      "integrity": "sha512-1XbCOz/ymhj24lFaIXtWnwv/6eFHXDrjP0jYkc6iHQ9q8oXKzUX1Lc6bu+wuGiLhGh2GS/2JlfORC5ZcXimRcg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.80.tgz",
+      "integrity": "sha512-XTzR125w5ZMs0lJcxRlS1K3P5RaZ9RmUsPtd1uGt+EfDyYMu4c6SEROYsxyatbbu/2+lPe7MPHOO/0a0x7L/gw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.80.tgz",
+      "integrity": "sha512-BeXAmhKg1kX3UCrJsYbdQd3hIMDH/K6HnP/pG2LuITaXhXBiNdh//TVVVVCBbJzVQaV5gK/4ZOCMrQW9mvuTqA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.80.tgz",
+      "integrity": "sha512-x0XvZWdHbkgdgucJsRxprX/4o4sEed7qo9rCQA9ugiS9qE2QvP0RIiEugtZhfLH3cyI+jIRFJHV4Fuz+1BHHMg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.80.tgz",
+      "integrity": "sha512-Z8jPsM6df5V8B1HrCHB05+bDiCxjE9QA//3YrkKIdVDEwn5RKaqOxCJDRJkl48cJbylcrJbW4HxZbTte8juuPg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -1915,10 +2102,18 @@
       "version": "22.19.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
       "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/react": {
@@ -2655,11 +2850,19 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3154,6 +3357,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/camelcase-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
@@ -3294,6 +3506,17 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -3317,7 +3540,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3330,7 +3552,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
@@ -3483,6 +3704,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -3552,6 +3782,12 @@
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
@@ -4533,6 +4769,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -5010,6 +5255,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-generator-function": {
@@ -6014,6 +6268,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -6031,7 +6294,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6071,6 +6333,38 @@
         "node": ">= 14.16"
       }
     },
+    "node_modules/pdf-parse": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-2.4.5.tgz",
+      "integrity": "sha512-mHU89HGh7v+4u2ubfnevJ03lmPgQ5WU4CxAVmTSh/sxVTEDYd1er/dKS/A6vg77NX47KTEoihq8jZBLr8Cxuwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@napi-rs/canvas": "0.1.80",
+        "pdfjs-dist": "5.4.296"
+      },
+      "bin": {
+        "pdf-parse": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.16.0 <21 || >=22.3.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/mehmet-kozan"
+      }
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "5.4.296",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.296.tgz",
+      "integrity": "sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.16.0 || >=22.3.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.80"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -6108,6 +6402,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -6347,6 +6650,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -6472,6 +6792,21 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.6",
@@ -6677,6 +7012,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -6935,6 +7276,26 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
@@ -7046,6 +7407,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-bom": {
@@ -7577,7 +7950,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -7905,6 +8277,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
     "node_modules/which-typed-array": {
       "version": "1.1.20",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
@@ -7954,6 +8332,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/write-file-atomic": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-6.0.0.tgz",
@@ -7968,6 +8360,12 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
     "node_modules/yallist": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
@@ -7976,6 +8374,93 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yocto-queue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@supabase/ssr": "^0.5.2",
         "@supabase/supabase-js": "^2.45.4",
         "@types/qrcode": "^1.5.6",
+        "bwip-js": "^4.10.1",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "lucide-react": "^0.451.0",
@@ -3285,6 +3286,15 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bwip-js": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/bwip-js/-/bwip-js-4.10.1.tgz",
+      "integrity": "sha512-I/cEPiXsu7dRCp78PpVY4gdIXmbH752n8dMC+DStM77XPkrzeathdYrjnZ/i/vZPIxXTUWc+JxgJ/MvbodqPLA==",
+      "license": "MIT",
+      "bin": {
+        "bwip-js": "bin/bwip-js.js"
       }
     },
     "node_modules/cac": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@supabase/ssr": "^0.5.2",
     "@supabase/supabase-js": "^2.45.4",
     "@types/qrcode": "^1.5.6",
+    "bwip-js": "^4.10.1",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "lucide-react": "^0.451.0",

--- a/package.json
+++ b/package.json
@@ -16,10 +16,13 @@
   "dependencies": {
     "@supabase/ssr": "^0.5.2",
     "@supabase/supabase-js": "^2.45.4",
+    "@types/qrcode": "^1.5.6",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "lucide-react": "^0.451.0",
     "next": "^15.5.18",
+    "pdf-parse": "^2.4.5",
+    "qrcode": "^1.5.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "tailwind-merge": "^2.5.4",

--- a/src/app/(app)/itineraries/[id]/gmail-import-panel.tsx
+++ b/src/app/(app)/itineraries/[id]/gmail-import-panel.tsx
@@ -87,21 +87,31 @@ function TransportBookingCard({
           style={{ background: "var(--card-2)", fontSize: 11 }}
         >
           {booking.segments.map((seg, i) => (
-            <div key={i} className="flex justify-between gap-2">
-              <span>
-                {seg.from_station} {"→"} {seg.to_station}
-              </span>
-              <span style={{ color: "var(--ink-dim)" }}>
-                {seg.departure_time} {"–"} {seg.arrival_time}
-                {seg.service_number ? ` (${seg.service_number})` : ""}
-              </span>
+            <div key={i} className="flex flex-col gap-0.5">
+              <div className="flex justify-between gap-2">
+                <span>
+                  {seg.from_station_code ?? ""}{seg.from_station_code ? " " : ""}{seg.from_station} {"→"} {seg.to_station}{seg.to_station_code ? ` ${seg.to_station_code}` : ""}
+                </span>
+                <span style={{ color: "var(--ink-dim)" }}>
+                  {seg.departure_time}{seg.arrival_time ? ` – ${seg.arrival_time}` : ""}
+                </span>
+              </div>
+              {(seg.operator || seg.ticket_type || seg.coach || seg.seat) && (
+                <div style={{ color: "var(--ink-dim)", fontSize: 10 }}>
+                  {seg.operator}{seg.ticket_type ? ` · ${seg.ticket_type}` : ""}
+                  {seg.coach ? ` · Coach ${seg.coach}` : ""}
+                  {seg.seat ? ` Seat ${seg.seat}` : ""}
+                  {seg.barcode_ref ? ` · ${seg.barcode_ref}` : ""}
+                </div>
+              )}
             </div>
           ))}
         </div>
       ) : first?.service_number ? (
         <p className="text-xs" style={{ color: "var(--ink-dim)" }}>
           Service: {first.service_number}
-          {first.seat ? ` · Seat: ${first.seat}` : ""}
+          {first.coach ? ` · Coach ${first.coach}` : ""}
+          {first.seat ? ` Seat ${first.seat}` : ""}
         </p>
       ) : null}
 

--- a/src/app/api/debug-email/route.ts
+++ b/src/app/api/debug-email/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+import { debugFetchEmail } from "@/lib/actions/gmail";
+
+export async function GET(req: NextRequest) {
+  const messageId = req.nextUrl.searchParams.get("id");
+  if (!messageId) {
+    return NextResponse.json({ error: "Missing ?id= parameter" }, { status: 400 });
+  }
+
+  const result = await debugFetchEmail(messageId);
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    subject: result.value.subject,
+    from: result.value.from,
+    cleanedTextLength: result.value.cleanedText.length,
+    cleanedText: result.value.cleanedText,
+    htmlLength: result.value.html?.length ?? 0,
+    parsed: result.value.parsed,
+  });
+}

--- a/src/app/api/debug-email/route.ts
+++ b/src/app/api/debug-email/route.ts
@@ -18,6 +18,8 @@ export async function GET(req: NextRequest) {
     cleanedTextLength: result.value.cleanedText.length,
     cleanedText: result.value.cleanedText,
     htmlLength: result.value.html?.length ?? 0,
+    attachments: result.value.attachments,
+    pdfTexts: result.value.pdfTexts,
     parsed: result.value.parsed,
   });
 }

--- a/src/lib/actions/gmail.ts
+++ b/src/lib/actions/gmail.ts
@@ -10,7 +10,7 @@ import {
   getHeader,
   extractMessageBody,
 } from "@/lib/google/gmail";
-import { detectAndParse } from "@/lib/gmail/parsers";
+import { detectAndParse, stripHtmlPublic } from "@/lib/gmail/parsers";
 import { type ParsedBooking, getTravelDate } from "@/lib/gmail/types";
 
 const BOOKING_SENDERS = [
@@ -253,4 +253,25 @@ export async function disconnectGmail(): Promise<Result<{ id: string }>> {
   if (error) return err(errors.unexpected(error.message));
 
   return ok({ id: existing.id });
+}
+
+export async function debugFetchEmail(messageId: string): Promise<
+  Result<{ subject: string; from: string; cleanedText: string; html: string | null; parsed: Partial<ParsedBooking> | null }>
+> {
+  await requireUserContext();
+  const gmail = await getValidGmailAccessToken();
+  if (!gmail) return err(errors.integration("gmail", "Gmail not connected."));
+
+  const msg = await gmailGetMessage({
+    accessToken: gmail.accessToken,
+    messageId,
+  });
+
+  const from = getHeader(msg.payload.headers, "From") ?? "";
+  const subject = getHeader(msg.payload.headers, "Subject") ?? "";
+  const { html, text } = extractMessageBody(msg);
+  const cleanedText = text ?? (html ? stripHtmlPublic(html) : "");
+  const parsed = detectAndParse(from, subject, html, text);
+
+  return ok({ subject, from, cleanedText, html, parsed });
 }

--- a/src/lib/actions/gmail.ts
+++ b/src/lib/actions/gmail.ts
@@ -17,6 +17,8 @@ import { type ParsedBooking, getTravelDate } from "@/lib/gmail/types";
 import {
   parseTrainlinePdfText,
   pdfTicketsToSegments,
+  tryDownloadPkpass,
+  extractBarcodeFromPkpass,
 } from "@/lib/gmail/trainline-pdf";
 
 const BOOKING_SENDERS = [
@@ -102,6 +104,7 @@ async function enrichTrainlineFromPdfs(
     (a) => a.mimeType === "application/pdf" || a.filename?.endsWith(".pdf"),
   );
   if (pdfs.length === 0) return parsed;
+  if (parsed.type !== "transport") return parsed;
 
   let PDFParse: typeof import("pdf-parse").PDFParse;
   try {
@@ -125,8 +128,6 @@ async function enrichTrainlineFromPdfs(
   const validTickets = tickets.filter((t): t is NonNullable<typeof t> => t !== null);
   if (validTickets.length === 0) return parsed;
 
-  if (parsed.type !== "transport") return parsed;
-
   const fallbackDate = parsed.segments?.[0]?.departure_date ?? new Date().toISOString().slice(0, 10);
   const pdfSegments = pdfTicketsToSegments(validTickets, fallbackDate);
 
@@ -136,7 +137,6 @@ async function enrichTrainlineFromPdfs(
   if (existingSegments.length > 0 && pdfSegments.length > 0) {
     for (const existing of existingSegments) {
       if (!existing.departure_time || existing.departure_time === "00:00") continue;
-      // Find a PDF segment with matching station and enrich it
       const match = pdfSegments.find(
         (ps) =>
           ps.from_station.toLowerCase().includes(existing.from_station.toLowerCase()) ||
@@ -144,6 +144,35 @@ async function enrichTrainlineFromPdfs(
       );
       if (match && (!match.departure_time || match.departure_time === "00:00")) {
         match.departure_time = existing.departure_time;
+      }
+    }
+  }
+
+  // If PDF segments lack barcode_data, try .pkpass downloads from email HTML
+  const needsBarcodeData = pdfSegments.some((s) => !s.barcode_data);
+  if (needsBarcodeData) {
+    const { html } = extractMessageBody(msg);
+    if (html) {
+      const pkpassUrls: string[] = [];
+      const urlPattern = /https:\/\/download\.thetrainline\.com\/resource#[A-F0-9]{64}/gi;
+      let urlMatch;
+      while ((urlMatch = urlPattern.exec(html)) !== null) {
+        pkpassUrls.push(urlMatch[0]);
+      }
+
+      for (let i = 0; i < Math.min(pkpassUrls.length, pdfSegments.length); i++) {
+        if (pdfSegments[i].barcode_data) continue;
+        try {
+          const pkpassBuf = await tryDownloadPkpass(pkpassUrls[i]);
+          if (pkpassBuf) {
+            const barcodeData = await extractBarcodeFromPkpass(pkpassBuf);
+            if (barcodeData) {
+              pdfSegments[i].barcode_data = barcodeData;
+            }
+          }
+        } catch {
+          // .pkpass download is best-effort
+        }
       }
     }
   }

--- a/src/lib/actions/gmail.ts
+++ b/src/lib/actions/gmail.ts
@@ -7,11 +7,17 @@ import { getValidGmailAccessToken } from "@/lib/google/gmail-client";
 import {
   gmailSearchMessages,
   gmailGetMessage,
+  gmailGetAttachment,
   getHeader,
   extractMessageBody,
+  extractAttachments,
 } from "@/lib/google/gmail";
 import { detectAndParse, stripHtmlPublic } from "@/lib/gmail/parsers";
 import { type ParsedBooking, getTravelDate } from "@/lib/gmail/types";
+import {
+  parseTrainlinePdfText,
+  pdfTicketsToSegments,
+} from "@/lib/gmail/trainline-pdf";
 
 const BOOKING_SENDERS = [
   "trainline",
@@ -85,6 +91,69 @@ function deduplicateTrainlineBookings(bookings: ParsedBooking[]): ParsedBooking[
   return [...rest, ...kept];
 }
 
+async function enrichTrainlineFromPdfs(
+  accessToken: string,
+  messageId: string,
+  msg: Awaited<ReturnType<typeof gmailGetMessage>>,
+  parsed: Partial<ParsedBooking>,
+): Promise<Partial<ParsedBooking>> {
+  const attachments = extractAttachments(msg);
+  const pdfs = attachments.filter(
+    (a) => a.mimeType === "application/pdf" || a.filename?.endsWith(".pdf"),
+  );
+  if (pdfs.length === 0) return parsed;
+
+  let PDFParse: typeof import("pdf-parse").PDFParse;
+  try {
+    PDFParse = (await import("pdf-parse")).PDFParse;
+  } catch {
+    return parsed;
+  }
+
+  const tickets = await Promise.all(
+    pdfs.map(async (pdf) => {
+      const buf = await gmailGetAttachment({
+        accessToken, messageId, attachmentId: pdf.attachmentId,
+      });
+      const parser = new PDFParse({ data: new Uint8Array(buf) });
+      const result = await parser.getText();
+      await parser.destroy();
+      return parseTrainlinePdfText(result.text);
+    }),
+  );
+
+  const validTickets = tickets.filter((t): t is NonNullable<typeof t> => t !== null);
+  if (validTickets.length === 0) return parsed;
+
+  if (parsed.type !== "transport") return parsed;
+
+  const fallbackDate = parsed.segments?.[0]?.departure_date ?? new Date().toISOString().slice(0, 10);
+  const pdfSegments = pdfTicketsToSegments(validTickets, fallbackDate);
+
+  // If existing segments have departure times from the booking confirmation
+  // subject, merge those times onto matching PDF segments
+  const existingSegments = parsed.segments ?? [];
+  if (existingSegments.length > 0 && pdfSegments.length > 0) {
+    for (const existing of existingSegments) {
+      if (!existing.departure_time || existing.departure_time === "00:00") continue;
+      // Find a PDF segment with matching station and enrich it
+      const match = pdfSegments.find(
+        (ps) =>
+          ps.from_station.toLowerCase().includes(existing.from_station.toLowerCase()) ||
+          (ps.from_station_code && existing.from_station.toLowerCase().includes(ps.from_station_code.toLowerCase())),
+      );
+      if (match && (!match.departure_time || match.departure_time === "00:00")) {
+        match.departure_time = existing.departure_time;
+      }
+    }
+  }
+
+  return {
+    ...parsed,
+    segments: pdfSegments.length >= existingSegments.length ? pdfSegments : existingSegments,
+  };
+}
+
 function buildSearchQuery(): string {
   const senderClauses = BOOKING_SENDERS.map((s) => `from:${s}`).join(" OR ");
   const subjectTerms =
@@ -156,8 +225,19 @@ export async function scanGmailForBookings(): Promise<
         const date = getHeader(msg.payload.headers, "Date") ?? "";
         const { html, text } = extractMessageBody(msg);
 
-        const parsed = detectAndParse(from, subject, html, text);
+        let parsed = detectAndParse(from, subject, html, text);
         if (!parsed) return null;
+
+        // Enrich Trainline bookings with PDF attachment data (seat, coach, barcode)
+        if (parsed.type === "transport" && /trainline/i.test(from)) {
+          try {
+            parsed = await enrichTrainlineFromPdfs(
+              gmail.accessToken, ref.id, msg, parsed,
+            );
+          } catch (e) {
+            console.warn("gmail: PDF enrichment failed", ref.id, e);
+          }
+        }
 
         const emailDate =
           date && !isNaN(Date.parse(date))
@@ -256,7 +336,15 @@ export async function disconnectGmail(): Promise<Result<{ id: string }>> {
 }
 
 export async function debugFetchEmail(messageId: string): Promise<
-  Result<{ subject: string; from: string; cleanedText: string; html: string | null; parsed: Partial<ParsedBooking> | null }>
+  Result<{
+    subject: string;
+    from: string;
+    cleanedText: string;
+    html: string | null;
+    attachments: Array<{ filename: string; mimeType: string; size: number }>;
+    pdfTexts: string[];
+    parsed: Partial<ParsedBooking> | null;
+  }>
 > {
   await requireUserContext();
   const gmail = await getValidGmailAccessToken();
@@ -271,7 +359,50 @@ export async function debugFetchEmail(messageId: string): Promise<
   const subject = getHeader(msg.payload.headers, "Subject") ?? "";
   const { html, text } = extractMessageBody(msg);
   const cleanedText = text ?? (html ? stripHtmlPublic(html) : "");
-  const parsed = detectAndParse(from, subject, html, text);
 
-  return ok({ subject, from, cleanedText, html, parsed });
+  const attachmentList = extractAttachments(msg);
+  const pdfAttachments = attachmentList.filter(
+    (a) => a.mimeType === "application/pdf" || a.filename?.endsWith(".pdf"),
+  );
+
+  const pdfTexts: string[] = [];
+  try {
+    const { PDFParse } = await import("pdf-parse");
+    for (const pdf of pdfAttachments) {
+      const buf = await gmailGetAttachment({
+        accessToken: gmail.accessToken,
+        messageId,
+        attachmentId: pdf.attachmentId,
+      });
+      const parser = new PDFParse({ data: new Uint8Array(buf) });
+      const result = await parser.getText();
+      pdfTexts.push(result.text);
+      await parser.destroy();
+    }
+  } catch (e) {
+    console.warn("PDF extraction failed in debug", e);
+  }
+
+  let parsed = detectAndParse(from, subject, html, text);
+  if (parsed?.type === "transport" && /trainline/i.test(from)) {
+    try {
+      parsed = await enrichTrainlineFromPdfs(
+        gmail.accessToken, messageId, msg, parsed,
+      );
+    } catch (e) {
+      console.warn("PDF enrichment failed in debug", e);
+    }
+  }
+
+  return ok({
+    subject,
+    from,
+    cleanedText,
+    html,
+    attachments: attachmentList.map((a) => ({
+      filename: a.filename, mimeType: a.mimeType, size: a.size,
+    })),
+    pdfTexts,
+    parsed,
+  });
 }

--- a/src/lib/actions/gmail.ts
+++ b/src/lib/actions/gmail.ts
@@ -38,6 +38,53 @@ const BOOKING_SENDERS = [
   "virgin atlantic",
 ];
 
+function deduplicateTrainlineBookings(bookings: ParsedBooking[]): ParsedBooking[] {
+  const trainline: ParsedBooking[] = [];
+  const rest: ParsedBooking[] = [];
+
+  for (const b of bookings) {
+    if (b.type === "transport" && b.provider === "Trainline") {
+      trainline.push(b);
+    } else {
+      rest.push(b);
+    }
+  }
+
+  if (trainline.length <= 1) return bookings;
+
+  // Group by travel date — bookings on the same date are likely duplicates
+  const byDate = new Map<string, ParsedBooking[]>();
+  for (const b of trainline) {
+    const date = getTravelDate(b) ?? "unknown";
+    const group = byDate.get(date) ?? [];
+    group.push(b);
+    byDate.set(date, group);
+  }
+
+  const kept: ParsedBooking[] = [];
+  for (const group of byDate.values()) {
+    if (group.length === 1) {
+      kept.push(group[0]);
+      continue;
+    }
+    // Prefer booking confirmation (has departure times != "00:00") over eticket
+    const scored = group.map((b) => {
+      let score = 0;
+      if (b.type === "transport") {
+        if (/booking\s*confirmation/i.test(b.raw_subject)) score += 10;
+        if (b.price != null) score += 3;
+        const hasTimes = b.segments.some((s) => s.departure_time && s.departure_time !== "00:00");
+        if (hasTimes) score += 5;
+      }
+      return { booking: b, score };
+    });
+    scored.sort((a, b) => b.score - a.score);
+    kept.push(scored[0].booking);
+  }
+
+  return [...rest, ...kept];
+}
+
 function buildSearchQuery(): string {
   const senderClauses = BOOKING_SENDERS.map((s) => `from:${s}`).join(" OR ");
   const subjectTerms =
@@ -136,10 +183,15 @@ export async function scanGmailForBookings(): Promise<
     }
   }
 
+  // Deduplicate: when Trainline sends both a booking confirmation and an
+  // eticket for the same trip, keep only the booking confirmation (it has
+  // times and price; the eticket just has station codes).
+  const deduped = deduplicateTrainlineBookings(bookings);
+
   // Drop bookings where the travel date is in the past — users want
   // present/future bookings, not historical trips.
   const today = new Date().toISOString().slice(0, 10);
-  const futureBookings = bookings.filter((b) => {
+  const futureBookings = deduped.filter((b) => {
     const travelDate = getTravelDate(b);
     return !travelDate || travelDate >= today;
   });

--- a/src/lib/gmail/parsers.ts
+++ b/src/lib/gmail/parsers.ts
@@ -131,6 +131,46 @@ function parseTime(timeStr: string): string | null {
   return null;
 }
 
+function makeSegment(partial: {
+  from_station: string;
+  to_station: string;
+  departure_date: string;
+  departure_time: string;
+  arrival_date?: string;
+  arrival_time?: string;
+  from_station_code?: string | null;
+  to_station_code?: string | null;
+  service_number?: string | null;
+  operator?: string | null;
+  route_restriction?: string | null;
+  ticket_type?: string | null;
+  platform_dep?: string | null;
+  platform_arr?: string | null;
+  coach?: string | null;
+  seat?: string | null;
+  barcode_ref?: string | null;
+}): ParsedTransportSegment {
+  return {
+    from_station: partial.from_station,
+    to_station: partial.to_station,
+    from_station_code: partial.from_station_code ?? null,
+    to_station_code: partial.to_station_code ?? null,
+    departure_date: partial.departure_date,
+    departure_time: partial.departure_time,
+    arrival_date: partial.arrival_date ?? partial.departure_date,
+    arrival_time: partial.arrival_time ?? "",
+    service_number: partial.service_number ?? null,
+    operator: partial.operator ?? null,
+    route_restriction: partial.route_restriction ?? null,
+    ticket_type: partial.ticket_type ?? null,
+    platform_dep: partial.platform_dep ?? null,
+    platform_arr: partial.platform_arr ?? null,
+    coach: partial.coach ?? null,
+    seat: partial.seat ?? null,
+    barcode_ref: partial.barcode_ref ?? null,
+  };
+}
+
 // ── Trainline ──────────────────────────────────────────────────────────
 
 function isTrainlineMarketing(from: string, subject: string): boolean {
@@ -432,17 +472,14 @@ function parseTrainlineBookingConfirmation(
       }
     }
 
-    segments = textLegs.map((leg, i) => ({
+    segments = textLegs.map((leg, i) => makeSegment({
       from_station: leg.depStation,
       to_station: leg.arrStation,
       departure_date: i < returnStartIdx ? travelDate : returnDate,
       departure_time: leg.depTime,
       arrival_date: i < returnStartIdx ? travelDate : returnDate,
       arrival_time: leg.arrTime,
-      service_number: null,
-      platform_dep: null,
-      platform_arr: null,
-      seat: null,
+      operator: leg.operator,
     }));
   }
   // Fallback: HTML time+station pairs → pair into legs
@@ -452,64 +489,42 @@ function parseTrainlineBookingConfirmation(
       const dep = pairs[i];
       const arr = pairs[i + 1];
       const isReturnLeg = route.to ? dep.station.toLowerCase().includes(route.to.toLowerCase()) : i >= pairs.length / 2;
-      segments.push({
+      segments.push(makeSegment({
         from_station: dep.station,
         to_station: arr.station,
         departure_date: isReturnLeg ? returnDate : travelDate,
         departure_time: dep.time,
         arrival_date: isReturnLeg ? returnDate : travelDate,
         arrival_time: arr.time,
-        service_number: null,
-        platform_dep: null,
-        platform_arr: null,
-        seat: null,
-      });
+      }));
     }
   }
   // Fallback: use train-times URLs for summary legs
   else if (urlLegs.length > 0) {
-    segments = urlLegs.map((leg) => ({
+    segments = urlLegs.map((leg) => makeSegment({
       from_station: leg.from,
       to_station: leg.to,
       departure_date: leg.date,
       departure_time: leg.time,
-      arrival_date: leg.date,
-      arrival_time: "",
-      service_number: null,
-      platform_dep: null,
-      platform_arr: null,
-      seat: null,
     }));
   }
   // Last resort: subject line
   else if (route.from && route.to) {
     const outDate = subjectTimes.outboundDate ?? new Date().toISOString().slice(0, 10);
-    segments.push({
+    segments.push(makeSegment({
       from_station: route.from,
       to_station: route.to,
       departure_date: outDate,
       departure_time: subjectTimes.outboundTime ?? "00:00",
-      arrival_date: outDate,
-      arrival_time: "",
-      service_number: null,
-      platform_dep: null,
-      platform_arr: null,
-      seat: null,
-    });
+    }));
     if (route.isReturn && subjectTimes.returnTime) {
       const retDate = subjectTimes.returnDate ?? outDate;
-      segments.push({
+      segments.push(makeSegment({
         from_station: route.to,
         to_station: route.from,
         departure_date: retDate,
         departure_time: subjectTimes.returnTime,
-        arrival_date: retDate,
-        arrival_time: "",
-        service_number: null,
-        platform_dep: null,
-        platform_arr: null,
-        seat: null,
-      });
+      }));
     }
   }
 
@@ -543,28 +558,15 @@ function parseTrainlineEticket(
   // Check train-times URLs for structured data
   const urlLegs = parseTrainlineTrainTimesUrls(html);
   if (urlLegs.length > 0) {
-    const segments: ParsedTransportSegment[] = urlLegs.map((leg) => ({
-      from_station: leg.from,
-      to_station: leg.to,
-      departure_date: leg.date,
-      departure_time: leg.time,
-      arrival_date: leg.date,
-      arrival_time: "",
-      service_number: null,
-      platform_dep: null,
-      platform_arr: null,
-      seat: null,
+    const segments = urlLegs.map((leg) => makeSegment({
+      from_station: leg.from, to_station: leg.to,
+      departure_date: leg.date, departure_time: leg.time,
     }));
-
-    const price = findPrice(text);
-    const ref = findTrainlineBookingRef(text);
     return {
-      type: "transport",
-      mode: "train",
-      provider: "Trainline",
-      booking_reference: ref,
-      price: price?.amount ?? null,
-      currency: price?.currency ?? "GBP",
+      type: "transport", mode: "train", provider: "Trainline",
+      booking_reference: findTrainlineBookingRef(text),
+      price: findPrice(text)?.amount ?? null,
+      currency: findPrice(text)?.currency ?? "GBP",
       segments,
     };
   }
@@ -580,23 +582,13 @@ function parseTrainlineEticket(
   const date = travelDate ?? new Date().toISOString().slice(0, 10);
 
   if (codePairs.length > 0) {
-    const segments: ParsedTransportSegment[] = codePairs.map(([from, to]) => ({
-      from_station: from,
-      to_station: to,
-      departure_date: date,
-      departure_time: "00:00",
-      arrival_date: date,
-      arrival_time: "",
-      service_number: null,
-      platform_dep: null,
-      platform_arr: null,
-      seat: null,
+    const segments = codePairs.map(([fc, tc]) => makeSegment({
+      from_station: fc, to_station: tc,
+      from_station_code: fc, to_station_code: tc,
+      departure_date: date, departure_time: "00:00",
     }));
-
     return {
-      type: "transport",
-      mode: "train",
-      provider: "Trainline",
+      type: "transport", mode: "train", provider: "Trainline",
       booking_reference: findTrainlineBookingRef(text),
       price: findPrice(text)?.amount ?? null,
       currency: findPrice(text)?.currency ?? "GBP",
@@ -606,24 +598,14 @@ function parseTrainlineEticket(
 
   if (destination) {
     return {
-      type: "transport",
-      mode: "train",
-      provider: "Trainline",
+      type: "transport", mode: "train", provider: "Trainline",
       booking_reference: findTrainlineBookingRef(text),
       price: findPrice(text)?.amount ?? null,
       currency: findPrice(text)?.currency ?? "GBP",
-      segments: [{
-        from_station: "Unknown",
-        to_station: destination,
-        departure_date: date,
-        departure_time: "00:00",
-        arrival_date: date,
-        arrival_time: "",
-        service_number: null,
-        platform_dep: null,
-        platform_arr: null,
-        seat: null,
-      }],
+      segments: [makeSegment({
+        from_station: "Unknown", to_station: destination,
+        departure_date: date, departure_time: "00:00",
+      })],
     };
   }
 
@@ -635,26 +617,14 @@ function parseTrainlineGeneric(
   text: string,
   subject: string,
 ): Partial<ParsedTransportBooking> | null {
-  // Try train-times URLs first
   const urlLegs = parseTrainlineTrainTimesUrls(html);
   if (urlLegs.length > 0) {
-    const segments: ParsedTransportSegment[] = urlLegs.map((leg) => ({
-      from_station: leg.from,
-      to_station: leg.to,
-      departure_date: leg.date,
-      departure_time: leg.time,
-      arrival_date: leg.date,
-      arrival_time: "",
-      service_number: null,
-      platform_dep: null,
-      platform_arr: null,
-      seat: null,
+    const segments = urlLegs.map((leg) => makeSegment({
+      from_station: leg.from, to_station: leg.to,
+      departure_date: leg.date, departure_time: leg.time,
     }));
-
     return {
-      type: "transport",
-      mode: "train",
-      provider: "Trainline",
+      type: "transport", mode: "train", provider: "Trainline",
       booking_reference: findTrainlineBookingRef(text),
       price: findPrice(text)?.amount ?? null,
       currency: findPrice(text)?.currency ?? "GBP",
@@ -693,18 +663,14 @@ function parseTrainlineGeneric(
   const segments: ParsedTransportSegment[] = [];
   const count = Math.max(stations.length, timePairs.length, 1);
   for (let i = 0; i < count; i++) {
-    segments.push({
+    segments.push(makeSegment({
       from_station: stations[i]?.[0] ?? "Unknown",
       to_station: stations[i]?.[1] ?? "Unknown",
       departure_date: travelDate,
       departure_time: timePairs[i]?.[0] ?? "00:00",
       arrival_date: dates[i + 1] ?? travelDate,
       arrival_time: timePairs[i]?.[1] ?? "00:00",
-      service_number: null,
-      platform_dep: null,
-      platform_arr: null,
-      seat: null,
-    });
+    }));
   }
 
   if (segments.length === 0) return null;
@@ -760,18 +726,11 @@ function parseUkRail(
     const arrTime = parseTime(m[3]);
     const to = m[4].trim();
     if (depTime && arrTime && from.length > 2 && to.length > 2) {
-      segments.push({
-        from_station: from,
-        to_station: to,
-        departure_date: travelDate,
-        departure_time: depTime,
-        arrival_date: travelDate,
+      segments.push(makeSegment({
+        from_station: from, to_station: to,
+        departure_date: travelDate, departure_time: depTime,
         arrival_time: arrTime,
-        service_number: null,
-        platform_dep: null,
-        platform_arr: null,
-        seat: null,
-      });
+      }));
     }
   }
 
@@ -798,18 +757,11 @@ function parseUkRail(
     }
 
     if (stationNames.length > 0 && destNames.length > 0 && allTimes.length >= 2) {
-      segments.push({
-        from_station: stationNames[0],
-        to_station: destNames[0],
-        departure_date: travelDate,
-        departure_time: allTimes[0],
-        arrival_date: travelDate,
+      segments.push(makeSegment({
+        from_station: stationNames[0], to_station: destNames[0],
+        departure_date: travelDate, departure_time: allTimes[0],
         arrival_time: allTimes[1],
-        service_number: null,
-        platform_dep: null,
-        platform_arr: null,
-        seat: null,
-      });
+      }));
     }
   }
 
@@ -891,18 +843,17 @@ function parseFlightBooking(
 
   const count = Math.max(routes.length, 1);
   for (let i = 0; i < count; i++) {
-    segments.push({
+    segments.push(makeSegment({
       from_station: routes[i]?.[0] ?? "Unknown",
       to_station: routes[i]?.[1] ?? "Unknown",
       departure_date: dates[i] ?? travelDate,
       departure_time: allTimes[i * 2] ?? "00:00",
-      arrival_date: dates[i] ?? travelDate,
       arrival_time: allTimes[i * 2 + 1] ?? "00:00",
       service_number: flights[i] ?? null,
       platform_dep: terminals[0] ?? null,
       platform_arr: terminals[1] ?? null,
       seat: i === 0 ? seatMatch?.[1] ?? null : null,
-    });
+    }));
   }
 
   if (segments.length === 0) return null;

--- a/src/lib/gmail/parsers.ts
+++ b/src/lib/gmail/parsers.ts
@@ -12,6 +12,8 @@ import type {
 
 // ── Helpers ────────────────────────────────────────────────────────────
 
+export { stripHtml as stripHtmlPublic };
+
 function stripHtml(html: string): string {
   return html
     .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, "")
@@ -236,39 +238,257 @@ function parseTrainline(html: string, text: string, subject: string): Partial<Pa
   return parseTrainlineGeneric(html, text, subject);
 }
 
+// Known UK rail operators and ticket types that pollute station names
+const TRAINLINE_NOISE = [
+  "East Midlands Railway",
+  "Avanti West Coast",
+  "CrossCountry",
+  "Great Western Railway",
+  "LNER",
+  "Northern",
+  "TransPennine Express",
+  "Southern",
+  "Southeastern",
+  "South Western Railway",
+  "ScotRail",
+  "Chiltern Railways",
+  "c2c",
+  "Greater Anglia",
+  "Thameslink",
+  "West Midlands Railway",
+  "London Northwestern Railway",
+  "Merseyrail",
+  "Advance Single",
+  "Advance Return",
+  "Off-Peak Single",
+  "Off-Peak Return",
+  "Off-Peak Day Single",
+  "Off-Peak Day Return",
+  "Anytime Single",
+  "Anytime Return",
+  "Anytime Day Single",
+  "Anytime Day Return",
+  "Super Off-Peak Single",
+  "Super Off-Peak Return",
+  "Advance",
+  "Single",
+  "Return",
+];
+
+function cleanStationName(raw: string): string {
+  let name = raw;
+  for (const noise of TRAINLINE_NOISE) {
+    name = name.replace(new RegExp(noise.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "gi"), "");
+  }
+  return name.replace(/\s{2,}/g, " ").trim();
+}
+
+function parseTrainlineHtmlTimeStations(html: string): Array<{ time: string; station: string }> {
+  // Trainline MJML emails render times and station names as text nodes in
+  // adjacent table cells or spans. Find all times that appear as bare text
+  // inside tags, then look for the nearest station-like text.
+  const results: Array<{ time: string; station: string; pos: number }> = [];
+
+  // Match time values that appear as the main text content of an element
+  const pattern = />(\d{1,2}:\d{2})\s*</g;
+  let m;
+  while ((m = pattern.exec(html)) !== null) {
+    const time = parseTime(m[1]);
+    if (!time) continue;
+
+    // Look ahead up to 800 chars for a station name (capitalised words in a text node)
+    const after = html.slice(m.index + m[0].length, m.index + m[0].length + 800);
+    const stationMatch = after.match(
+      />([A-Z][a-z]+(?:\s+(?:[A-Z][a-z]+|Street|Road|Central|Parkway|International|Lime|Junction|Cross|Bridge|upon|on|in|the|de|la))*)\s*</,
+    );
+    if (stationMatch) {
+      const station = cleanStationName(stationMatch[1]);
+      if (station.length > 2) {
+        results.push({ time, station, pos: m.index });
+      }
+    }
+  }
+
+  // Deduplicate by time+station
+  const seen = new Set<string>();
+  return results.filter((r) => {
+    const key = `${r.time}|${r.station}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function parseTrainlineTextLegs(text: string): Array<{
+  depTime: string;
+  depStation: string;
+  arrTime: string;
+  arrStation: string;
+  operator: string | null;
+}> {
+  // After proper HTML stripping, the cleaned text contains time+station
+  // pairs on adjacent lines. Pair them up into departure→arrival legs.
+  const timeStations: Array<{ time: string; station: string; lineIdx: number }> = [];
+  const lines = text.split("\n").map((l) => l.trim()).filter(Boolean);
+
+  for (let i = 0; i < lines.length; i++) {
+    const timeMatch = lines[i].match(/^(\d{1,2}:\d{2})$/);
+    if (timeMatch) {
+      // Station name is on the next non-empty, non-time line
+      for (let j = i + 1; j < Math.min(i + 4, lines.length); j++) {
+        if (/^\d{1,2}:\d{2}$/.test(lines[j])) break;
+        const cleaned = cleanStationName(lines[j]);
+        if (cleaned.length > 2 && /^[A-Z]/.test(cleaned) && !/change|total|paid|operator|ticket/i.test(cleaned)) {
+          timeStations.push({ time: parseTime(timeMatch[1]) ?? timeMatch[1], station: cleaned, lineIdx: i });
+          break;
+        }
+      }
+      continue;
+    }
+
+    // Also match "HH:MM StationName" on one line
+    const inlineMatch = lines[i].match(/^(\d{1,2}:\d{2})\s+([A-Z][a-z].{2,40})$/);
+    if (inlineMatch) {
+      const station = cleanStationName(inlineMatch[2]);
+      if (station.length > 2) {
+        timeStations.push({ time: parseTime(inlineMatch[1]) ?? inlineMatch[1], station, lineIdx: i });
+      }
+    }
+  }
+
+  // Pair consecutive time+station entries into legs (depart→arrive)
+  const legs: Array<{
+    depTime: string; depStation: string;
+    arrTime: string; arrStation: string;
+    operator: string | null;
+  }> = [];
+
+  for (let i = 0; i + 1 < timeStations.length; i += 2) {
+    const dep = timeStations[i];
+    const arr = timeStations[i + 1];
+    if (dep.station === arr.station) {
+      // Skip self-referencing pairs (same station depart+arrive = change marker)
+      i--;
+      timeStations.splice(i + 1, 1);
+      continue;
+    }
+
+    // Look for operator between these lines
+    let operator: string | null = null;
+    for (let j = dep.lineIdx; j <= Math.min(arr.lineIdx + 3, lines.length - 1); j++) {
+      for (const op of TRAINLINE_NOISE.slice(0, 17)) {
+        if (lines[j]?.includes(op)) {
+          operator = op;
+          break;
+        }
+      }
+      if (operator) break;
+    }
+
+    legs.push({
+      depTime: dep.time,
+      depStation: dep.station,
+      arrTime: arr.time,
+      arrStation: arr.station,
+      operator,
+    });
+  }
+
+  return legs;
+}
+
 function parseTrainlineBookingConfirmation(
   html: string,
   text: string,
   subject: string,
 ): Partial<ParsedTransportBooking> | null {
   const route = parseTrainlineSubjectRoute(subject);
-  const times = parseTrainlineSubjectTimes(subject);
+  const subjectTimes = parseTrainlineSubjectTimes(subject);
   const urlLegs = parseTrainlineTrainTimesUrls(html);
 
-  const segments: ParsedTransportSegment[] = [];
+  // Try to extract individual journey legs from the email body.
+  // Strategy 1: parse HTML for time+station pairs in tag text
+  const htmlTimeStations = parseTrainlineHtmlTimeStations(html);
+  // Strategy 2: parse cleaned text for time+station lines
+  const textLegs = parseTrainlineTextLegs(text);
 
-  if (urlLegs.length > 0) {
-    for (const leg of urlLegs) {
+  // Determine the travel date
+  const travelDate = subjectTimes.outboundDate ?? urlLegs[0]?.date ?? new Date().toISOString().slice(0, 10);
+  const returnDate = subjectTimes.returnDate ?? urlLegs[1]?.date ?? travelDate;
+
+  let segments: ParsedTransportSegment[] = [];
+
+  // Best case: text parsing found individual legs with times
+  if (textLegs.length > 0) {
+    // Split legs into outbound/return using the subject route info
+    const isReturn = route.isReturn;
+    let returnStartIdx = textLegs.length;
+    if (isReturn && route.to && route.from) {
+      for (let i = 1; i < textLegs.length; i++) {
+        if (textLegs[i].depStation.toLowerCase().includes(route.to.toLowerCase())) {
+          returnStartIdx = i;
+          break;
+        }
+      }
+    }
+
+    segments = textLegs.map((leg, i) => ({
+      from_station: leg.depStation,
+      to_station: leg.arrStation,
+      departure_date: i < returnStartIdx ? travelDate : returnDate,
+      departure_time: leg.depTime,
+      arrival_date: i < returnStartIdx ? travelDate : returnDate,
+      arrival_time: leg.arrTime,
+      service_number: null,
+      platform_dep: null,
+      platform_arr: null,
+      seat: null,
+    }));
+  }
+  // Fallback: HTML time+station pairs → pair into legs
+  else if (htmlTimeStations.length >= 4) {
+    const pairs = htmlTimeStations;
+    for (let i = 0; i + 1 < pairs.length; i += 2) {
+      const dep = pairs[i];
+      const arr = pairs[i + 1];
+      const isReturnLeg = route.to ? dep.station.toLowerCase().includes(route.to.toLowerCase()) : i >= pairs.length / 2;
       segments.push({
-        from_station: leg.from,
-        to_station: leg.to,
-        departure_date: leg.date,
-        departure_time: leg.time,
-        arrival_date: leg.date,
-        arrival_time: "",
+        from_station: dep.station,
+        to_station: arr.station,
+        departure_date: isReturnLeg ? returnDate : travelDate,
+        departure_time: dep.time,
+        arrival_date: isReturnLeg ? returnDate : travelDate,
+        arrival_time: arr.time,
         service_number: null,
         platform_dep: null,
         platform_arr: null,
         seat: null,
       });
     }
-  } else if (route.from && route.to) {
-    const outDate = times.outboundDate ?? new Date().toISOString().slice(0, 10);
+  }
+  // Fallback: use train-times URLs for summary legs
+  else if (urlLegs.length > 0) {
+    segments = urlLegs.map((leg) => ({
+      from_station: leg.from,
+      to_station: leg.to,
+      departure_date: leg.date,
+      departure_time: leg.time,
+      arrival_date: leg.date,
+      arrival_time: "",
+      service_number: null,
+      platform_dep: null,
+      platform_arr: null,
+      seat: null,
+    }));
+  }
+  // Last resort: subject line
+  else if (route.from && route.to) {
+    const outDate = subjectTimes.outboundDate ?? new Date().toISOString().slice(0, 10);
     segments.push({
       from_station: route.from,
       to_station: route.to,
       departure_date: outDate,
-      departure_time: times.outboundTime ?? "00:00",
+      departure_time: subjectTimes.outboundTime ?? "00:00",
       arrival_date: outDate,
       arrival_time: "",
       service_number: null,
@@ -276,13 +496,13 @@ function parseTrainlineBookingConfirmation(
       platform_arr: null,
       seat: null,
     });
-    if (route.isReturn && times.returnTime) {
-      const retDate = times.returnDate ?? outDate;
+    if (route.isReturn && subjectTimes.returnTime) {
+      const retDate = subjectTimes.returnDate ?? outDate;
       segments.push({
         from_station: route.to,
         to_station: route.from,
         departure_date: retDate,
-        departure_time: times.returnTime,
+        departure_time: subjectTimes.returnTime,
         arrival_date: retDate,
         arrival_time: "",
         service_number: null,

--- a/src/lib/gmail/parsers.ts
+++ b/src/lib/gmail/parsers.ts
@@ -149,6 +149,7 @@ function makeSegment(partial: {
   coach?: string | null;
   seat?: string | null;
   barcode_ref?: string | null;
+  barcode_data?: string | null;
 }): ParsedTransportSegment {
   return {
     from_station: partial.from_station,
@@ -168,6 +169,7 @@ function makeSegment(partial: {
     coach: partial.coach ?? null,
     seat: partial.seat ?? null,
     barcode_ref: partial.barcode_ref ?? null,
+    barcode_data: partial.barcode_data ?? null,
   };
 }
 

--- a/src/lib/gmail/parsers.ts
+++ b/src/lib/gmail/parsers.ts
@@ -14,6 +14,9 @@ import type {
 
 function stripHtml(html: string): string {
   return html
+    .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, "")
+    .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, "")
+    .replace(/<!--[\s\S]*?-->/g, "")
     .replace(/<br\s*\/?>/gi, "\n")
     .replace(/<\/?(p|div|tr|li|h\d)[^>]*>/gi, "\n")
     .replace(/<[^>]+>/g, "")
@@ -128,86 +131,172 @@ function parseTime(timeStr: string): string | null {
 
 // ── Trainline ──────────────────────────────────────────────────────────
 
-function parseTrainline(html: string, text: string): Partial<ParsedTransportBooking> | null {
+function isTrainlineMarketing(from: string, subject: string): boolean {
+  if (/no-reply@comms\.trainline/i.test(from)) return true;
+  if (/open\s+this\s+email\s+for\s+tickets/i.test(subject)) return true;
+  if (/forgotten\s+something/i.test(subject)) return true;
+  return false;
+}
+
+function titleCase(s: string): string {
+  return s.replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function parseTrainlineTrainTimesUrls(html: string): Array<{
+  from: string;
+  to: string;
+  date: string;
+  time: string;
+}> {
+  const results: Array<{ from: string; to: string; date: string; time: string }> = [];
+  const urlPattern = /\/train-times\/([a-z-]+)-to-([a-z-]+)\/(\d{1,2}-[A-Za-z]+-\d{4})\/(\d{4})/g;
+  let m;
+  while ((m = urlPattern.exec(html)) !== null) {
+    const from = titleCase(m[1].replace(/-/g, " "));
+    const to = titleCase(m[2].replace(/-/g, " "));
+    const dateParts = m[3].split("-");
+    const dateStr = `${dateParts[0]} ${dateParts[1]} ${dateParts[2]}`;
+    const date = parseDate(dateStr) ?? "";
+    const time = `${m[4].slice(0, 2)}:${m[4].slice(2)}`;
+    results.push({ from, to, date, time });
+  }
+  // Deduplicate by from+to+time (same URL appears multiple times in email)
+  const seen = new Set<string>();
+  return results.filter((r) => {
+    const key = `${r.from}|${r.to}|${r.time}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function parseTrainlineSubjectTimes(subject: string): {
+  outboundDate: string | null;
+  outboundTime: string | null;
+  returnDate: string | null;
+  returnTime: string | null;
+} {
+  const m = subject.match(
+    /\((\d{1,2}\s+\w+)\s+at\s+(\d{1,2}:\d{2})\s*-\s*(\d{1,2}\s+\w+)\s+at\s+(\d{1,2}:\d{2})\)/,
+  );
+  if (m) {
+    return {
+      outboundDate: parseDate(m[1]),
+      outboundTime: parseTime(m[2]),
+      returnDate: parseDate(m[3]),
+      returnTime: parseTime(m[4]),
+    };
+  }
+  const single = subject.match(/\((\d{1,2}\s+\w+)\s+at\s+(\d{1,2}:\d{2})\)/);
+  if (single) {
+    return {
+      outboundDate: parseDate(single[1]),
+      outboundTime: parseTime(single[2]),
+      returnDate: null,
+      returnTime: null,
+    };
+  }
+  return { outboundDate: null, outboundTime: null, returnDate: null, returnTime: null };
+}
+
+function parseTrainlineSubjectRoute(subject: string): {
+  from: string | null;
+  to: string | null;
+  isReturn: boolean;
+} {
+  const returnMatch = subject.match(
+    /(?:return\s+trip|round\s+trip)\s+(.+?)\s+to\s+(.+?)\s*\(/i,
+  );
+  if (returnMatch) {
+    return { from: returnMatch[1].trim(), to: returnMatch[2].trim(), isReturn: true };
+  }
+  const singleMatch = subject.match(
+    /(?:booking\s+confirmation\s+for\s+)(.+?)\s+to\s+(.+?)\s*\(/i,
+  );
+  if (singleMatch) {
+    return { from: singleMatch[1].trim(), to: singleMatch[2].trim(), isReturn: false };
+  }
+  return { from: null, to: null, isReturn: false };
+}
+
+function parseTrainline(html: string, text: string, subject: string): Partial<ParsedTransportBooking> | null {
+  // Booking confirmation emails are the best data source — subject line
+  // and embedded train-times URLs contain clean station names, dates, times.
+  const isBookingConfirmation = /booking\s*confirmation/i.test(subject);
+  const isEticket = /e-?tickets?\s+to\s/i.test(subject);
+
+  if (isBookingConfirmation) {
+    return parseTrainlineBookingConfirmation(html, text, subject);
+  }
+  if (isEticket) {
+    return parseTrainlineEticket(html, text, subject);
+  }
+
+  // Fallback: generic parse for other Trainline email types
+  return parseTrainlineGeneric(html, text, subject);
+}
+
+function parseTrainlineBookingConfirmation(
+  html: string,
+  text: string,
+  subject: string,
+): Partial<ParsedTransportBooking> | null {
+  const route = parseTrainlineSubjectRoute(subject);
+  const times = parseTrainlineSubjectTimes(subject);
+  const urlLegs = parseTrainlineTrainTimesUrls(html);
+
   const segments: ParsedTransportSegment[] = [];
 
-  // Trainline typically has patterns like:
-  // "London Euston" → "Manchester Piccadilly"
-  // "Departs: 14:30" / "Arrives: 16:45"
-  const stationPairPattern =
-    /(?:from|depart(?:s|ing)?(?:\s+from)?)\s*:?\s*([A-Za-z\s&'.()-]+?)(?:\s+to\s+|\s*→\s*|\s*->\s*|\s*➔\s*)([A-Za-z\s&'.()-]+?)(?:\n|<|,|\s{2})/gi;
-
-  const timeBlockPattern =
-    /(\d{1,2}:\d{2})\s*(?:→|->|to|–|-|➔)\s*(\d{1,2}:\d{2})/g;
-
-  const datePattern =
-    /(?:(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)\w*\s+)?(\d{1,2}\s+(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\s*\d{0,4})/gi;
-
-  const stations: Array<[string, string]> = [];
-  let m;
-  while ((m = stationPairPattern.exec(text)) !== null) {
-    stations.push([m[1].trim(), m[2].trim()]);
-  }
-
-  if (stations.length === 0) {
-    // Fallback: look for station names on separate lines
-    const lines = text.split("\n").map((l) => l.trim()).filter(Boolean);
-    for (let i = 0; i < lines.length - 1; i++) {
-      if (/depart/i.test(lines[i]) && /arriv/i.test(lines[i + 1])) {
-        const from = lines[i].replace(/^.*?:\s*/, "").trim();
-        const to = lines[i + 1].replace(/^.*?:\s*/, "").trim();
-        if (from.length > 2 && to.length > 2) {
-          stations.push([from, to]);
-        }
-      }
+  if (urlLegs.length > 0) {
+    for (const leg of urlLegs) {
+      segments.push({
+        from_station: leg.from,
+        to_station: leg.to,
+        departure_date: leg.date,
+        departure_time: leg.time,
+        arrival_date: leg.date,
+        arrival_time: "",
+        service_number: null,
+        platform_dep: null,
+        platform_arr: null,
+        seat: null,
+      });
     }
-  }
-
-  const times: Array<[string, string]> = [];
-  while ((m = timeBlockPattern.exec(text)) !== null) {
-    const dep = parseTime(m[1]);
-    const arr = parseTime(m[2]);
-    if (dep && arr) times.push([dep, arr]);
-  }
-
-  const dates: string[] = [];
-  while ((m = datePattern.exec(text)) !== null) {
-    const d = parseDate(m[1]);
-    if (d) dates.push(d);
-  }
-  const travelDate = dates[0] ?? new Date().toISOString().slice(0, 10);
-
-  const trainNumbers: string[] = [];
-  const trainPattern = /(?:train|service)\s*(?:no\.?|number|#)?\s*:?\s*([A-Z0-9]{2,8})/gi;
-  while ((m = trainPattern.exec(text)) !== null) {
-    trainNumbers.push(m[1]);
-  }
-
-  const seatMatch = text.match(
-    /(?:seat|coach\s*[&+]?\s*seat)\s*:?\s*(?:coach\s+)?([A-Z0-9]+(?:\s*,?\s*seat\s*\d+[A-Z]?)?)/i,
-  );
-  const seat = seatMatch ? seatMatch[1].trim() : null;
-
-  const count = Math.max(stations.length, times.length, 1);
-  for (let i = 0; i < count; i++) {
+  } else if (route.from && route.to) {
+    const outDate = times.outboundDate ?? new Date().toISOString().slice(0, 10);
     segments.push({
-      from_station: stations[i]?.[0] ?? "Unknown",
-      to_station: stations[i]?.[1] ?? "Unknown",
-      departure_date: travelDate,
-      departure_time: times[i]?.[0] ?? "00:00",
-      arrival_date: dates[i + 1] ?? travelDate,
-      arrival_time: times[i]?.[1] ?? "00:00",
-      service_number: trainNumbers[i] ?? null,
+      from_station: route.from,
+      to_station: route.to,
+      departure_date: outDate,
+      departure_time: times.outboundTime ?? "00:00",
+      arrival_date: outDate,
+      arrival_time: "",
+      service_number: null,
       platform_dep: null,
       platform_arr: null,
-      seat: i === 0 ? seat : null,
+      seat: null,
     });
+    if (route.isReturn && times.returnTime) {
+      const retDate = times.returnDate ?? outDate;
+      segments.push({
+        from_station: route.to,
+        to_station: route.from,
+        departure_date: retDate,
+        departure_time: times.returnTime,
+        arrival_date: retDate,
+        arrival_time: "",
+        service_number: null,
+        platform_dep: null,
+        platform_arr: null,
+        seat: null,
+      });
+    }
   }
 
   if (segments.length === 0) return null;
 
   const price = findPrice(text);
-  const ref = findBookingRef(text);
+  const ref = findTrainlineBookingRef(text);
 
   return {
     type: "transport",
@@ -218,6 +307,207 @@ function parseTrainline(html: string, text: string): Partial<ParsedTransportBook
     currency: price?.currency ?? "GBP",
     segments,
   };
+}
+
+function parseTrainlineEticket(
+  html: string,
+  text: string,
+  subject: string,
+): Partial<ParsedTransportBooking> | null {
+  // Subject: "Your etickets to Derby Thursday 25 June"
+  const destMatch = subject.match(/e-?tickets?\s+to\s+(.+?)(?:\s+(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)\w*)?(?:\s+\d{1,2}\s+\w+)/i);
+  const dateMatch = subject.match(/(\d{1,2}\s+(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?))/i);
+  const destination = destMatch?.[1]?.trim() ?? null;
+  const travelDate = dateMatch ? parseDate(dateMatch[1]) : null;
+
+  // Check train-times URLs for structured data
+  const urlLegs = parseTrainlineTrainTimesUrls(html);
+  if (urlLegs.length > 0) {
+    const segments: ParsedTransportSegment[] = urlLegs.map((leg) => ({
+      from_station: leg.from,
+      to_station: leg.to,
+      departure_date: leg.date,
+      departure_time: leg.time,
+      arrival_date: leg.date,
+      arrival_time: "",
+      service_number: null,
+      platform_dep: null,
+      platform_arr: null,
+      seat: null,
+    }));
+
+    const price = findPrice(text);
+    const ref = findTrainlineBookingRef(text);
+    return {
+      type: "transport",
+      mode: "train",
+      provider: "Trainline",
+      booking_reference: ref,
+      price: price?.amount ?? null,
+      currency: price?.currency ?? "GBP",
+      segments,
+    };
+  }
+
+  // Fallback: extract station codes from body (WEL→LEI pattern)
+  const stationCodePattern = /\b([A-Z]{3})\s*→\s*([A-Z]{3})\b/g;
+  const codePairs: Array<[string, string]> = [];
+  let m;
+  while ((m = stationCodePattern.exec(text)) !== null) {
+    codePairs.push([m[1], m[2]]);
+  }
+
+  const date = travelDate ?? new Date().toISOString().slice(0, 10);
+
+  if (codePairs.length > 0) {
+    const segments: ParsedTransportSegment[] = codePairs.map(([from, to]) => ({
+      from_station: from,
+      to_station: to,
+      departure_date: date,
+      departure_time: "00:00",
+      arrival_date: date,
+      arrival_time: "",
+      service_number: null,
+      platform_dep: null,
+      platform_arr: null,
+      seat: null,
+    }));
+
+    return {
+      type: "transport",
+      mode: "train",
+      provider: "Trainline",
+      booking_reference: findTrainlineBookingRef(text),
+      price: findPrice(text)?.amount ?? null,
+      currency: findPrice(text)?.currency ?? "GBP",
+      segments,
+    };
+  }
+
+  if (destination) {
+    return {
+      type: "transport",
+      mode: "train",
+      provider: "Trainline",
+      booking_reference: findTrainlineBookingRef(text),
+      price: findPrice(text)?.amount ?? null,
+      currency: findPrice(text)?.currency ?? "GBP",
+      segments: [{
+        from_station: "Unknown",
+        to_station: destination,
+        departure_date: date,
+        departure_time: "00:00",
+        arrival_date: date,
+        arrival_time: "",
+        service_number: null,
+        platform_dep: null,
+        platform_arr: null,
+        seat: null,
+      }],
+    };
+  }
+
+  return null;
+}
+
+function parseTrainlineGeneric(
+  html: string,
+  text: string,
+  subject: string,
+): Partial<ParsedTransportBooking> | null {
+  // Try train-times URLs first
+  const urlLegs = parseTrainlineTrainTimesUrls(html);
+  if (urlLegs.length > 0) {
+    const segments: ParsedTransportSegment[] = urlLegs.map((leg) => ({
+      from_station: leg.from,
+      to_station: leg.to,
+      departure_date: leg.date,
+      departure_time: leg.time,
+      arrival_date: leg.date,
+      arrival_time: "",
+      service_number: null,
+      platform_dep: null,
+      platform_arr: null,
+      seat: null,
+    }));
+
+    return {
+      type: "transport",
+      mode: "train",
+      provider: "Trainline",
+      booking_reference: findTrainlineBookingRef(text),
+      price: findPrice(text)?.amount ?? null,
+      currency: findPrice(text)?.currency ?? "GBP",
+      segments,
+    };
+  }
+
+  // Fallback: station pairs from text
+  const stationPairPattern =
+    /(?:from|depart(?:s|ing)?(?:\s+from)?)\s*:?\s*([A-Za-z\s&'.()-]+?)(?:\s+to\s+|\s*→\s*|\s*->\s*|\s*➔\s*)([A-Za-z\s&'.()-]+?)(?:\n|<|,|\s{2})/gi;
+  const timeBlockPattern =
+    /(\d{1,2}:\d{2})\s*(?:→|->|to|–|-|➔)\s*(\d{1,2}:\d{2})/g;
+  const datePattern =
+    /(?:(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)\w*\s+)?(\d{1,2}\s+(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\s*\d{0,4})/gi;
+
+  const stations: Array<[string, string]> = [];
+  let m;
+  while ((m = stationPairPattern.exec(text)) !== null) {
+    stations.push([m[1].trim(), m[2].trim()]);
+  }
+
+  const timePairs: Array<[string, string]> = [];
+  while ((m = timeBlockPattern.exec(text)) !== null) {
+    const dep = parseTime(m[1]);
+    const arr = parseTime(m[2]);
+    if (dep && arr) timePairs.push([dep, arr]);
+  }
+
+  const dates: string[] = [];
+  while ((m = datePattern.exec(text)) !== null) {
+    const d = parseDate(m[1]);
+    if (d) dates.push(d);
+  }
+  const travelDate = dates[0] ?? new Date().toISOString().slice(0, 10);
+
+  const segments: ParsedTransportSegment[] = [];
+  const count = Math.max(stations.length, timePairs.length, 1);
+  for (let i = 0; i < count; i++) {
+    segments.push({
+      from_station: stations[i]?.[0] ?? "Unknown",
+      to_station: stations[i]?.[1] ?? "Unknown",
+      departure_date: travelDate,
+      departure_time: timePairs[i]?.[0] ?? "00:00",
+      arrival_date: dates[i + 1] ?? travelDate,
+      arrival_time: timePairs[i]?.[1] ?? "00:00",
+      service_number: null,
+      platform_dep: null,
+      platform_arr: null,
+      seat: null,
+    });
+  }
+
+  if (segments.length === 0) return null;
+
+  return {
+    type: "transport",
+    mode: "train",
+    provider: "Trainline",
+    booking_reference: findTrainlineBookingRef(text),
+    price: findPrice(text)?.amount ?? null,
+    currency: findPrice(text)?.currency ?? "GBP",
+    segments,
+  };
+}
+
+function findTrainlineBookingRef(text: string): string | null {
+  // Trainline booking refs are typically 10+ char alphanumeric tokens
+  // found near "order" or "booking" keywords, or in order URLs
+  const orderUrl = text.match(/order[/-](?:token|id)[#/]?\s*([A-Za-z0-9]{8,})/i);
+  if (orderUrl) return orderUrl[1];
+  const refLine = text.match(/(?:order|booking)\s*(?:ref(?:erence)?|number|#|ID)\s*[:.]?\s*([A-Z0-9]{6,})/i);
+  if (refLine) return refLine[1];
+  return null;
 }
 
 // ── UK Rail operators (LNER, Avanti, GWR, etc.) ────────────────────────
@@ -497,13 +787,16 @@ function parseAccommodation(
 
 type SenderConfig = {
   match: (from: string, subject: string) => boolean;
-  parse: (html: string, text: string) => Partial<ParsedBooking> | null;
+  parse: (html: string, text: string, subject: string) => Partial<ParsedBooking> | null;
 };
 
 const SENDER_CONFIGS: SenderConfig[] = [
   {
     match: (from) => /trainline/i.test(from),
-    parse: (html, text) => parseTrainline(html, text),
+    parse: (html, text, subject) => {
+      if (isTrainlineMarketing(from, subject)) return null;
+      return parseTrainline(html, text, subject);
+    },
   },
   {
     match: (from) => /lner/i.test(from),
@@ -561,7 +854,7 @@ const SENDER_CONFIGS: SenderConfig[] = [
   },
 ];
 
-let from = ""; // closure var for airline sender config
+let from = ""; // closure var for sender config
 
 export function detectAndParse(
   senderEmail: string,
@@ -589,7 +882,7 @@ export function detectAndParse(
 
   for (const config of SENDER_CONFIGS) {
     if (config.match(senderEmail, subject)) {
-      result = config.parse(htmlContent, text);
+      result = config.parse(htmlContent, text, subject);
       break;
     }
   }

--- a/src/lib/gmail/trainline-pdf.ts
+++ b/src/lib/gmail/trainline-pdf.ts
@@ -65,6 +65,7 @@ export type TrainlinePdfTicket = {
   coach: string | null;
   seat: string | null;
   barcode_ref: string | null;
+  barcode_data: string | null;
 };
 
 export function parseTrainlinePdfText(pdfText: string): TrainlinePdfTicket | null {
@@ -146,10 +147,15 @@ export function parseTrainlinePdfText(pdfText: string): TrainlinePdfTicket | nul
   const coach = coachMatch?.[1] ?? null;
   const seat = seatMatch?.[1] ?? null;
 
-  // Barcode reference: alphanumeric string near bottom, often 10-12 chars
-  const barcodeMatch = pdfText.match(/\b([A-Z0-9]{10,14})\b(?:\s*$)/m)
-    ?? pdfText.match(/\b(TT[A-Z0-9]{8,12})\b/);
+  // Barcode reference: display reference like TTBQEBVV49M
+  const barcodeMatch = pdfText.match(/\b(TT[A-Z0-9]{8,12})\b/)
+    ?? pdfText.match(/\b([A-Z0-9]{10,14})\b(?:\s*$)/m);
   const barcodeRef = barcodeMatch?.[1] ?? null;
+
+  // Full barcode data: RSP Aztec payload — starts with 2-digit version,
+  // then ticket ID, then encoded+signed journey data. ~200-300 chars.
+  const barcodeDataMatch = pdfText.match(/\b(\d{2}[A-Z0-9]{50,300})\b/);
+  const barcodeData = barcodeDataMatch?.[1] ?? null;
 
   if (!fromCode && !toCode && stationNames.length < 2) return null;
 
@@ -166,7 +172,93 @@ export function parseTrainlinePdfText(pdfText: string): TrainlinePdfTicket | nul
     coach,
     seat,
     barcode_ref: barcodeRef,
+    barcode_data: barcodeData,
   };
+}
+
+// Extract barcode data from .pkpass wallet pass files.
+// A .pkpass is a ZIP containing pass.json with barcode info.
+export async function extractBarcodeFromPkpass(pkpassBuffer: Buffer): Promise<string | null> {
+  try {
+    const { Readable } = await import("stream");
+    const { createUnzip } = await import("zlib");
+    // Minimal ZIP parsing — find pass.json entry and extract it
+    const passJson = await extractFileFromZip(pkpassBuffer, "pass.json");
+    if (!passJson) return null;
+    const pass = JSON.parse(passJson);
+    // Apple Wallet pass format
+    const barcode = pass.barcodes?.[0] ?? pass.barcode;
+    return barcode?.message ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function extractFileFromZip(zipBuf: Buffer, filename: string): Promise<string | null> {
+  // Minimal ZIP parsing: find local file headers, locate the target file
+  let offset = 0;
+  while (offset < zipBuf.length - 4) {
+    const sig = zipBuf.readUInt32LE(offset);
+    if (sig !== 0x04034b50) break; // Local file header signature
+    const compMethod = zipBuf.readUInt16LE(offset + 8);
+    const compSize = zipBuf.readUInt32LE(offset + 18);
+    const uncompSize = zipBuf.readUInt32LE(offset + 22);
+    const nameLen = zipBuf.readUInt16LE(offset + 26);
+    const extraLen = zipBuf.readUInt16LE(offset + 28);
+    const name = zipBuf.toString("utf-8", offset + 30, offset + 30 + nameLen);
+    const dataStart = offset + 30 + nameLen + extraLen;
+
+    if (name === filename) {
+      if (compMethod === 0) {
+        return zipBuf.toString("utf-8", dataStart, dataStart + uncompSize);
+      }
+      if (compMethod === 8) {
+        const { inflateRawSync } = await import("zlib");
+        const compressed = zipBuf.subarray(dataStart, dataStart + compSize);
+        return inflateRawSync(compressed).toString("utf-8");
+      }
+      return null;
+    }
+    offset = dataStart + compSize;
+  }
+  return null;
+}
+
+// Try to download a .pkpass file from a Trainline download URL.
+// The URL format is https://download.thetrainline.com/resource#HASH
+// The hash might work as a direct path or query parameter.
+export async function tryDownloadPkpass(downloadUrl: string): Promise<Buffer | null> {
+  const hashMatch = downloadUrl.match(/#([A-F0-9]{64})/i);
+  if (!hashMatch) return null;
+  const hash = hashMatch[1];
+
+  const attempts = [
+    `https://download.thetrainline.com/resource/${hash}`,
+    `https://download.thetrainline.com/resource?token=${hash}`,
+  ];
+
+  for (const url of attempts) {
+    try {
+      const res = await fetch(url, {
+        headers: {
+          "Accept": "application/vnd.apple.pkpass, application/octet-stream, */*",
+          "User-Agent": "Mozilla/5.0",
+        },
+        redirect: "follow",
+      });
+      if (!res.ok) continue;
+      const contentType = res.headers.get("content-type") ?? "";
+      if (contentType.includes("text/html")) continue;
+      const buf = Buffer.from(await res.arrayBuffer());
+      // Verify it's a ZIP (PKZip magic bytes)
+      if (buf.length > 4 && buf.readUInt32LE(0) === 0x04034b50) {
+        return buf;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return null;
 }
 
 export function pdfTicketsToSegments(
@@ -191,5 +283,6 @@ export function pdfTicketsToSegments(
     coach: t.coach,
     seat: t.seat,
     barcode_ref: t.barcode_ref,
+    barcode_data: t.barcode_data,
   }));
 }

--- a/src/lib/gmail/trainline-pdf.ts
+++ b/src/lib/gmail/trainline-pdf.ts
@@ -1,0 +1,195 @@
+// Parse text extracted from Trainline eticket PDF attachments.
+// Each PDF represents one ticket (one leg of the journey).
+
+import type { ParsedTransportSegment } from "./types";
+
+// NRS station code → full name mapping (common UK stations)
+const STATION_NAMES: Record<string, string> = {
+  WEL: "Wellingborough",
+  LEI: "Leicester",
+  DER: "Derby",
+  NTG: "Nottingham",
+  SHF: "Sheffield",
+  LDS: "Leeds",
+  MAN: "Manchester Piccadilly",
+  MCV: "Manchester Victoria",
+  BHM: "Birmingham New Street",
+  LIV: "Liverpool Lime Street",
+  LBG: "London Bridge",
+  KGX: "London Kings Cross",
+  STP: "London St Pancras",
+  EUS: "London Euston",
+  PAD: "London Paddington",
+  VIC: "London Victoria",
+  WAT: "London Waterloo",
+  BRI: "Brighton",
+  CBG: "Cambridge",
+  OXF: "Oxford",
+  YRK: "York",
+  NCL: "Newcastle",
+  EDB: "Edinburgh Waverley",
+  GLC: "Glasgow Central",
+  CRE: "Crewe",
+  RDG: "Reading",
+  BTN: "Brighton",
+  BMS: "Bromley South",
+  MKC: "Milton Keynes Central",
+  KET: "Kettering",
+  COV: "Coventry",
+  PMH: "Portsmouth Harbour",
+  SOT: "Southampton Central",
+  BHI: "Bournemouth",
+  EXD: "Exeter St Davids",
+  PLY: "Plymouth",
+  TBD: "Taunton",
+  SWA: "Swansea",
+  CDF: "Cardiff Central",
+  BPW: "Bristol Parkway",
+  BTH: "Bath Spa",
+};
+
+export function resolveStationName(code: string): string {
+  return STATION_NAMES[code] ?? code;
+}
+
+export type TrainlinePdfTicket = {
+  from_code: string;
+  to_code: string;
+  from_name: string;
+  to_name: string;
+  departure_time: string;
+  date: string;
+  ticket_type: string | null;
+  route_restriction: string | null;
+  operator: string | null;
+  coach: string | null;
+  seat: string | null;
+  barcode_ref: string | null;
+};
+
+export function parseTrainlinePdfText(pdfText: string): TrainlinePdfTicket | null {
+  // Trainline eticket PDFs have a consistent layout:
+  // Station codes (WEL, LEI), times, ticket type, route, coach/seat
+
+  // Station codes: 3-letter NRS codes, usually near top
+  const codePattern = /\b([A-Z]{3})\s*[-–→]\s*([A-Z]{3})\b/;
+  const codeMatch = pdfText.match(codePattern);
+
+  // Also try separate patterns: "WELLINGBOROUGH" header + "WEL" code
+  const fromCodeMatch = pdfText.match(/\b([A-Z]{3})\b[\s\S]{0,50}→|^([A-Z]{3})\s/m);
+  const toCodeMatch = pdfText.match(/→[\s\S]{0,50}\b([A-Z]{3})\b|→\s*([A-Z]{3})/);
+
+  let fromCode = codeMatch?.[1] ?? fromCodeMatch?.[1] ?? fromCodeMatch?.[2] ?? "";
+  let toCode = codeMatch?.[2] ?? toCodeMatch?.[1] ?? toCodeMatch?.[2] ?? "";
+
+  // Station names: look for UPPERCASE station names
+  const stationNamePattern = /([A-Z][A-Z\s]+(?:STREET|ROAD|CENTRAL|PARKWAY|LIME|CROSS|BRIDGE)?)\s/g;
+  const stationNames: string[] = [];
+  let m;
+  while ((m = stationNamePattern.exec(pdfText)) !== null) {
+    const name = m[1].trim();
+    if (name.length > 3 && !/TICKET|TYPE|ROUTE|ADULT|CHILD|DEPART|RESERV|SINGLE|RETURN|ADVANCE|OFF.PEAK/i.test(name)) {
+      stationNames.push(name);
+    }
+  }
+
+  // Time: departure time
+  const timeMatch = pdfText.match(/(?:DEPART|DEP|Depart)\s*:?\s*(\d{1,2}:\d{2})/i)
+    ?? pdfText.match(/\b(\d{1,2}:\d{2})\b/);
+  const departureTime = timeMatch?.[1] ?? "";
+
+  // Date
+  const dateMatch = pdfText.match(
+    /(\d{1,2}\s+(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\s*\d{0,4})/i,
+  );
+  let date = "";
+  if (dateMatch) {
+    const MONTHS: Record<string, string> = {
+      jan: "01", feb: "02", mar: "03", apr: "04", may: "05", jun: "06",
+      jul: "07", aug: "08", sep: "09", oct: "10", nov: "11", dec: "12",
+      january: "01", february: "02", march: "03", april: "04",
+      june: "06", july: "07", august: "08", september: "09",
+      october: "10", november: "11", december: "12",
+    };
+    const parts = dateMatch[1].match(/(\d{1,2})\s+(\w+)\s*(\d{4})?/);
+    if (parts) {
+      const day = parts[1].padStart(2, "0");
+      const month = MONTHS[parts[2].toLowerCase()] ?? "01";
+      const year = parts[3] ?? new Date().getFullYear().toString();
+      date = `${year}-${month}-${day}`;
+    }
+  }
+
+  // Ticket type: "Advance Single", "Off-Peak Return", etc.
+  const ticketTypeMatch = pdfText.match(
+    /(?:TICKET\s*TYPE|Ticket\s*Type)\s*:?\s*(.+?)(?:\n|$)/i,
+  ) ?? pdfText.match(
+    /((?:Advance|Off[- ]?Peak|Anytime|Super Off[- ]?Peak)\s+(?:Single|Return|Day Single|Day Return))/i,
+  );
+  const ticketType = ticketTypeMatch?.[1]?.trim() ?? null;
+
+  // Route restriction: "Emr Only", "Any Permitted", etc.
+  const routeMatch = pdfText.match(
+    /(?:ROUTE|Route)\s*:?\s*(.+?)(?:\n|$)/i,
+  );
+  const routeRestriction = routeMatch?.[1]?.trim() ?? null;
+
+  // Operator
+  const operatorMatch = pdfText.match(
+    /(East Midlands Railway|Avanti West Coast|LNER|CrossCountry|Great Western Railway|Northern|TransPennine Express|South(?:ern|western)|Southeastern|ScotRail|Chiltern|c2c|Greater Anglia|Thameslink|West Midlands Railway)/i,
+  );
+  const operator = operatorMatch?.[1] ?? null;
+
+  // Coach and seat: "Coach B Seat 42" or "COACH: B  SEAT: 42"
+  const coachMatch = pdfText.match(/(?:COACH|Coach)\s*:?\s*([A-Z0-9]{1,3})/i);
+  const seatMatch = pdfText.match(/(?:SEAT|Seat)\s*:?\s*(\d{1,3}[A-Z]?)/i);
+  const coach = coachMatch?.[1] ?? null;
+  const seat = seatMatch?.[1] ?? null;
+
+  // Barcode reference: alphanumeric string near bottom, often 10-12 chars
+  const barcodeMatch = pdfText.match(/\b([A-Z0-9]{10,14})\b(?:\s*$)/m)
+    ?? pdfText.match(/\b(TT[A-Z0-9]{8,12})\b/);
+  const barcodeRef = barcodeMatch?.[1] ?? null;
+
+  if (!fromCode && !toCode && stationNames.length < 2) return null;
+
+  return {
+    from_code: fromCode,
+    to_code: toCode,
+    from_name: resolveStationName(fromCode) || stationNames[0] || fromCode,
+    to_name: resolveStationName(toCode) || stationNames[1] || toCode,
+    departure_time: departureTime,
+    date,
+    ticket_type: ticketType,
+    route_restriction: routeRestriction,
+    operator,
+    coach,
+    seat,
+    barcode_ref: barcodeRef,
+  };
+}
+
+export function pdfTicketsToSegments(
+  tickets: TrainlinePdfTicket[],
+  fallbackDate: string,
+): ParsedTransportSegment[] {
+  return tickets.map((t) => ({
+    from_station: t.from_name,
+    to_station: t.to_name,
+    from_station_code: t.from_code || null,
+    to_station_code: t.to_code || null,
+    departure_date: t.date || fallbackDate,
+    departure_time: t.departure_time || "00:00",
+    arrival_date: t.date || fallbackDate,
+    arrival_time: "",
+    service_number: null,
+    operator: t.operator,
+    route_restriction: t.route_restriction,
+    ticket_type: t.ticket_type,
+    platform_dep: null,
+    platform_arr: null,
+    coach: t.coach,
+    seat: t.seat,
+    barcode_ref: t.barcode_ref,
+  }));
+}

--- a/src/lib/gmail/types.ts
+++ b/src/lib/gmail/types.ts
@@ -3,14 +3,21 @@
 export type ParsedTransportSegment = {
   from_station: string;
   to_station: string;
+  from_station_code: string | null;
+  to_station_code: string | null;
   departure_date: string; // YYYY-MM-DD
   departure_time: string; // HH:MM
   arrival_date: string; // YYYY-MM-DD
   arrival_time: string; // HH:MM
   service_number: string | null;
+  operator: string | null;
+  route_restriction: string | null;
+  ticket_type: string | null;
   platform_dep: string | null;
   platform_arr: string | null;
+  coach: string | null;
   seat: string | null;
+  barcode_ref: string | null;
 };
 
 export type ParsedTransportBooking = {

--- a/src/lib/gmail/types.ts
+++ b/src/lib/gmail/types.ts
@@ -18,6 +18,7 @@ export type ParsedTransportSegment = {
   coach: string | null;
   seat: string | null;
   barcode_ref: string | null;
+  barcode_data: string | null; // Full Aztec/barcode payload for regeneration
 };
 
 export type ParsedTransportBooking = {

--- a/src/lib/google/gmail.ts
+++ b/src/lib/google/gmail.ts
@@ -9,8 +9,9 @@ type GmailMessageHeader = {
 
 type GmailMessagePart = {
   mimeType: string;
+  filename?: string;
   headers?: GmailMessageHeader[];
-  body?: { data?: string; size?: number };
+  body?: { data?: string; size?: number; attachmentId?: string };
   parts?: GmailMessagePart[];
 };
 
@@ -97,6 +98,58 @@ function extractPartsRecursive(
   if (part.parts) {
     for (const child of part.parts) {
       results.push(...extractPartsRecursive(child, mimeType));
+    }
+  }
+  return results;
+}
+
+export async function gmailGetAttachment(args: {
+  accessToken: string;
+  messageId: string;
+  attachmentId: string;
+}): Promise<Buffer> {
+  const res = await fetch(
+    `${BASE}/messages/${args.messageId}/attachments/${args.attachmentId}`,
+    { headers: { Authorization: `Bearer ${args.accessToken}` } },
+  );
+  if (!res.ok) {
+    throw new Error(`Gmail get attachment failed: ${res.status}`);
+  }
+  const data = (await res.json()) as { data: string; size: number };
+  const base64 = data.data.replace(/-/g, "+").replace(/_/g, "/");
+  return Buffer.from(base64, "base64");
+}
+
+export type EmailAttachment = {
+  filename: string;
+  mimeType: string;
+  attachmentId: string;
+  size: number;
+};
+
+function findAttachmentsRecursive(part: GmailMessagePart): EmailAttachment[] {
+  const results: EmailAttachment[] = [];
+  if (part.body?.attachmentId && part.filename) {
+    results.push({
+      filename: part.filename,
+      mimeType: part.mimeType,
+      attachmentId: part.body.attachmentId,
+      size: part.body.size ?? 0,
+    });
+  }
+  if (part.parts) {
+    for (const child of part.parts) {
+      results.push(...findAttachmentsRecursive(child));
+    }
+  }
+  return results;
+}
+
+export function extractAttachments(msg: GmailMessage): EmailAttachment[] {
+  const results: EmailAttachment[] = [];
+  if (msg.payload.parts) {
+    for (const part of msg.payload.parts) {
+      results.push(...findAttachmentsRecursive(part));
     }
   }
   return results;


### PR DESCRIPTION
Trainline sends two emails per booking (eticket + booking confirmation).
The booking confirmation subject contains clean station names and departure
times; its HTML embeds /train-times/ URLs with structured route data. The
parser now prioritises these reliable sources instead of regex-matching the
garbled HTML body text.

- Strip <style>/<script>/comments in stripHtml before tag removal
- Parse booking confirmation subjects for route, times, and return-trip flag
- Extract station/date/time from train-times URLs in HTML
- Filter marketing emails (no-reply@comms.trainline.com, "Open this email")
- Trainline-specific booking ref finder (avoids false positives like "outlook")
- Deduplicate same-date Trainline bookings, preferring confirmation over eticket

https://claude.ai/code/session_01JaNRmRz7BRGNNmyRJ1eW4V