### PR TITLE
Calling points, planning-page bookings, map improvements, OSM route relations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,10 +173,24 @@ Three themes: `dusk` (warm cream, default), `midnight` (dark), `sahara` (dayligh
 ### Tile source
 Currently OSM raster tiles (always available, no API key). Upgrade path: Protomaps or MapTiler vector tiles for full brand control (custom layer colours, hidden POIs). Requires an API key.
 
+### Calling Points (intermediate stations)
+Trainline PDF etickets contain an "Itinerary" section listing intermediate stops with times. These are parsed by `parseItineraryCallingPoints()` in `trainline-pdf.ts` and stored as `calling_points` on:
+- `TrainlinePdfTicket.calling_points` — raw parse output
+- `ParsedTransportSegment.calling_points` — flows through Gmail import
+- `BriefTransportBooking.segmentCallingPoints` — client state (array of arrays, one per segment)
+- `travel_booking_segments.calling_points` — DB column (jsonb, migration 0027)
+- Stop `metadata.calling_points` — on transit_departure/transit_changeover stops, enriched with lat/lng at insert time
+
+On the **map**, calling points populate `Leg.waypoints` in the editor's journey builder. Rendered as small gold-bordered circles (5px) with 7.5px labels at 70% opacity — subtler than origin/destination/intermediate markers.
+
+On the **timeline** (both brief spine and planning page), calling points appear:
+1. As a "calling at KET, MKC +1 more" hint on the collapsed transport booking in the spine
+2. As a visual strip (time · dot · station code) between the station names and ticket details on the `TrainTicketCard`
+
 ### Next steps
-- Calling points: parse intermediate stops from Trainline PDFs, render as small waypoint markers on the rail leg
 - Planning-page transport booking: polyline + duration should work when adding transport during planning (not just from brief)
 - Day-of mode: live position dot, adaptive zoom — component API supports it, just needs wiring
+- Leicester→Derby routing: Dijkstra may fork toward Nottingham at Trent Junction — calling point waypoints could help constrain the polyline to the correct branch
 
 ## Key File Map
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,9 +188,22 @@ On the **timeline** (both brief spine and planning page), calling points appear:
 2. As a visual strip (time · dot · station code) between the station names and ticket details on the `TrainTicketCard`
 
 ### Next steps
-- Planning-page transport booking: polyline + duration should work when adding transport during planning (not just from brief)
 - Day-of mode: live position dot, adaptive zoom — component API supports it, just needs wiring
 - Leicester→Derby routing: Dijkstra may fork toward Nottingham at Trent Junction — calling point waypoints could help constrain the polyline to the correct branch
+
+## Planning-Page Transport Booking
+
+The planning page can add transport bookings directly (not just via the brief). The `+ Transport` button opens the same `TransportBookingCard` as the brief. On "Done", it calls `addFullTransportBooking` in `bookings.ts` which creates:
+- Departure/changeover/arrival stops with full metadata (operator, ticket type, barcodes, calling_points with resolved coordinates)
+- Booking entities (booking_intent, travel_booking, travel_booking_segments)
+- Locked transition with computed duration
+- Expense record (if price is set)
+
+The Gmail import panel (`gmail-import-panel.tsx`) also passes calling_points through when importing.
+
+### Re-Enrich Existing Itineraries
+
+`reEnrichItineraryFromGmail()` in `gmail.ts` re-fetches Trainline PDFs from Gmail for an existing itinerary's transit stops. Re-parses with the updated parser (extracting calling points), resolves coordinates, and patches stop metadata. Triggered by the "Refresh ticket details" button on the planning page toolbar.
 
 ## Key File Map
 

--- a/docs/itinerary-pages.md
+++ b/docs/itinerary-pages.md
@@ -134,6 +134,8 @@ Two-column grid:
 
 **Transit groups** — consecutive locked transit stops (departure → changeover → arrival) render as a single transport entry with ticket cards per leg. This grouping is handled by `buildPlanningTimeline`.
 
+**Calling points** — intermediate stations parsed from Trainline PDF etickets. Stored in stop metadata as `calling_points` (with lat/lng resolved from transport_hubs at insert time). Rendered on the `TrainTicketCard` as a subtle strip (time, dot, station code) between station names and ticket details. On the JourneyMap, calling points populate `Leg.waypoints` and render as small gold-bordered markers (5px) along the rail line.
+
 **TransitionMeta** — below each transition row, shows computed duration, distance in miles, and a feasibility badge (tight/infeasible) when travel time doesn't fit between two time-fixed stops.
 
 **Stopovers with back-calc** — the planning page computes the available window for stopovers based on surrounding anchors' times and leg transition durations. Shows "fits", "tight", or "infeasible" status.

--- a/src/app/(app)/itineraries/[id]/gmail-import-panel.tsx
+++ b/src/app/(app)/itineraries/[id]/gmail-import-panel.tsx
@@ -53,6 +53,7 @@ function TransportBookingCard({
     seat: seg.seat,
     barcode_ref: seg.barcode_ref,
     barcode_data: seg.barcode_data,
+    calling_points: seg.calling_points ?? null,
   }));
 
   return (
@@ -251,6 +252,7 @@ export function GmailImportPanel({
       seat: seg.seat ?? null,
       barcode_ref: seg.barcode_ref ?? null,
       barcode_data: seg.barcode_data ?? null,
+      calling_points: seg.calling_points ?? null,
     }));
 
     const result = await attachTransportBookingToStop({

--- a/src/app/(app)/itineraries/[id]/itinerary-editor.tsx
+++ b/src/app/(app)/itineraries/[id]/itinerary-editor.tsx
@@ -20,10 +20,11 @@ import {
   updateStop,
 } from "@/lib/actions/stops";
 import {
-  insertTransitLeg,
   upsertTransition,
   setTransitionMode,
 } from "@/lib/actions/transitions";
+import { addFullTransportBooking } from "@/lib/actions/bookings";
+import { reEnrichItineraryFromGmail } from "@/lib/actions/gmail";
 import { transitionItineraryStatus } from "@/lib/actions/itineraries";
 import type { InitialPreviewSeed } from "@/components/itinerary/use-route-preview";
 import { checkLegFeasibility } from "@/lib/feasibility/check";
@@ -296,8 +297,7 @@ export function ItineraryEditor({
     });
   };
   const submitTransportBooking = (b: BriefTransportBooking) => {
-    const lastStop = sortedStops[sortedStops.length - 1];
-    if (!lastStop || !b.departureHub.id || !b.destinationHub.id) return;
+    if (!b.departureHub.id || !b.destinationHub.id) return;
     const departIso = b.date && b.departTime
       ? new Date(`${b.date}T${b.departTime}`).toISOString()
       : new Date().toISOString();
@@ -306,10 +306,8 @@ export function ItineraryEditor({
       : new Date().toISOString();
     startTransition(async () => {
       setError(null);
-      const result = await insertTransitLeg({
+      const result = await addFullTransportBooking({
         itinerary_id: itinerary.id,
-        before_stop_id: lastStop.id,
-        after_stop_id: null,
         mode: b.mode ?? "train",
         depart_hub_id: b.departureHub.id!,
         depart_label: b.departureHub.label ?? "Departure",
@@ -317,7 +315,23 @@ export function ItineraryEditor({
         arrive_hub_id: b.destinationHub.id!,
         arrive_label: b.destinationHub.label ?? "Arrival",
         arrive_time: arriveIso,
+        changeovers: b.changeovers
+          .filter((co) => co.hub.id || co.hub.label)
+          .map((co) => ({
+            hub_id: co.hub.id,
+            hub_label: co.hub.label ?? "Changeover",
+            arrive_time: co.arriveTime ? new Date(`${b.date}T${co.arriveTime}`).toISOString() : departIso,
+            depart_time: co.departTime ? new Date(`${b.date}T${co.departTime}`).toISOString() : departIso,
+          })),
         service_number: b.serviceNumber?.trim() || null,
+        reference: b.reference?.trim() || null,
+        seat: b.seat?.trim() || null,
+        price: b.price ? Number(b.price) : null,
+        operator: b.operator,
+        ticket_type: b.ticketType,
+        route_restriction: b.routeRestriction,
+        barcodes: b.barcodes,
+        segment_calling_points: b.segmentCallingPoints,
       });
       if (!result.ok) {
         setError(feedbackFromError(result.error).message);
@@ -1256,16 +1270,37 @@ export function ItineraryEditor({
             + Accommodation
           </button>
           {gmailConnected ? (
-            <button
-              type="button"
-              className="btn-ghost"
-              style={{ fontSize: 12, display: "inline-flex", alignItems: "center", gap: 6 }}
-              onClick={() => setGmailImportOpen(true)}
-              disabled={pending}
-            >
-              {Icon.ticket}
-              Scan for tickets
-            </button>
+            <>
+              <button
+                type="button"
+                className="btn-ghost"
+                style={{ fontSize: 12, display: "inline-flex", alignItems: "center", gap: 6 }}
+                onClick={() => setGmailImportOpen(true)}
+                disabled={pending}
+              >
+                {Icon.ticket}
+                Scan for tickets
+              </button>
+              <button
+                type="button"
+                className="btn-ghost"
+                style={{ fontSize: 12 }}
+                onClick={() => {
+                  startTransition(async () => {
+                    setError(null);
+                    const result = await reEnrichItineraryFromGmail(itinerary.id);
+                    if (!result.ok) {
+                      setError(feedbackFromError(result.error).message);
+                      return;
+                    }
+                    if (result.value.enriched > 0) router.refresh();
+                  });
+                }}
+                disabled={pending}
+              >
+                Refresh ticket details
+              </button>
+            </>
           ) : null}
           <span style={{ marginLeft: "auto" }}>
             <DeleteItineraryButton

--- a/src/app/(app)/itineraries/[id]/itinerary-editor.tsx
+++ b/src/app/(app)/itineraries/[id]/itinerary-editor.tsx
@@ -1082,6 +1082,25 @@ export function ItineraryEditor({
       const durationMins = transition.computed_duration_minutes ?? 0;
       const durationLabel = durationMins > 0 ? fmtDuration(durationMins) : "";
 
+      // Extract calling points from stop metadata as map waypoints
+      const meta = fromStop.metadata as Record<string, unknown> | null;
+      const rawCps = meta?.calling_points;
+      const waypoints: Station[] = [];
+      if (Array.isArray(rawCps)) {
+        for (const cp of rawCps) {
+          const cpLat = Number(cp.lat);
+          const cpLng = Number(cp.lng);
+          if (cpLat && cpLng) {
+            waypoints.push({
+              name: cp.station ?? "",
+              code: cp.station_code ?? undefined,
+              lat: cpLat,
+              lng: cpLng,
+            });
+          }
+        }
+      }
+
       legs.push({
         mode: legMode,
         from: fromStation,
@@ -1089,6 +1108,7 @@ export function ItineraryEditor({
         track,
         durationLabel,
         durationMinutes: durationMins || undefined,
+        ...(waypoints.length > 0 ? { waypoints } : {}),
       });
     }
 

--- a/src/app/(app)/itineraries/[id]/itinerary-editor.tsx
+++ b/src/app/(app)/itineraries/[id]/itinerary-editor.tsx
@@ -22,6 +22,7 @@ import {
 import {
   upsertTransition,
   setTransitionMode,
+  backfillRailPolylines,
 } from "@/lib/actions/transitions";
 import { addFullTransportBooking } from "@/lib/actions/bookings";
 import { reEnrichItineraryFromGmail } from "@/lib/actions/gmail";
@@ -285,6 +286,7 @@ export function ItineraryEditor({
   // the card renders in a modal. On "Done" (confirmed: true), we call
   // the server action and dismiss.
   const [editingTransport, setEditingTransport] = useState<BriefTransportBooking | null>(null);
+  const [mapExpanded, setMapExpanded] = useState(false);
   const handleTransportCardChange = (patch: Partial<BriefTransportBooking>) => {
     setEditingTransport((prev) => {
       if (!prev) return prev;
@@ -1293,7 +1295,8 @@ export function ItineraryEditor({
                       setError(feedbackFromError(result.error).message);
                       return;
                     }
-                    if (result.value.enriched > 0) router.refresh();
+                    await backfillRailPolylines(itinerary.id, true);
+                    router.refresh();
                   });
                 }}
                 disabled={pending}
@@ -1504,7 +1507,7 @@ export function ItineraryEditor({
           {/* Right: map + day digest */}
           <aside className="flex flex-col gap-5">
             {journeyMapData && journeyMapData.legs.length > 0 ? (
-              <div className="route-map-card">
+              <div className={`route-map-card${mapExpanded ? " map-expanded" : ""}`}>
                 <div className="route-map-header">
                   <span className="route-map-eyebrow">Door-to-door</span>
                   <span className="route-map-headline">
@@ -1512,12 +1515,28 @@ export function ItineraryEditor({
                     {totalMiles > 0 && totalMinutes > 0 && " · "}
                     {totalMinutes > 0 && <>{fmtDuration(totalMinutes)}</>}
                   </span>
+                  <button
+                    type="button"
+                    className="map-expand-btn"
+                    onClick={() => setMapExpanded((v) => !v)}
+                    title={mapExpanded ? "Collapse map" : "Expand map"}
+                  >
+                    {mapExpanded ? (
+                      <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                        <path d="M10 2v4h4M2 10h4v4M14 2l-4 4M2 14l4-4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+                      </svg>
+                    ) : (
+                      <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                        <path d="M10 2v4h4M2 10h4v4M6 6L2 2M10 10l4 4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+                      </svg>
+                    )}
+                  </button>
                 </div>
-                <div style={{ borderRadius: "0 0 12px 12px", overflow: "hidden" }}>
+                <div style={{ borderRadius: "0 0 12px 12px", overflow: "hidden", flex: mapExpanded ? 1 : undefined }}>
                   <JourneyMap
                     journey={journeyMapData}
                     mode="planning"
-                    height={320}
+                    height={mapExpanded ? undefined : 320}
                   />
                 </div>
               </div>

--- a/src/app/(app)/itineraries/new/new-itinerary-form.tsx
+++ b/src/app/(app)/itineraries/new/new-itinerary-form.tsx
@@ -311,6 +311,13 @@ export function NewItineraryBrief({
             ref: seg.barcode_ref ?? null,
             data: seg.barcode_data ?? null,
           })),
+          segmentCallingPoints: legs.map((seg) =>
+            (seg.calling_points ?? []).map((cp) => ({
+              station: cp.station,
+              station_code: cp.station_code ?? null,
+              time: cp.time,
+            })),
+          ),
         };
       };
 
@@ -786,6 +793,7 @@ export function NewItineraryBrief({
             ticket_type: tb.ticketType || null,
             route_restriction: tb.routeRestriction || null,
             barcodes: tb.barcodes,
+            segment_calling_points: tb.segmentCallingPoints,
           })),
         accommodation_bookings: accommodationBookings
           .filter((ab) => ab.hotel != null || ab.checkInDate)

--- a/src/app/(app)/settings/rail-routes/page.tsx
+++ b/src/app/(app)/settings/rail-routes/page.tsx
@@ -1,0 +1,21 @@
+import { redirect } from "next/navigation";
+import { PageShell } from "@/components/ui/page-shell";
+import { requireUserContext } from "@/lib/auth";
+import { getRouteSegmentStats } from "@/lib/actions/rail-network";
+import { RailRouteSeeder } from "./rail-route-seeder";
+
+export default async function RailRoutesPage() {
+  const ctx = await requireUserContext();
+  if (!ctx.isAdmin) redirect("/settings");
+
+  const stats = await getRouteSegmentStats();
+
+  return (
+    <PageShell
+      title="Rail Route Relations"
+      description="Upload an Overpass JSON export of OSM train route relations. Extracts station-to-station polylines from named routes — no algorithmic routing needed."
+    >
+      <RailRouteSeeder initialCount={stats?.count ?? 0} />
+    </PageShell>
+  );
+}

--- a/src/app/(app)/settings/rail-routes/rail-route-seeder.tsx
+++ b/src/app/(app)/settings/rail-routes/rail-route-seeder.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useState, useRef } from "react";
-import { seedRouteSegments, clearRouteSegments, type RouteSegment } from "@/lib/actions/rail-network";
-import { searchTransportHubs } from "@/lib/actions/travel-profile";
+import { seedRouteSegments, clearRouteSegments, getAllRailStationCodes, type RouteSegment } from "@/lib/actions/rail-network";
 
 type OsmNode = { type: "node"; id: number; lat: number; lon: number; tags?: Record<string, string> };
 type OsmWay = { type: "way"; id: number; nodes: number[]; tags?: Record<string, string> };
@@ -166,24 +165,12 @@ export function RailRouteSeeder({ initialCount }: { initialCount: number }) {
 
       setStatus(`Resolving station codes for ${allSegments.length} segments...`);
 
-      const nameToCode = new Map<string, string>();
-      const uniqueNames = [...new Set(allSegments.flatMap((s) => [s.from_station_name, s.to_station_name]))];
-      for (const name of uniqueNames) {
-        if (nameToCode.has(name)) continue;
-        try {
-          const result = await searchTransportHubs({ query: name, kind: "rail_station" });
-          if (result.ok && result.value.length > 0) {
-            const match = result.value.find(
-              (h) => h.name.toLowerCase() === name.toLowerCase(),
-            ) ?? result.value[0];
-            if (match.code) nameToCode.set(name, match.code);
-          }
-        } catch { /* best effort */ }
-      }
+      const rawMap = await getAllRailStationCodes() as unknown as Record<string, string>;
+      const nameToCode = new Map<string, string>(Object.entries(rawMap));
 
       for (const seg of allSegments) {
-        seg.from_station_code = nameToCode.get(seg.from_station_name) ?? null;
-        seg.to_station_code = nameToCode.get(seg.to_station_name) ?? null;
+        seg.from_station_code = nameToCode.get(seg.from_station_name.toLowerCase()) ?? null;
+        seg.to_station_code = nameToCode.get(seg.to_station_name.toLowerCase()) ?? null;
       }
 
       const withCodes = allSegments.filter((s) => s.from_station_code && s.to_station_code);

--- a/src/app/(app)/settings/rail-routes/rail-route-seeder.tsx
+++ b/src/app/(app)/settings/rail-routes/rail-route-seeder.tsx
@@ -1,0 +1,333 @@
+"use client";
+
+import { useState, useRef } from "react";
+import { seedRouteSegments, clearRouteSegments, type RouteSegment } from "@/lib/actions/rail-network";
+import { searchTransportHubs } from "@/lib/actions/travel-profile";
+
+type OsmNode = { type: "node"; id: number; lat: number; lon: number; tags?: Record<string, string> };
+type OsmWay = { type: "way"; id: number; nodes: number[]; tags?: Record<string, string> };
+type OsmRelation = {
+  type: "relation";
+  id: number;
+  tags?: Record<string, string>;
+  members: Array<{ type: string; ref: number; role: string }>;
+};
+type OsmElement = OsmNode | OsmWay | OsmRelation;
+
+type StationMatch = {
+  osmNodeId: number;
+  name: string;
+  code: string | null;
+  lat: number;
+  lon: number;
+  positionOnRoute: number;
+};
+
+export function RailRouteSeeder({ initialCount }: { initialCount: number }) {
+  const [status, setStatus] = useState<string>(
+    initialCount > 0 ? `${initialCount} route segments stored` : "No route segments yet",
+  );
+  const [processing, setProcessing] = useState(false);
+  const [segments, setSegments] = useState<RouteSegment[]>([]);
+  const [seeded, setSeeded] = useState(0);
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setProcessing(true);
+    setStatus("Reading file...");
+
+    try {
+      const text = await file.text();
+      setStatus("Parsing JSON...");
+      const data = JSON.parse(text) as { elements: OsmElement[] };
+
+      const nodeMap = new Map<number, { lat: number; lon: number }>();
+      const wayMap = new Map<number, number[]>();
+      const relations: OsmRelation[] = [];
+
+      for (const el of data.elements) {
+        if (el.type === "node") nodeMap.set(el.id, { lat: el.lat, lon: el.lon });
+        else if (el.type === "way") wayMap.set(el.id, el.nodes);
+        else if (el.type === "relation") relations.push(el);
+      }
+
+      setStatus(`Parsed ${nodeMap.size} nodes, ${wayMap.size} ways, ${relations.length} relations. Processing routes...`);
+
+      const allSegments: RouteSegment[] = [];
+      let processed = 0;
+
+      for (const rel of relations) {
+        const tags = rel.tags ?? {};
+        if (tags.type !== "route" || tags.route !== "train") continue;
+
+        const routeName = tags.name ?? tags.ref ?? `Relation ${rel.id}`;
+        const operator = tags.operator ?? null;
+
+        const wayMembers = rel.members.filter((m) => m.type === "way");
+        const stopMembers = rel.members.filter(
+          (m) => m.type === "node" && (m.role.includes("stop") || m.role === ""),
+        );
+
+        if (wayMembers.length === 0) continue;
+
+        const routePoints: Array<{ lat: number; lon: number }> = [];
+        const usedWayIds = new Set<number>();
+
+        for (const wm of wayMembers) {
+          const nodeIds = wayMap.get(wm.ref);
+          if (!nodeIds) continue;
+          if (usedWayIds.has(wm.ref)) continue;
+          usedWayIds.add(wm.ref);
+
+          const wayPts: Array<{ lat: number; lon: number }> = [];
+          for (const nid of nodeIds) {
+            const nd = nodeMap.get(nid);
+            if (nd) wayPts.push(nd);
+          }
+          if (wayPts.length === 0) continue;
+
+          if (routePoints.length > 0 && wayPts.length > 0) {
+            const last = routePoints[routePoints.length - 1];
+            const distToFirst = sqDist(last, wayPts[0]);
+            const distToLast = sqDist(last, wayPts[wayPts.length - 1]);
+            if (distToLast < distToFirst) wayPts.reverse();
+            wayPts.shift();
+          }
+          routePoints.push(...wayPts);
+        }
+
+        if (routePoints.length < 2) continue;
+
+        const stations: StationMatch[] = [];
+        for (const sm of stopMembers) {
+          const nd = nodeMap.get(sm.ref);
+          if (!nd) continue;
+          const nodeTags = data.elements.find(
+            (el) => el.type === "node" && el.id === sm.ref,
+          ) as OsmNode | undefined;
+          const name = nodeTags?.tags?.name ?? `Node ${sm.ref}`;
+
+          let bestIdx = 0;
+          let bestDist = Infinity;
+          for (let i = 0; i < routePoints.length; i++) {
+            const d = sqDist(nd, routePoints[i]);
+            if (d < bestDist) { bestDist = d; bestIdx = i; }
+          }
+
+          stations.push({
+            osmNodeId: sm.ref,
+            name,
+            code: null,
+            lat: nd.lat,
+            lon: nd.lon,
+            positionOnRoute: bestIdx,
+          });
+        }
+
+        stations.sort((a, b) => a.positionOnRoute - b.positionOnRoute);
+        const uniqueStations = stations.filter(
+          (s, i) => i === 0 || s.positionOnRoute !== stations[i - 1].positionOnRoute,
+        );
+
+        if (uniqueStations.length < 2) continue;
+
+        for (let i = 0; i < uniqueStations.length - 1; i++) {
+          const from = uniqueStations[i];
+          const to = uniqueStations[i + 1];
+          const startIdx = from.positionOnRoute;
+          const endIdx = to.positionOnRoute;
+          if (endIdx <= startIdx) continue;
+
+          const segPts = routePoints.slice(startIdx, endIdx + 1);
+          if (segPts.length < 2) continue;
+
+          const encoded = googleEncodePolyline(segPts);
+          allSegments.push({
+            osm_relation_id: rel.id,
+            route_name: routeName,
+            operator,
+            from_station_name: from.name,
+            to_station_name: to.name,
+            from_station_code: null,
+            to_station_code: null,
+            encoded_polyline: encoded,
+            point_count: segPts.length,
+          });
+        }
+
+        processed++;
+        if (processed % 10 === 0) {
+          setStatus(`Processed ${processed}/${relations.length} relations, ${allSegments.length} segments...`);
+        }
+      }
+
+      setStatus(`Resolving station codes for ${allSegments.length} segments...`);
+
+      const nameToCode = new Map<string, string>();
+      const uniqueNames = [...new Set(allSegments.flatMap((s) => [s.from_station_name, s.to_station_name]))];
+      for (const name of uniqueNames) {
+        if (nameToCode.has(name)) continue;
+        try {
+          const result = await searchTransportHubs({ query: name, kind: "rail_station" });
+          if (result.ok && result.value.length > 0) {
+            const match = result.value.find(
+              (h) => h.name.toLowerCase() === name.toLowerCase(),
+            ) ?? result.value[0];
+            if (match.code) nameToCode.set(name, match.code);
+          }
+        } catch { /* best effort */ }
+      }
+
+      for (const seg of allSegments) {
+        seg.from_station_code = nameToCode.get(seg.from_station_name) ?? null;
+        seg.to_station_code = nameToCode.get(seg.to_station_name) ?? null;
+      }
+
+      const withCodes = allSegments.filter((s) => s.from_station_code && s.to_station_code);
+      setSegments(withCodes);
+      setStatus(`Ready: ${withCodes.length} segments with station codes (${allSegments.length - withCodes.length} skipped — no code match). Click Seed to store.`);
+    } catch (err) {
+      setStatus(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setProcessing(false);
+    }
+  };
+
+  const handleSeed = async () => {
+    if (segments.length === 0) return;
+    setProcessing(true);
+    setSeeded(0);
+
+    const chunkSize = 50;
+    let total = 0;
+    for (let i = 0; i < segments.length; i += chunkSize) {
+      const chunk = segments.slice(i, i + chunkSize);
+      try {
+        const result = await seedRouteSegments(chunk);
+        total += result.inserted;
+        setSeeded(total);
+        setStatus(`Seeded ${total}/${segments.length}...`);
+      } catch (err) {
+        setStatus(`Error at chunk ${i}: ${err instanceof Error ? err.message : String(err)}`);
+        break;
+      }
+    }
+
+    setStatus(`Done: ${total} route segments stored.`);
+    setProcessing(false);
+  };
+
+  const handleClear = async () => {
+    setProcessing(true);
+    try {
+      await clearRouteSegments();
+      setStatus("Cleared all route segments.");
+      setSegments([]);
+      setSeeded(0);
+    } catch (err) {
+      setStatus(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    setProcessing(false);
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <p className="small" style={{ color: "var(--ink-dim)" }}>{status}</p>
+
+      <div className="flex gap-3 flex-wrap">
+        <label
+          className="btn-ghost"
+          style={{ cursor: processing ? "wait" : "pointer", fontSize: 13 }}
+        >
+          Upload Overpass JSON
+          <input
+            ref={fileRef}
+            type="file"
+            accept=".json"
+            onChange={handleFile}
+            disabled={processing}
+            style={{ display: "none" }}
+          />
+        </label>
+
+        {segments.length > 0 && (
+          <button
+            className="btn-primary"
+            onClick={handleSeed}
+            disabled={processing}
+            style={{ fontSize: 13 }}
+          >
+            Seed {segments.length} segments
+          </button>
+        )}
+
+        <button
+          className="btn-ghost"
+          onClick={handleClear}
+          disabled={processing}
+          style={{ fontSize: 13, color: "var(--rust)" }}
+        >
+          Clear all
+        </button>
+      </div>
+
+      {segments.length > 0 && (
+        <div style={{ maxHeight: 300, overflow: "auto", fontSize: 12, color: "var(--ink-dim)" }}>
+          <table style={{ width: "100%", borderCollapse: "collapse" }}>
+            <thead>
+              <tr style={{ textAlign: "left", borderBottom: "1px solid var(--rule)" }}>
+                <th style={{ padding: "4px 8px" }}>From</th>
+                <th style={{ padding: "4px 8px" }}>To</th>
+                <th style={{ padding: "4px 8px" }}>Route</th>
+                <th style={{ padding: "4px 8px" }}>Points</th>
+              </tr>
+            </thead>
+            <tbody>
+              {segments.slice(0, 100).map((s, i) => (
+                <tr key={i} style={{ borderBottom: "1px solid var(--rule-2)" }}>
+                  <td style={{ padding: "3px 8px" }}>{s.from_station_code} {s.from_station_name}</td>
+                  <td style={{ padding: "3px 8px" }}>{s.to_station_code} {s.to_station_name}</td>
+                  <td style={{ padding: "3px 8px" }}>{s.route_name}</td>
+                  <td style={{ padding: "3px 8px" }}>{s.point_count}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function sqDist(a: { lat: number; lon: number }, b: { lat: number; lon: number }): number {
+  return (a.lat - b.lat) ** 2 + (a.lon - b.lon) ** 2;
+}
+
+function googleEncodePolyline(points: Array<{ lat: number; lon: number }>): string {
+  let encoded = "";
+  let prevLat = 0;
+  let prevLng = 0;
+  for (const { lat, lon } of points) {
+    const latE5 = Math.round(lat * 1e5);
+    const lngE5 = Math.round(lon * 1e5);
+    encoded += encVal(latE5 - prevLat);
+    encoded += encVal(lngE5 - prevLng);
+    prevLat = latE5;
+    prevLng = lngE5;
+  }
+  return encoded;
+}
+
+function encVal(value: number): string {
+  let v = value < 0 ? ~(value << 1) : value << 1;
+  let out = "";
+  while (v >= 0x20) {
+    out += String.fromCharCode((0x20 | (v & 0x1f)) + 63);
+    v >>= 5;
+  }
+  out += String.fromCharCode(v + 63);
+  return out;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3618,6 +3618,41 @@
 
 .route-map-header {
   padding: 20px 22px 14px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 8px;
+}
+.route-map-header .route-map-eyebrow { width: 100%; }
+
+.map-expand-btn {
+  display: none;
+  margin-left: auto;
+  background: none;
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  padding: 4px 6px;
+  cursor: pointer;
+  color: var(--ink-dim);
+  line-height: 0;
+  transition: color 0.15s, border-color 0.15s;
+}
+.map-expand-btn:hover { color: var(--ink); border-color: var(--ink-faint); }
+@media (min-width: 1024px) {
+  .map-expand-btn { display: inline-flex; }
+  .route-map-card.map-expanded {
+    position: fixed;
+    inset: 24px;
+    z-index: 40;
+    border-radius: 14px;
+    display: flex;
+    flex-direction: column;
+  }
+  .route-map-card.map-expanded .route-map-header { flex-shrink: 0; }
+  .route-map-card.map-expanded > div:last-child {
+    flex: 1;
+    border-radius: 0 0 12px 12px;
+  }
 }
 
 .route-map-eyebrow {

--- a/src/components/itinerary/build-planning-timeline.ts
+++ b/src/components/itinerary/build-planning-timeline.ts
@@ -436,6 +436,8 @@ function buildTransitGroup(
     const from = groupStops[j];
     const to = groupStops[j + 1];
     const fromMeta = from.stop.metadata as Record<string, unknown> | null;
+    const rawCp = fromMeta?.calling_points;
+    const callingPoints = Array.isArray(rawCp) ? rawCp as Array<{ station: string; station_code: string | null; time: string }> : null;
     legs.push({
       from_station: from.stop.title ?? "?",
       to_station: to.stop.title ?? "?",
@@ -452,6 +454,7 @@ function buildTransitGroup(
       barcode_ref: (fromMeta?.barcode_ref as string) ?? (fromMeta?.booking_reference as string) ?? null,
       barcode_data: (fromMeta?.barcode_data as string) ?? null,
       price: (fromMeta?.price as number) ?? null,
+      calling_points: callingPoints,
     });
   }
 

--- a/src/components/itinerary/journey-spine.tsx
+++ b/src/components/itinerary/journey-spine.tsx
@@ -503,6 +503,17 @@ function SpineTransportBooking({
             {tb.departTime ? ` · ${tb.departTime}` : ""}
             {tb.arriveTime ? ` → ${tb.arriveTime}` : ""}
           </p>
+          {(() => {
+            const allCps = (tb.segmentCallingPoints ?? []).flat();
+            if (allCps.length === 0) return null;
+            const names = allCps.map((cp) => cp.station_code ?? cp.station);
+            const summary = names.length <= 3 ? names.join(", ") : `${names.slice(0, 2).join(", ")} +${names.length - 2} more`;
+            return (
+              <p className="tl-sub" style={{ marginTop: 2, fontSize: 10, color: "var(--ink-faint)" }}>
+                calling at {summary}
+              </p>
+            );
+          })()}
         </button>
         {expanded ? (
           <div style={{ marginTop: 6, display: "flex", flexDirection: "column", gap: 6 }}>
@@ -524,6 +535,7 @@ function buildSpineTicketSegments(tb: BriefTransportBooking): TicketSegment[] {
 
   if (tb.changeovers.length === 0) {
     const bc = tb.barcodes[0];
+    const cp = tb.segmentCallingPoints?.[0];
     return [{
       from_station: tb.departureHub?.label ?? "?",
       to_station: tb.destinationHub?.label ?? "?",
@@ -540,6 +552,7 @@ function buildSpineTicketSegments(tb: BriefTransportBooking): TicketSegment[] {
       barcode_ref: bc?.ref ?? (tb.reference || null),
       barcode_data: bc?.data ?? null,
       price: tb.price ? Number(tb.price) : null,
+      calling_points: cp && cp.length > 0 ? cp : null,
     }];
   }
 
@@ -551,6 +564,7 @@ function buildSpineTicketSegments(tb: BriefTransportBooking): TicketSegment[] {
   ];
   for (let i = 0; i < stops.length - 1; i++) {
     const bc = tb.barcodes[i];
+    const cp = tb.segmentCallingPoints?.[i];
     segments.push({
       from_station: stops[i].label,
       to_station: stops[i + 1].label,
@@ -567,6 +581,7 @@ function buildSpineTicketSegments(tb: BriefTransportBooking): TicketSegment[] {
       barcode_ref: bc?.ref ?? null,
       barcode_data: bc?.data ?? null,
       price: i === 0 && tb.price ? Number(tb.price) : null,
+      calling_points: cp && cp.length > 0 ? cp : null,
     });
   }
   return segments;

--- a/src/components/itinerary/transport-booking-card.tsx
+++ b/src/components/itinerary/transport-booking-card.tsx
@@ -36,6 +36,12 @@ export type SegmentBarcode = {
   data: string | null;
 };
 
+export type SegmentCallingPoint = {
+  station: string;
+  station_code: string | null;
+  time: string;
+};
+
 export type BookingSource = "manual" | "imported" | "suggested" | "booked";
 
 export type BriefTransportBooking = {
@@ -57,6 +63,7 @@ export type BriefTransportBooking = {
   ticketType: string | null;
   routeRestriction: string | null;
   barcodes: SegmentBarcode[];
+  segmentCallingPoints: SegmentCallingPoint[][];
 };
 
 export function emptyTransportBookingItem(): BriefTransportBooking {
@@ -79,6 +86,7 @@ export function emptyTransportBookingItem(): BriefTransportBooking {
     ticketType: null,
     routeRestriction: null,
     barcodes: [],
+    segmentCallingPoints: [],
   };
 }
 
@@ -105,6 +113,7 @@ export function returnTransportBooking(
     ticketType: from.ticketType,
     routeRestriction: from.routeRestriction,
     barcodes: [],
+    segmentCallingPoints: [],
   };
 }
 

--- a/src/components/journey-map/journey-map.tsx
+++ b/src/components/journey-map/journey-map.tsx
@@ -32,12 +32,21 @@ export function JourneyMap({
 
   const stations = useMemo(() => {
     const seen = new Set<string>();
-    const out: Array<{ lat: number; lng: number; label: string; role: "origin" | "destination" | "intermediate" }> = [];
+    const out: Array<{ lat: number; lng: number; label: string; role: "origin" | "destination" | "intermediate" | "waypoint" }> = [];
     journey.legs.forEach((leg, i) => {
       const fk = `${leg.from.lat.toFixed(4)},${leg.from.lng.toFixed(4)}`;
       if (!seen.has(fk)) {
         seen.add(fk);
         out.push({ lat: leg.from.lat, lng: leg.from.lng, label: leg.from.code ?? leg.from.name, role: i === 0 ? "origin" : "intermediate" });
+      }
+      if (leg.waypoints) {
+        for (const wp of leg.waypoints) {
+          const wk = `${wp.lat.toFixed(4)},${wp.lng.toFixed(4)}`;
+          if (!seen.has(wk)) {
+            seen.add(wk);
+            out.push({ lat: wp.lat, lng: wp.lng, label: wp.code ?? wp.name, role: "waypoint" });
+          }
+        }
       }
       const tk = `${leg.to.lat.toFixed(4)},${leg.to.lng.toFixed(4)}`;
       if (!seen.has(tk)) {
@@ -184,11 +193,11 @@ function createMarkerEl(role: string, label: string, theme: JourneyTheme): HTMLE
   const el = document.createElement("div");
   el.style.display = "flex";
   el.style.alignItems = "center";
-  el.style.gap = "5px";
+  el.style.gap = role === "waypoint" ? "3px" : "5px";
   el.style.pointerEvents = "none";
 
   const dot = document.createElement("div");
-  const sz = role === "origin" ? 12 : role === "destination" ? 10 : 8;
+  const sz = role === "origin" ? 12 : role === "destination" ? 10 : role === "waypoint" ? 5 : 8;
   dot.style.width = `${sz}px`;
   dot.style.height = `${sz}px`;
   dot.style.borderRadius = "50%";
@@ -210,6 +219,9 @@ function createMarkerEl(role: string, label: string, theme: JourneyTheme): HTMLE
     dot.appendChild(inner);
   } else if (role === "destination") {
     dot.style.background = theme.colors.markerFill;
+  } else if (role === "waypoint") {
+    dot.style.background = theme.colors.labelHalo;
+    dot.style.border = `1px solid ${theme.colors.gold}`;
   } else {
     dot.style.background = theme.colors.labelHalo;
     dot.style.border = `1.5px solid ${theme.colors.markerFill}`;
@@ -218,10 +230,11 @@ function createMarkerEl(role: string, label: string, theme: JourneyTheme): HTMLE
   const lbl = document.createElement("span");
   lbl.textContent = label.toUpperCase();
   lbl.style.fontFamily = theme.fonts.mono;
-  lbl.style.fontSize = "9px";
+  lbl.style.fontSize = role === "waypoint" ? "7.5px" : "9px";
   lbl.style.letterSpacing = "0.06em";
   lbl.style.color = theme.colors.labelText;
   lbl.style.whiteSpace = "nowrap";
+  if (role === "waypoint") lbl.style.opacity = "0.7";
 
   el.appendChild(dot);
   el.appendChild(lbl);

--- a/src/components/journey-map/journey-map.tsx
+++ b/src/components/journey-map/journey-map.tsx
@@ -41,6 +41,7 @@ export function JourneyMap({
       }
       if (leg.waypoints) {
         for (const wp of leg.waypoints) {
+          if (!wp.lat || !wp.lng) continue;
           const wk = `${wp.lat.toFixed(4)},${wp.lng.toFixed(4)}`;
           if (!seen.has(wk)) {
             seen.add(wk);

--- a/src/components/train-ticket-card.tsx
+++ b/src/components/train-ticket-card.tsx
@@ -2,6 +2,12 @@
 
 import { useState } from "react";
 
+export type TicketCallingPoint = {
+  station: string;
+  station_code: string | null;
+  time: string;
+};
+
 export type TicketSegment = {
   from_station: string;
   to_station: string;
@@ -18,6 +24,7 @@ export type TicketSegment = {
   barcode_ref: string | null;
   barcode_data: string | null;
   price?: number | null;
+  calling_points?: TicketCallingPoint[] | null;
 };
 
 function formatDate(iso: string): string {
@@ -110,6 +117,11 @@ export function TrainTicketCard({
           </div>
         </div>
       </div>
+
+      {/* Calling points */}
+      {segment.calling_points && segment.calling_points.length > 0 && (
+        <CallingPointsStrip points={segment.calling_points} />
+      )}
 
       {/* Ticket details row */}
       <div
@@ -214,6 +226,92 @@ export function TrainTicketCard({
           </span>
         </div>
       )}
+    </div>
+  );
+}
+
+function CallingPointsStrip({ points }: { points: TicketCallingPoint[] }) {
+  return (
+    <div
+      style={{
+        padding: "6px 14px 2px",
+        display: "flex",
+        alignItems: "center",
+        gap: 0,
+        overflow: "hidden",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 0,
+          flex: 1,
+          position: "relative",
+        }}
+      >
+        {/* Connecting line */}
+        <div
+          style={{
+            position: "absolute",
+            top: "50%",
+            left: 0,
+            right: 0,
+            height: 1,
+            background: "var(--rule)",
+            transform: "translateY(-50%)",
+          }}
+        />
+        {points.map((pt, i) => (
+          <div
+            key={i}
+            style={{
+              flex: 1,
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              position: "relative",
+              zIndex: 1,
+            }}
+          >
+            <span
+              style={{
+                fontSize: 8.5,
+                fontFamily: "var(--mono)",
+                color: "var(--ink-faint)",
+                letterSpacing: "0.04em",
+                marginBottom: 3,
+                whiteSpace: "nowrap",
+              }}
+            >
+              {pt.time}
+            </span>
+            <div
+              style={{
+                width: 5,
+                height: 5,
+                borderRadius: "50%",
+                border: "1px solid var(--ink-faint)",
+                background: "var(--card)",
+                flexShrink: 0,
+              }}
+            />
+            <span
+              style={{
+                fontSize: 8,
+                fontFamily: "var(--mono)",
+                color: "var(--ink-faint)",
+                letterSpacing: "0.04em",
+                marginTop: 3,
+                whiteSpace: "nowrap",
+                textTransform: "uppercase",
+              }}
+            >
+              {pt.station_code ?? pt.station}
+            </span>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/lib/actions/bookings.ts
+++ b/src/lib/actions/bookings.ts
@@ -1146,7 +1146,8 @@ export async function addFullTransportBooking(
     const { data: hubs } = await supabase
       .from("transport_hubs")
       .select("code, latitude, longitude")
-      .in("code", [...allCpCodes]);
+      .in("code", [...allCpCodes])
+      .eq("kind", "rail_station");
     for (const h of hubs ?? []) {
       if (h.latitude && h.longitude) {
         cpCoords.set(h.code, { lat: Number(h.latitude), lng: Number(h.longitude) });

--- a/src/lib/actions/bookings.ts
+++ b/src/lib/actions/bookings.ts
@@ -1076,3 +1076,292 @@ export async function recordTravelBooking(
   }
   return result;
 }
+
+// ── addFullTransportBooking ──────────────────────────────────────────
+// Creates a full transport booking on an existing itinerary: departure
+// stop, changeover stops, arrival stop, locked transitions, booking
+// entities, segments — everything. Used by the planning page's
+// "+ Transport" flow and as the foundation for adding bookings outside
+// the brief.
+
+const addFullTransportBookingSchema = z.object({
+  itinerary_id: z.string().uuid(),
+  mode: z.enum(["train", "flight", "taxi", "bus", "tube", "drive"]),
+  depart_hub_id: z.string().uuid(),
+  depart_label: z.string().trim().max(200),
+  depart_time: z.string().datetime(),
+  arrive_hub_id: z.string().uuid(),
+  arrive_label: z.string().trim().max(200),
+  arrive_time: z.string().datetime(),
+  changeovers: z.array(z.object({
+    hub_id: z.string().uuid().nullable().optional(),
+    hub_label: z.string().max(200),
+    arrive_time: z.string().datetime(),
+    depart_time: z.string().datetime(),
+  })).optional().default([]),
+  service_number: z.string().max(100).nullable().optional(),
+  reference: z.string().max(200).nullable().optional(),
+  seat: z.string().max(200).nullable().optional(),
+  price: z.number().min(0).nullable().optional(),
+  operator: z.string().max(200).nullable().optional(),
+  ticket_type: z.string().max(200).nullable().optional(),
+  route_restriction: z.string().max(200).nullable().optional(),
+  barcodes: z.array(z.object({
+    ref: z.string().nullable(),
+    data: z.string().nullable(),
+  })).optional().default([]),
+  segment_calling_points: z.array(z.array(z.object({
+    station: z.string().max(200),
+    station_code: z.string().max(10).nullable().optional(),
+    time: z.string().max(10).optional().default(""),
+  }))).optional().default([]),
+});
+
+export async function addFullTransportBooking(
+  input: z.input<typeof addFullTransportBookingSchema>,
+): Promise<Result<{ depart_stop_id: string; arrive_stop_id: string }>> {
+  const parsed = parseInput(addFullTransportBookingSchema, input);
+  if (!parsed.ok) return parsed;
+  const v = parsed.value;
+  const ctx = await requireUserContext();
+  const supabase = await createClient();
+
+  const { data: itin } = await supabase
+    .from("itineraries")
+    .select("id")
+    .eq("id", v.itinerary_id)
+    .eq("workspace_id", ctx.workspaceId)
+    .maybeSingle();
+  if (!itin) return err(errors.notFound("itinerary"));
+
+  // Resolve calling point coordinates
+  const allCpCodes = new Set<string>();
+  for (const segCps of v.segment_calling_points) {
+    for (const cp of segCps) {
+      if (cp.station_code) allCpCodes.add(cp.station_code);
+    }
+  }
+  const cpCoords = new Map<string, { lat: number; lng: number }>();
+  if (allCpCodes.size > 0) {
+    const { data: hubs } = await supabase
+      .from("transport_hubs")
+      .select("code, latitude, longitude")
+      .in("code", [...allCpCodes]);
+    for (const h of hubs ?? []) {
+      if (h.latitude && h.longitude) {
+        cpCoords.set(h.code, { lat: Number(h.latitude), lng: Number(h.longitude) });
+      }
+    }
+  }
+  const namesToResolve = new Set<string>();
+  for (const segCps of v.segment_calling_points) {
+    for (const cp of segCps) {
+      if (!cp.station_code && !cpCoords.has(cp.station)) namesToResolve.add(cp.station);
+    }
+  }
+  for (const name of namesToResolve) {
+    const { data: hub } = await supabase
+      .from("transport_hubs")
+      .select("code, latitude, longitude")
+      .ilike("name", name)
+      .limit(1)
+      .maybeSingle();
+    if (hub?.latitude && hub?.longitude) {
+      cpCoords.set(name, { lat: Number(hub.latitude), lng: Number(hub.longitude) });
+    }
+  }
+
+  function enrichCps(
+    cps: Array<{ station: string; station_code?: string | null; time?: string }> | undefined,
+  ) {
+    if (!cps || cps.length === 0) return null;
+    return cps.map((cp) => {
+      const coords = cpCoords.get(cp.station_code ?? "") ?? cpCoords.get(cp.station);
+      return { station: cp.station, station_code: cp.station_code ?? null, time: cp.time ?? "", lat: coords?.lat ?? null, lng: coords?.lng ?? null };
+    });
+  }
+
+  // Append at end of existing stops
+  const { data: maxRow } = await supabase
+    .from("stops")
+    .select("sequence")
+    .eq("itinerary_id", v.itinerary_id)
+    .eq("workspace_id", ctx.workspaceId)
+    .order("sequence", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  let seq = ((maxRow?.sequence as number | undefined) ?? -1) + 1;
+
+  const { data: departStop, error: dErr } = await supabase
+    .from("stops")
+    .insert({
+      itinerary_id: v.itinerary_id,
+      workspace_id: ctx.workspaceId,
+      sequence: seq++,
+      type: "transit_departure",
+      title: v.depart_label,
+      transport_hub_id: v.depart_hub_id,
+      start_time: v.depart_time,
+      end_time: v.depart_time,
+      is_time_fixed: true,
+      metadata: {
+        kind: "transit_departure",
+        transport_mode: v.mode,
+        service_number: v.service_number,
+        booking_reference: v.reference,
+        seat: v.seat,
+        price: v.price,
+        operator: v.operator,
+        ticket_type: v.ticket_type,
+        route_restriction: v.route_restriction,
+        barcode_ref: v.barcodes[0]?.ref ?? null,
+        barcode_data: v.barcodes[0]?.data ?? null,
+        calling_points: enrichCps(v.segment_calling_points[0]),
+      },
+    })
+    .select("id")
+    .single();
+  if (dErr || !departStop) return err(errors.notFound("stop"));
+
+  const changeovers = v.changeovers;
+  for (let coIdx = 0; coIdx < changeovers.length; coIdx++) {
+    const co = changeovers[coIdx];
+    const coBarcode = v.barcodes[coIdx + 1];
+    await supabase.from("stops").insert({
+      itinerary_id: v.itinerary_id,
+      workspace_id: ctx.workspaceId,
+      sequence: seq++,
+      type: "transit_changeover",
+      title: co.hub_label,
+      transport_hub_id: co.hub_id ?? null,
+      start_time: co.arrive_time,
+      end_time: co.depart_time,
+      is_time_fixed: true,
+      metadata: {
+        kind: "transit_changeover",
+        transport_mode: v.mode,
+        operator: v.operator,
+        barcode_ref: coBarcode?.ref ?? null,
+        barcode_data: coBarcode?.data ?? null,
+        calling_points: enrichCps(v.segment_calling_points[coIdx + 1]),
+      },
+    });
+  }
+
+  const { data: arriveStop, error: aErr } = await supabase
+    .from("stops")
+    .insert({
+      itinerary_id: v.itinerary_id,
+      workspace_id: ctx.workspaceId,
+      sequence: seq++,
+      type: "transit_arrival",
+      title: v.arrive_label,
+      transport_hub_id: v.arrive_hub_id,
+      start_time: v.arrive_time,
+      end_time: v.arrive_time,
+      is_time_fixed: true,
+      metadata: { kind: "transit_arrival", transport_mode: v.mode },
+    })
+    .select("id")
+    .single();
+  if (aErr || !arriveStop) return err(errors.notFound("stop"));
+
+  // Booking entities
+  const provider = v.mode === "train" ? "trainline" : v.mode;
+  const { data: intent } = await supabase
+    .from("booking_intents")
+    .insert({
+      stop_id: departStop.id,
+      itinerary_id: v.itinerary_id,
+      workspace_id: ctx.workspaceId,
+      provider,
+      status: "booked",
+      currency: "GBP",
+    })
+    .select("id")
+    .single();
+  if (!intent) return err(errors.notFound("booking_intent"));
+
+  const { data: booking } = await supabase
+    .from("travel_bookings")
+    .insert({
+      booking_intent_id: intent.id,
+      workspace_id: ctx.workspaceId,
+      provider,
+      booking_reference: v.reference ?? null,
+      ticket_status: "booked",
+      actual_price: v.price ?? null,
+      currency: "GBP",
+      booked_at: new Date().toISOString(),
+      departure_at: v.depart_time,
+      arrival_at: v.arrive_time,
+      seat_reservation: v.seat ?? null,
+    })
+    .select("id")
+    .single();
+  if (!booking) return err(errors.notFound("travel_booking"));
+
+  // Segments
+  const segStops = [
+    { label: v.depart_label, time: v.depart_time },
+    ...changeovers.map((co) => ({ label: co.hub_label, time: co.depart_time })),
+    { label: v.arrive_label, time: v.arrive_time },
+  ];
+  const dbSegs = [];
+  for (let i = 0; i < segStops.length - 1; i++) {
+    const bc = v.barcodes[i];
+    const cpArr = v.segment_calling_points[i];
+    dbSegs.push({
+      travel_booking_id: booking.id,
+      workspace_id: ctx.workspaceId,
+      sequence: i,
+      from_location_name: segStops[i].label,
+      to_location_name: segStops[i + 1].label,
+      departure_at: i === 0 ? v.depart_time : changeovers[i - 1].depart_time,
+      arrival_at: i < changeovers.length ? changeovers[i].arrive_time : v.arrive_time,
+      train_number: v.service_number ?? null,
+      operator: v.operator ?? null,
+      ticket_type: v.ticket_type ?? null,
+      route_restriction: v.route_restriction ?? null,
+      seat: i === 0 ? (v.seat ?? null) : null,
+      barcode_ref: bc?.ref ?? null,
+      barcode_data: bc?.data ?? null,
+      calling_points: cpArr && cpArr.length > 0 ? cpArr : null,
+    });
+  }
+  if (dbSegs.length > 0) {
+    await supabase.from("travel_booking_segments").insert(dbSegs);
+  }
+
+  // Locked transition
+  const totalMins = Math.max(1, Math.round(
+    (new Date(v.arrive_time).getTime() - new Date(v.depart_time).getTime()) / 60_000,
+  ));
+  await supabase.from("transitions").insert({
+    itinerary_id: v.itinerary_id,
+    workspace_id: ctx.workspaceId,
+    from_stop_id: departStop.id,
+    to_stop_id: arriveStop.id,
+    mode: v.mode,
+    is_locked: true,
+    start_time: v.depart_time,
+    end_time: v.arrive_time,
+    computed_duration_minutes: totalMins,
+    notes: v.service_number ? `khonsera:service=${v.service_number}` : null,
+  });
+
+  if (v.price != null && v.price > 0) {
+    await supabase.from("expense_records").insert({
+      itinerary_id: v.itinerary_id,
+      stop_id: departStop.id,
+      workspace_id: ctx.workspaceId,
+      user_id: ctx.userId,
+      type: "rail_ticket",
+      amount: v.price,
+      currency: "GBP",
+      notes: v.reference ? `Booking ref: ${v.reference}` : null,
+    });
+  }
+
+  return ok({ depart_stop_id: departStop.id, arrive_stop_id: arriveStop.id });
+}

--- a/src/lib/actions/bookings.ts
+++ b/src/lib/actions/bookings.ts
@@ -428,6 +428,11 @@ const transportSegmentSchema = z.object({
   seat: z.string().trim().max(20).nullable().optional(),
   barcode_ref: z.string().trim().max(40).nullable().optional(),
   barcode_data: z.string().max(500).nullable().optional(),
+  calling_points: z.array(z.object({
+    station: z.string().max(200),
+    station_code: z.string().max(10).nullable().optional(),
+    time: z.string().max(10).optional().default(""),
+  })).nullable().optional(),
 });
 
 const attachTransportBookingSchema = z
@@ -630,6 +635,7 @@ export async function attachTransportBookingToStop(
     seat: s.seat ?? null,
     barcode_ref: s.barcode_ref ?? null,
     barcode_data: s.barcode_data ?? null,
+    calling_points: s.calling_points ?? null,
   }));
   await supabase.from("travel_booking_segments").insert(segmentRows);
 
@@ -649,6 +655,7 @@ export async function attachTransportBookingToStop(
         route_restriction: first.route_restriction ?? null,
         barcode_ref: first.barcode_ref ?? null,
         barcode_data: first.barcode_data ?? null,
+        calling_points: first.calling_points ?? null,
       },
     })
     .eq("id", parsed.value.from_stop_id)

--- a/src/lib/actions/gmail.ts
+++ b/src/lib/actions/gmail.ts
@@ -439,3 +439,143 @@ export async function debugFetchEmail(messageId: string): Promise<
     parsed,
   });
 }
+
+// ── reEnrichItineraryFromGmail ────────────────────────────────────────
+// Re-fetches Trainline PDF attachments from Gmail for an existing
+// itinerary's transit stops. Re-parses with the updated parser (which
+// now extracts calling points) and patches stop metadata + segments.
+
+export async function reEnrichItineraryFromGmail(
+  itineraryId: string,
+): Promise<Result<{ enriched: number }>> {
+  const ctx = await requireUserContext();
+  const gmail = await getValidGmailAccessToken();
+  if (!gmail) {
+    return err(errors.integration("gmail", "Gmail not connected. Connect in Settings."));
+  }
+  const supabase = await createClient();
+
+  // Find transit_departure stops for this itinerary
+  const { data: transitStops } = await supabase
+    .from("stops")
+    .select("id, metadata, transport_hub_id")
+    .eq("itinerary_id", itineraryId)
+    .eq("workspace_id", ctx.workspaceId)
+    .in("type", ["transit_departure", "transit_changeover"]);
+
+  if (!transitStops || transitStops.length === 0) return ok({ enriched: 0 });
+
+  // Filter to stops that don't already have calling_points
+  const stopsToEnrich = transitStops.filter((s) => {
+    const meta = s.metadata as Record<string, unknown> | null;
+    return meta && !meta.calling_points;
+  });
+  if (stopsToEnrich.length === 0) return ok({ enriched: 0 });
+
+  // Collect gmail_message_ids from the scan cache that match our booking refs
+  const bookingRefs = new Set<string>();
+  for (const s of stopsToEnrich) {
+    const meta = s.metadata as Record<string, unknown> | null;
+    if (meta?.booking_reference) bookingRefs.add(meta.booking_reference as string);
+    if (meta?.barcode_ref) bookingRefs.add(meta.barcode_ref as string);
+  }
+
+  // Search Gmail for Trainline emails (re-use the same broad search)
+  const query = buildSearchQuery();
+  let messageRefs;
+  try {
+    messageRefs = await gmailSearchMessages({
+      accessToken: gmail.accessToken,
+      query,
+    });
+  } catch {
+    return err(errors.integration("gmail", "Failed to search Gmail."));
+  }
+
+  let enrichedCount = 0;
+
+  // Process each message — fetch, parse PDFs, look for calling points
+  for (const ref of messageRefs.slice(0, 20)) {
+    let msg;
+    try {
+      msg = await gmailGetMessage({ accessToken: gmail.accessToken, messageId: ref.id });
+    } catch { continue; }
+
+    const attachments = extractAttachments(msg);
+    const pdfs = attachments.filter(
+      (a) => a.mimeType === "application/pdf" || a.filename?.endsWith(".pdf"),
+    );
+    if (pdfs.length === 0) continue;
+
+    // Fetch and parse each PDF
+    for (const pdf of pdfs) {
+      let buf: Buffer;
+      try {
+        buf = await gmailGetAttachment({
+          accessToken: gmail.accessToken,
+          messageId: ref.id,
+          attachmentId: pdf.attachmentId,
+        });
+      } catch { continue; }
+
+      const { extractText } = await import("unpdf").catch(() => ({ extractText: null }));
+      if (!extractText) continue;
+
+      let ticket;
+      try {
+        const result = await extractText(new Uint8Array(buf).buffer);
+        const pdfText = Array.isArray(result.text) ? result.text.join("\n") : result.text;
+        ticket = parseTrainlinePdfText(pdfText);
+      } catch { continue; }
+      if (!ticket || ticket.calling_points.length === 0) continue;
+
+      // Match this ticket to a stop by barcode_ref or station codes
+      for (const stop of stopsToEnrich) {
+        const meta = stop.metadata as Record<string, unknown> | null;
+        if (!meta) continue;
+
+        const matchByBarcode = meta.barcode_ref && ticket.barcode_ref &&
+          meta.barcode_ref === ticket.barcode_ref;
+        const matchByRef = meta.booking_reference && ticket.nrs_ref &&
+          meta.booking_reference === ticket.nrs_ref;
+
+        if (!matchByBarcode && !matchByRef) continue;
+
+        // Resolve calling point coordinates
+        const cpCodes = ticket.calling_points
+          .filter((cp) => cp.station_code)
+          .map((cp) => cp.station_code!);
+        const cpCoords = new Map<string, { lat: number; lng: number }>();
+        if (cpCodes.length > 0) {
+          const { data: hubs } = await supabase
+            .from("transport_hubs")
+            .select("code, latitude, longitude")
+            .in("code", cpCodes);
+          for (const h of hubs ?? []) {
+            if (h.latitude && h.longitude) {
+              cpCoords.set(h.code, { lat: Number(h.latitude), lng: Number(h.longitude) });
+            }
+          }
+        }
+
+        const enrichedCps = ticket.calling_points.map((cp) => {
+          const coords = cpCoords.get(cp.station_code ?? "");
+          return { ...cp, lat: coords?.lat ?? null, lng: coords?.lng ?? null };
+        });
+
+        // Patch the stop metadata
+        await supabase
+          .from("stops")
+          .update({
+            metadata: { ...meta, calling_points: enrichedCps },
+          })
+          .eq("id", stop.id)
+          .eq("workspace_id", ctx.workspaceId);
+
+        enrichedCount++;
+      }
+    }
+  }
+
+  return ok({ enriched: enrichedCount });
+}

--- a/src/lib/actions/gmail.ts
+++ b/src/lib/actions/gmail.ts
@@ -550,7 +550,8 @@ export async function reEnrichItineraryFromGmail(
           const { data: hubs } = await supabase
             .from("transport_hubs")
             .select("code, latitude, longitude")
-            .in("code", cpCodes);
+            .in("code", cpCodes)
+            .eq("kind", "rail_station");
           for (const h of hubs ?? []) {
             if (h.latitude && h.longitude) {
               cpCoords.set(h.code, { lat: Number(h.latitude), lng: Number(h.longitude) });

--- a/src/lib/actions/gmail.ts
+++ b/src/lib/actions/gmail.ts
@@ -578,5 +578,11 @@ export async function reEnrichItineraryFromGmail(
     }
   }
 
+  // Regenerate rail polylines using the updated calling points as waypoints
+  if (enrichedCount > 0) {
+    const { backfillRailPolylines } = await import("@/lib/actions/transitions");
+    await backfillRailPolylines(itineraryId, true);
+  }
+
   return ok({ enriched: enrichedCount });
 }

--- a/src/lib/actions/itineraries.ts
+++ b/src/lib/actions/itineraries.ts
@@ -1412,7 +1412,7 @@ export async function createItineraryFromBrief(
               const { data: trStops } = await supabase
                 .from("stops")
                 .select(
-                  `id, transport_hub_id,
+                  `id, transport_hub_id, metadata,
                    location:locations(latitude, longitude),
                    customer_site:customer_sites(latitude, longitude),
                    transport_hub:transport_hubs(latitude, longitude, code)`,
@@ -1451,10 +1451,19 @@ export async function createItineraryFromBrief(
                 const toHub = (toS as any)?.transport_hub;
                 const fromCode = fromHub?.code ?? null;
                 const toCode = toHub?.code ?? null;
+                // Extract calling point waypoints from departure stop metadata
+                const fromMeta = fromS?.metadata as Record<string, unknown> | null;
+                const rawCps = fromMeta?.calling_points;
+                const wpArr = Array.isArray(rawCps)
+                  ? (rawCps as Array<{ lat?: number; lng?: number }>)
+                      .filter((cp) => cp.lat && cp.lng)
+                      .map((cp) => ({ lat: cp.lat!, lng: cp.lng! }))
+                  : undefined;
                 const railPoly = await getRailPolyline(
                   fromPt.lat, fromPt.lng,
                   toPt.lat, toPt.lng,
                   fromCode, toCode,
+                  wpArr && wpArr.length > 0 ? wpArr : undefined,
                 );
                 if (railPoly) {
                   await supabase

--- a/src/lib/actions/itineraries.ts
+++ b/src/lib/actions/itineraries.ts
@@ -338,6 +338,11 @@ const briefTransportBookingSchema = z.object({
     ref: z.string().nullable(),
     data: z.string().nullable(),
   })).optional().default([]),
+  segment_calling_points: z.array(z.array(z.object({
+    station: z.string().max(200),
+    station_code: z.string().max(10).nullable().optional(),
+    time: z.string().regex(/^\d{1,2}:\d{2}$/).optional().default(""),
+  }))).optional().default([]),
 });
 
 const briefAccommodationBookingSchema = z.object({
@@ -678,6 +683,70 @@ export async function createItineraryFromBrief(
     });
   }
 
+  // Batch-resolve calling point station codes → coordinates for map waypoints.
+  const allCpCodes = new Set<string>();
+  for (const tb of parsed.value.transport_bookings) {
+    for (const segCps of tb.segment_calling_points ?? []) {
+      for (const cp of segCps) {
+        if (cp.station_code) allCpCodes.add(cp.station_code);
+      }
+    }
+  }
+  const cpHubCoords = new Map<string, { lat: number; lng: number }>();
+  if (allCpCodes.size > 0) {
+    const { data: hubs } = await supabase
+      .from("transport_hubs")
+      .select("code, latitude, longitude")
+      .in("code", [...allCpCodes]);
+    for (const h of hubs ?? []) {
+      if (h.latitude && h.longitude) {
+        cpHubCoords.set(h.code, { lat: Number(h.latitude), lng: Number(h.longitude) });
+      }
+    }
+  }
+
+  // Also try name-based resolution for calling points without codes
+  const cpNamesToResolve: string[] = [];
+  for (const tb of parsed.value.transport_bookings) {
+    for (const segCps of tb.segment_calling_points ?? []) {
+      for (const cp of segCps) {
+        if (!cp.station_code && !cpHubCoords.has(cp.station)) {
+          cpNamesToResolve.push(cp.station);
+        }
+      }
+    }
+  }
+  if (cpNamesToResolve.length > 0) {
+    const uniqueNames = [...new Set(cpNamesToResolve)];
+    for (const name of uniqueNames) {
+      const { data: hub } = await supabase
+        .from("transport_hubs")
+        .select("code, latitude, longitude")
+        .ilike("name", name)
+        .limit(1)
+        .maybeSingle();
+      if (hub?.latitude && hub?.longitude) {
+        cpHubCoords.set(name, { lat: Number(hub.latitude), lng: Number(hub.longitude) });
+      }
+    }
+  }
+
+  function enrichCallingPoints(
+    cps: Array<{ station: string; station_code?: string | null; time?: string }> | undefined,
+  ) {
+    if (!cps || cps.length === 0) return null;
+    return cps.map((cp) => {
+      const coords = cpHubCoords.get(cp.station_code ?? "") ?? cpHubCoords.get(cp.station);
+      return {
+        station: cp.station,
+        station_code: cp.station_code ?? null,
+        time: cp.time ?? "",
+        lat: coords?.lat ?? null,
+        lng: coords?.lng ?? null,
+      };
+    });
+  }
+
   // Transport bookings → departure + arrival stops with a locked
   // transition between them. The booking data is stored in metadata
   // so the planning page can display it.
@@ -718,6 +787,7 @@ export async function createItineraryFromBrief(
         barcode_data: tb.barcodes[0]?.data ?? null,
         departure_hub_id: tb.departure_hub_id,
         destination_hub_id: tb.destination_hub_id,
+        calling_points: enrichCallingPoints(tb.segment_calling_points?.[0]),
       },
       itinerary_id: itinerary.id,
       workspace_id: ctx.workspaceId,
@@ -757,6 +827,7 @@ export async function createItineraryFromBrief(
           route_restriction: tb.route_restriction,
           barcode_ref: coBarcode?.ref ?? null,
           barcode_data: coBarcode?.data ?? null,
+          calling_points: enrichCallingPoints(tb.segment_calling_points?.[coIdx + 1]),
         },
         itinerary_id: itinerary.id,
         workspace_id: ctx.workspaceId,

--- a/src/lib/actions/itineraries.ts
+++ b/src/lib/actions/itineraries.ts
@@ -697,7 +697,8 @@ export async function createItineraryFromBrief(
     const { data: hubs } = await supabase
       .from("transport_hubs")
       .select("code, latitude, longitude")
-      .in("code", [...allCpCodes]);
+      .in("code", [...allCpCodes])
+      .eq("kind", "rail_station");
     for (const h of hubs ?? []) {
       if (h.latitude && h.longitude) {
         cpHubCoords.set(h.code, { lat: Number(h.latitude), lng: Number(h.longitude) });

--- a/src/lib/actions/rail-network.ts
+++ b/src/lib/actions/rail-network.ts
@@ -98,144 +98,59 @@ async function routeRailPathViaWaypoints(
   toLng: number,
   waypoints: Array<{ lat: number; lng: number }>,
 ): Promise<string | null> {
-  await requireUserContext();
-  const supabase = await createClient();
-
-  // Build ONE bounding box encompassing the entire route + waypoints
+  // Route each segment independently using routeRailPathDirect.
+  // Each segment gets its own bounding box, edge fetch, and A*.
+  // Segments are concatenated by decoding/re-encoding.
   const allPts = [
     { lat: fromLat, lng: fromLng },
     ...waypoints,
     { lat: toLat, lng: toLng },
   ];
-  const pad = 0.08;
-  const minLat = Math.min(...allPts.map((p) => p.lat)) - pad;
-  const maxLat = Math.max(...allPts.map((p) => p.lat)) + pad;
-  const minLng = Math.min(...allPts.map((p) => p.lng)) - pad;
-  const maxLng = Math.max(...allPts.map((p) => p.lng)) + pad;
 
-  const { data: edges, error } = await supabase
-    .from("rail_network_edges")
-    .select("from_lat, from_lng, to_lat, to_lng")
-    .gte("from_lat", minLat)
-    .lte("from_lat", maxLat)
-    .gte("from_lng", minLng)
-    .lte("from_lng", maxLng);
-
-  if (error || !edges || edges.length === 0) return null;
-
-  // Build one shared adjacency graph
-  const adj = new Map<string, Set<string>>();
-  const coordMap = new Map<string, LatLng>();
-
-  const addEdge = (aLat: number, aLng: number, bLat: number, bLng: number) => {
-    const keyA = coordKey(aLat, aLng);
-    const keyB = coordKey(bLat, bLng);
-    if (!adj.has(keyA)) adj.set(keyA, new Set());
-    if (!adj.has(keyB)) adj.set(keyB, new Set());
-    adj.get(keyA)!.add(keyB);
-    adj.get(keyB)!.add(keyA);
-    if (!coordMap.has(keyA)) coordMap.set(keyA, { lat: aLat, lng: aLng });
-    if (!coordMap.has(keyB)) coordMap.set(keyB, { lat: bLat, lng: bLng });
-  };
-
-  for (const e of edges) {
-    if (
-      e.to_lat >= minLat - pad &&
-      e.to_lat <= maxLat + pad &&
-      e.to_lng >= minLng - pad &&
-      e.to_lng <= maxLng + pad
-    ) {
-      addEdge(e.from_lat, e.from_lng, e.to_lat, e.to_lng);
-    }
-  }
-
-  if (adj.size === 0) return null;
-
-  // Find nearest rail graph nodes for origin, each waypoint, and destination
-  const originKey = findNearestKey(coordMap, fromLat, fromLng);
-  const destKey = findNearestKey(coordMap, toLat, toLng);
-  if (!originKey || !destKey) return null;
-
-  const wpKeys = waypoints.map((wp) => findNearestKey(coordMap, wp.lat, wp.lng));
-  const nodeSequence = [originKey, ...wpKeys.filter((k): k is string => k !== null), destKey];
-
-  // Route through each sequential pair using Dijkstra on the shared graph
-  const fullPath: LatLng[] = [];
-  for (let i = 0; i < nodeSequence.length - 1; i++) {
-    const segPath = dijkstraOnGraph(
-      adj, coordMap, nodeSequence[i], nodeSequence[i + 1],
+  const allPoints: LatLng[] = [];
+  for (let i = 0; i < allPts.length - 1; i++) {
+    const segPoly = await routeRailPathDirect(
+      allPts[i].lat, allPts[i].lng,
+      allPts[i + 1].lat, allPts[i + 1].lng,
     );
-    if (!segPath) continue;
-    // Skip the first point of subsequent segments to avoid duplicates
-    const points = i > 0 && segPath.length > 0 ? segPath.slice(1) : segPath;
-    fullPath.push(...points);
+    if (!segPoly) continue;
+    const decoded = decodePolylineInternal(segPoly);
+    if (i > 0 && allPoints.length > 0 && decoded.length > 0) {
+      decoded.shift();
+    }
+    allPoints.push(...decoded);
   }
 
-  if (fullPath.length < 2) return null;
-
-  // Only trim at the actual origin and destination (not at intermediate waypoints)
-  const trimmed = trimPathToStations(fullPath, fromLat, fromLng, toLat, toLng);
-  return encodePolyline(trimmed);
+  if (allPoints.length < 2) return null;
+  return encodePolyline(allPoints);
 }
 
-function dijkstraOnGraph(
-  adj: Map<string, Set<string>>,
-  coordMap: Map<string, LatLng>,
-  startKey: string,
-  endKey: string,
-): LatLng[] | null {
-  if (startKey === endKey) {
-    const pt = coordMap.get(startKey);
-    return pt ? [pt] : null;
+function decodePolylineInternal(encoded: string): LatLng[] {
+  const points: LatLng[] = [];
+  let index = 0;
+  let lat = 0;
+  let lng = 0;
+  while (index < encoded.length) {
+    let b: number;
+    let shift = 0;
+    let result = 0;
+    do {
+      b = encoded.charCodeAt(index++) - 63;
+      result |= (b & 0x1f) << shift;
+      shift += 5;
+    } while (b >= 0x20);
+    lat += result & 1 ? ~(result >> 1) : result >> 1;
+    shift = 0;
+    result = 0;
+    do {
+      b = encoded.charCodeAt(index++) - 63;
+      result |= (b & 0x1f) << shift;
+      shift += 5;
+    } while (b >= 0x20);
+    lng += result & 1 ? ~(result >> 1) : result >> 1;
+    points.push({ lat: lat / 1e5, lng: lng / 1e5 });
   }
-
-  const endPt = coordMap.get(endKey)!;
-  const EPSILON = 1.3;
-
-  const gScore = new Map<string, number>();
-  const parent = new Map<string, string>();
-  gScore.set(startKey, 0);
-
-  const startPt = coordMap.get(startKey)!;
-  const startH = haversineKm(startPt.lat, startPt.lng, endPt.lat, endPt.lng);
-  const pq: Array<{ key: string; f: number; g: number }> = [
-    { key: startKey, f: EPSILON * startH, g: 0 },
-  ];
-
-  let found = false;
-  while (pq.length > 0) {
-    pq.sort((a, b) => a.f - b.f);
-    const { key: current, g: currentG } = pq.shift()!;
-    if (current === endKey) { found = true; break; }
-    if (currentG > (gScore.get(current) ?? Infinity)) continue;
-
-    const currentPt = coordMap.get(current)!;
-    for (const neighbor of adj.get(current) ?? []) {
-      const neighborPt = coordMap.get(neighbor);
-      if (!neighborPt) continue;
-      const edgeDist = haversineKm(currentPt.lat, currentPt.lng, neighborPt.lat, neighborPt.lng);
-      const newG = currentG + edgeDist;
-      if (newG < (gScore.get(neighbor) ?? Infinity)) {
-        gScore.set(neighbor, newG);
-        parent.set(neighbor, current);
-        const h = haversineKm(neighborPt.lat, neighborPt.lng, endPt.lat, endPt.lng);
-        pq.push({ key: neighbor, f: newG + EPSILON * h, g: newG });
-      }
-    }
-  }
-
-  if (!found) return null;
-
-  const pathKeys: string[] = [];
-  let node: string | undefined = endKey;
-  while (node != null) {
-    pathKeys.unshift(node);
-    node = parent.get(node);
-  }
-
-  return pathKeys
-    .map((k) => coordMap.get(k))
-    .filter((pt): pt is LatLng => pt != null);
+  return points;
 }
 
 async function routeRailPathDirect(

--- a/src/lib/actions/rail-network.ts
+++ b/src/lib/actions/rail-network.ts
@@ -83,11 +83,8 @@ export async function routeRailPath(
   fromLng: number,
   toLat: number,
   toLng: number,
-  waypoints?: Array<{ lat: number; lng: number }>,
+  _waypoints?: Array<{ lat: number; lng: number }>,
 ): Promise<string | null> {
-  if (waypoints && waypoints.length > 0) {
-    return routeRailPathViaWaypoints(fromLat, fromLng, toLat, toLng, waypoints);
-  }
   return routeRailPathDirect(fromLat, fromLng, toLat, toLng);
 }
 
@@ -162,8 +159,7 @@ async function routeRailPathDirect(
   await requireUserContext();
   const supabase = await createClient();
 
-  // Bounding box with padding
-  const pad = 0.05;
+  const pad = 0.1;
   const minLat = Math.min(fromLat, toLat) - pad;
   const maxLat = Math.max(fromLat, toLat) + pad;
   const minLng = Math.min(fromLng, toLng) - pad;
@@ -218,12 +214,12 @@ async function routeRailPathDirect(
   const endKey = findNearestKey(coordMap, toLat, toLng);
   if (!startKey || !endKey || startKey === endKey) return null;
 
-  // Weighted A* — biases toward the destination so the path prefers
-  // branches heading toward the target. Pure Dijkstra picks the
-  // geometrically shortest path which can detour through a nearby
-  // branch (e.g. via Beeston/Nottingham instead of direct to Derby).
-  // Epsilon > 1 trades slight optimality for directness.
-  const EPSILON = 1.3;
+  // Weighted A* — strongly biases toward the destination. At junctions
+  // like Trent Junction, this forces the path along the branch heading
+  // toward the destination rather than a nearby parallel line.
+  // High epsilon (3.0) sacrifices distance-optimality for directness —
+  // acceptable for rail where we want geometry, not shortest path.
+  const EPSILON = 3.0;
   const endPt = coordMap.get(endKey)!;
 
   const gScore = new Map<string, number>();

--- a/src/lib/actions/rail-network.ts
+++ b/src/lib/actions/rail-network.ts
@@ -72,6 +72,21 @@ export async function clearRouteSegments(): Promise<void> {
   await supabase.from("rail_named_route_segments").delete().gte("id", "00000000-0000-0000-0000-000000000000");
 }
 
+export async function getAllRailStationCodes(): Promise<Map<string, string>> {
+  await requireUserContext();
+  const supabase = await createClient();
+  const { data } = await supabase
+    .from("transport_hubs")
+    .select("name, code")
+    .eq("kind", "rail_station")
+    .not("code", "is", null);
+  const map = new Map<string, string>();
+  for (const h of data ?? []) {
+    if (h.code) map.set(h.name.toLowerCase(), h.code);
+  }
+  return Object.fromEntries(map) as any;
+}
+
 /**
  * Return the count of stored edges (null if table is empty / not seeded).
  */

--- a/src/lib/actions/rail-network.ts
+++ b/src/lib/actions/rail-network.ts
@@ -209,6 +209,32 @@ async function routeRailPathDirect(
 
   if (adj.size === 0) return null;
 
+  // Corridor pruning: remove graph nodes that are too far from the
+  // direct origin→destination line. This eliminates parallel branches
+  // (e.g. the Beeston/Nottingham line when routing Leicester→Derby).
+  const directDistKm = haversineKm(fromLat, fromLng, toLat, toLng);
+  if (directDistKm > 10) {
+    const corridorKm = Math.max(6, Math.min(15, directDistKm * 0.25));
+    const dLat = toLat - fromLat;
+    const dLng = toLng - fromLng;
+    const len2 = dLat * dLat + dLng * dLng;
+    const toRemove: string[] = [];
+    for (const [key, pt] of coordMap) {
+      const t = ((pt.lat - fromLat) * dLat + (pt.lng - fromLng) * dLng) / len2;
+      const projLat = fromLat + Math.max(0, Math.min(1, t)) * dLat;
+      const projLng = fromLng + Math.max(0, Math.min(1, t)) * dLng;
+      const perpDist = haversineKm(pt.lat, pt.lng, projLat, projLng);
+      if (perpDist > corridorKm) toRemove.push(key);
+    }
+    for (const key of toRemove) {
+      coordMap.delete(key);
+      adj.delete(key);
+      for (const neighbors of adj.values()) neighbors.delete(key);
+    }
+  }
+
+  if (adj.size === 0) return null;
+
   // Find nearest graph nodes to from/to stations
   const startKey = findNearestKey(coordMap, fromLat, fromLng);
   const endKey = findNearestKey(coordMap, toLat, toLng);

--- a/src/lib/actions/rail-network.ts
+++ b/src/lib/actions/rail-network.ts
@@ -98,58 +98,135 @@ async function routeRailPathViaWaypoints(
   toLng: number,
   waypoints: Array<{ lat: number; lng: number }>,
 ): Promise<string | null> {
-  const allPoints: Array<{ lat: number; lng: number }> = [
+  await requireUserContext();
+  const supabase = await createClient();
+
+  // Build ONE bounding box encompassing the entire route + waypoints
+  const allPts = [
     { lat: fromLat, lng: fromLng },
     ...waypoints,
     { lat: toLat, lng: toLng },
   ];
+  const pad = 0.08;
+  const minLat = Math.min(...allPts.map((p) => p.lat)) - pad;
+  const maxLat = Math.max(...allPts.map((p) => p.lat)) + pad;
+  const minLng = Math.min(...allPts.map((p) => p.lng)) - pad;
+  const maxLng = Math.max(...allPts.map((p) => p.lng)) + pad;
 
-  const allSegmentPoints: LatLng[] = [];
-  for (let i = 0; i < allPoints.length - 1; i++) {
-    const seg = await routeRailPathDirect(
-      allPoints[i].lat, allPoints[i].lng,
-      allPoints[i + 1].lat, allPoints[i + 1].lng,
-    );
-    if (!seg) continue;
-    const decoded = decodePolylineInternal(seg);
-    if (i > 0 && allSegmentPoints.length > 0 && decoded.length > 0) {
-      decoded.shift();
+  const { data: edges, error } = await supabase
+    .from("rail_network_edges")
+    .select("from_lat, from_lng, to_lat, to_lng")
+    .gte("from_lat", minLat)
+    .lte("from_lat", maxLat)
+    .gte("from_lng", minLng)
+    .lte("from_lng", maxLng);
+
+  if (error || !edges || edges.length === 0) return null;
+
+  // Build one shared adjacency graph
+  const adj = new Map<string, Set<string>>();
+  const coordMap = new Map<string, LatLng>();
+
+  const addEdge = (aLat: number, aLng: number, bLat: number, bLng: number) => {
+    const keyA = coordKey(aLat, aLng);
+    const keyB = coordKey(bLat, bLng);
+    if (!adj.has(keyA)) adj.set(keyA, new Set());
+    if (!adj.has(keyB)) adj.set(keyB, new Set());
+    adj.get(keyA)!.add(keyB);
+    adj.get(keyB)!.add(keyA);
+    if (!coordMap.has(keyA)) coordMap.set(keyA, { lat: aLat, lng: aLng });
+    if (!coordMap.has(keyB)) coordMap.set(keyB, { lat: bLat, lng: bLng });
+  };
+
+  for (const e of edges) {
+    if (
+      e.to_lat >= minLat - pad &&
+      e.to_lat <= maxLat + pad &&
+      e.to_lng >= minLng - pad &&
+      e.to_lng <= maxLng + pad
+    ) {
+      addEdge(e.from_lat, e.from_lng, e.to_lat, e.to_lng);
     }
-    allSegmentPoints.push(...decoded);
   }
 
-  if (allSegmentPoints.length < 2) return null;
-  return encodePolyline(allSegmentPoints);
+  if (adj.size === 0) return null;
+
+  // Find nearest rail graph nodes for origin, each waypoint, and destination
+  const originKey = findNearestKey(coordMap, fromLat, fromLng);
+  const destKey = findNearestKey(coordMap, toLat, toLng);
+  if (!originKey || !destKey) return null;
+
+  const wpKeys = waypoints.map((wp) => findNearestKey(coordMap, wp.lat, wp.lng));
+  const nodeSequence = [originKey, ...wpKeys.filter((k): k is string => k !== null), destKey];
+
+  // Route through each sequential pair using Dijkstra on the shared graph
+  const fullPath: LatLng[] = [];
+  for (let i = 0; i < nodeSequence.length - 1; i++) {
+    const segPath = dijkstraOnGraph(
+      adj, coordMap, nodeSequence[i], nodeSequence[i + 1],
+    );
+    if (!segPath) continue;
+    // Skip the first point of subsequent segments to avoid duplicates
+    const points = i > 0 && segPath.length > 0 ? segPath.slice(1) : segPath;
+    fullPath.push(...points);
+  }
+
+  if (fullPath.length < 2) return null;
+
+  // Only trim at the actual origin and destination (not at intermediate waypoints)
+  const trimmed = trimPathToStations(fullPath, fromLat, fromLng, toLat, toLng);
+  return encodePolyline(trimmed);
 }
 
-function decodePolylineInternal(encoded: string): LatLng[] {
-  const points: LatLng[] = [];
-  let index = 0;
-  let lat = 0;
-  let lng = 0;
-  while (index < encoded.length) {
-    let b: number;
-    let shift = 0;
-    let result = 0;
-    do {
-      b = encoded.charCodeAt(index++) - 63;
-      result |= (b & 0x1f) << shift;
-      shift += 5;
-    } while (b >= 0x20);
-    lat += result & 1 ? ~(result >> 1) : result >> 1;
-
-    shift = 0;
-    result = 0;
-    do {
-      b = encoded.charCodeAt(index++) - 63;
-      result |= (b & 0x1f) << shift;
-      shift += 5;
-    } while (b >= 0x20);
-    lng += result & 1 ? ~(result >> 1) : result >> 1;
-
-    points.push({ lat: lat / 1e5, lng: lng / 1e5 });
+function dijkstraOnGraph(
+  adj: Map<string, Set<string>>,
+  coordMap: Map<string, LatLng>,
+  startKey: string,
+  endKey: string,
+): LatLng[] | null {
+  if (startKey === endKey) {
+    const pt = coordMap.get(startKey);
+    return pt ? [pt] : null;
   }
-  return points;
+
+  const dist = new Map<string, number>();
+  const parent = new Map<string, string>();
+  dist.set(startKey, 0);
+  const pq: Array<{ key: string; d: number }> = [{ key: startKey, d: 0 }];
+
+  let found = false;
+  while (pq.length > 0) {
+    pq.sort((a, b) => a.d - b.d);
+    const { key: current, d: currentDist } = pq.shift()!;
+    if (current === endKey) { found = true; break; }
+    if (currentDist > (dist.get(current) ?? Infinity)) continue;
+
+    const currentPt = coordMap.get(current)!;
+    for (const neighbor of adj.get(current) ?? []) {
+      const neighborPt = coordMap.get(neighbor);
+      if (!neighborPt) continue;
+      const edgeDist = haversineKm(currentPt.lat, currentPt.lng, neighborPt.lat, neighborPt.lng);
+      const newDist = currentDist + edgeDist;
+      if (newDist < (dist.get(neighbor) ?? Infinity)) {
+        dist.set(neighbor, newDist);
+        parent.set(neighbor, current);
+        pq.push({ key: neighbor, d: newDist });
+      }
+    }
+  }
+
+  if (!found) return null;
+
+  const pathKeys: string[] = [];
+  let node: string | undefined = endKey;
+  while (node != null) {
+    pathKeys.unshift(node);
+    node = parent.get(node);
+  }
+
+  return pathKeys
+    .map((k) => coordMap.get(k))
+    .filter((pt): pt is LatLng => pt != null);
 }
 
 async function routeRailPathDirect(

--- a/src/lib/actions/rail-network.ts
+++ b/src/lib/actions/rail-network.ts
@@ -83,8 +83,11 @@ export async function routeRailPath(
   fromLng: number,
   toLat: number,
   toLng: number,
-  _waypoints?: Array<{ lat: number; lng: number }>,
+  waypoints?: Array<{ lat: number; lng: number }>,
 ): Promise<string | null> {
+  if (waypoints && waypoints.length > 0) {
+    return routeRailPathViaWaypoints(fromLat, fromLng, toLat, toLng, waypoints);
+  }
   return routeRailPathDirect(fromLat, fromLng, toLat, toLng);
 }
 
@@ -95,9 +98,6 @@ async function routeRailPathViaWaypoints(
   toLng: number,
   waypoints: Array<{ lat: number; lng: number }>,
 ): Promise<string | null> {
-  // Route each segment independently using routeRailPathDirect.
-  // Each segment gets its own bounding box, edge fetch, and A*.
-  // Segments are concatenated by decoding/re-encoding.
   const allPts = [
     { lat: fromLat, lng: fromLng },
     ...waypoints,
@@ -105,16 +105,31 @@ async function routeRailPathViaWaypoints(
   ];
 
   const allPoints: LatLng[] = [];
+  // Track the actual endpoint of the previous segment so the next
+  // segment starts from where the track actually is, not from the
+  // station entrance coordinates. This eliminates zigzag at junctions.
+  let prevEndpoint: { lat: number; lng: number } | null = null;
+
   for (let i = 0; i < allPts.length - 1; i++) {
+    const startPt = prevEndpoint ?? allPts[i];
+    const endPt = allPts[i + 1];
+
     const segPoly = await routeRailPathDirect(
-      allPts[i].lat, allPts[i].lng,
-      allPts[i + 1].lat, allPts[i + 1].lng,
+      startPt.lat, startPt.lng,
+      endPt.lat, endPt.lng,
     );
-    if (!segPoly) continue;
-    const decoded = decodePolylineInternal(segPoly);
-    if (i > 0 && allPoints.length > 0 && decoded.length > 0) {
-      decoded.shift();
+    if (!segPoly) {
+      prevEndpoint = null;
+      continue;
     }
+    const decoded = decodePolylineInternal(segPoly);
+    if (decoded.length === 0) continue;
+
+    // Capture the actual last track point for the next segment's start
+    prevEndpoint = decoded[decoded.length - 1];
+
+    // Skip the first point of subsequent segments to avoid duplicates
+    if (i > 0 && allPoints.length > 0) decoded.shift();
     allPoints.push(...decoded);
   }
 

--- a/src/lib/actions/rail-network.ts
+++ b/src/lib/actions/rail-network.ts
@@ -70,10 +70,89 @@ function coordKey(lat: number, lng: number): string {
 
 /**
  * Route between two points using the stored rail network graph.
- * Loads edges in the bounding box, builds an adjacency list, runs BFS,
- * trims to station boundaries, and returns an encoded Google polyline.
+ * Loads edges in the bounding box, builds an adjacency list, runs
+ * Dijkstra, trims to station boundaries, and returns an encoded
+ * Google polyline.
+ *
+ * When waypoints are provided, routes through each sequentially
+ * (from → wp1 → wp2 → ... → to) and concatenates the path segments.
+ * This forces the path through the correct branch at junctions.
  */
 export async function routeRailPath(
+  fromLat: number,
+  fromLng: number,
+  toLat: number,
+  toLng: number,
+  waypoints?: Array<{ lat: number; lng: number }>,
+): Promise<string | null> {
+  if (waypoints && waypoints.length > 0) {
+    return routeRailPathViaWaypoints(fromLat, fromLng, toLat, toLng, waypoints);
+  }
+  return routeRailPathDirect(fromLat, fromLng, toLat, toLng);
+}
+
+async function routeRailPathViaWaypoints(
+  fromLat: number,
+  fromLng: number,
+  toLat: number,
+  toLng: number,
+  waypoints: Array<{ lat: number; lng: number }>,
+): Promise<string | null> {
+  const allPoints: Array<{ lat: number; lng: number }> = [
+    { lat: fromLat, lng: fromLng },
+    ...waypoints,
+    { lat: toLat, lng: toLng },
+  ];
+
+  const allSegmentPoints: LatLng[] = [];
+  for (let i = 0; i < allPoints.length - 1; i++) {
+    const seg = await routeRailPathDirect(
+      allPoints[i].lat, allPoints[i].lng,
+      allPoints[i + 1].lat, allPoints[i + 1].lng,
+    );
+    if (!seg) continue;
+    const decoded = decodePolylineInternal(seg);
+    if (i > 0 && allSegmentPoints.length > 0 && decoded.length > 0) {
+      decoded.shift();
+    }
+    allSegmentPoints.push(...decoded);
+  }
+
+  if (allSegmentPoints.length < 2) return null;
+  return encodePolyline(allSegmentPoints);
+}
+
+function decodePolylineInternal(encoded: string): LatLng[] {
+  const points: LatLng[] = [];
+  let index = 0;
+  let lat = 0;
+  let lng = 0;
+  while (index < encoded.length) {
+    let b: number;
+    let shift = 0;
+    let result = 0;
+    do {
+      b = encoded.charCodeAt(index++) - 63;
+      result |= (b & 0x1f) << shift;
+      shift += 5;
+    } while (b >= 0x20);
+    lat += result & 1 ? ~(result >> 1) : result >> 1;
+
+    shift = 0;
+    result = 0;
+    do {
+      b = encoded.charCodeAt(index++) - 63;
+      result |= (b & 0x1f) << shift;
+      shift += 5;
+    } while (b >= 0x20);
+    lng += result & 1 ? ~(result >> 1) : result >> 1;
+
+    points.push({ lat: lat / 1e5, lng: lng / 1e5 });
+  }
+  return points;
+}
+
+async function routeRailPathDirect(
   fromLat: number,
   fromLng: number,
   toLat: number,

--- a/src/lib/actions/rail-network.ts
+++ b/src/lib/actions/rail-network.ts
@@ -189,28 +189,37 @@ function dijkstraOnGraph(
     return pt ? [pt] : null;
   }
 
-  const dist = new Map<string, number>();
+  const endPt = coordMap.get(endKey)!;
+  const EPSILON = 1.3;
+
+  const gScore = new Map<string, number>();
   const parent = new Map<string, string>();
-  dist.set(startKey, 0);
-  const pq: Array<{ key: string; d: number }> = [{ key: startKey, d: 0 }];
+  gScore.set(startKey, 0);
+
+  const startPt = coordMap.get(startKey)!;
+  const startH = haversineKm(startPt.lat, startPt.lng, endPt.lat, endPt.lng);
+  const pq: Array<{ key: string; f: number; g: number }> = [
+    { key: startKey, f: EPSILON * startH, g: 0 },
+  ];
 
   let found = false;
   while (pq.length > 0) {
-    pq.sort((a, b) => a.d - b.d);
-    const { key: current, d: currentDist } = pq.shift()!;
+    pq.sort((a, b) => a.f - b.f);
+    const { key: current, g: currentG } = pq.shift()!;
     if (current === endKey) { found = true; break; }
-    if (currentDist > (dist.get(current) ?? Infinity)) continue;
+    if (currentG > (gScore.get(current) ?? Infinity)) continue;
 
     const currentPt = coordMap.get(current)!;
     for (const neighbor of adj.get(current) ?? []) {
       const neighborPt = coordMap.get(neighbor);
       if (!neighborPt) continue;
       const edgeDist = haversineKm(currentPt.lat, currentPt.lng, neighborPt.lat, neighborPt.lng);
-      const newDist = currentDist + edgeDist;
-      if (newDist < (dist.get(neighbor) ?? Infinity)) {
-        dist.set(neighbor, newDist);
+      const newG = currentG + edgeDist;
+      if (newG < (gScore.get(neighbor) ?? Infinity)) {
+        gScore.set(neighbor, newG);
         parent.set(neighbor, current);
-        pq.push({ key: neighbor, d: newDist });
+        const h = haversineKm(neighborPt.lat, neighborPt.lng, endPt.lat, endPt.lng);
+        pq.push({ key: neighbor, f: newG + EPSILON * h, g: newG });
       }
     }
   }
@@ -294,38 +303,47 @@ async function routeRailPathDirect(
   const endKey = findNearestKey(coordMap, toLat, toLng);
   if (!startKey || !endKey || startKey === endKey) return null;
 
-  // Dijkstra — shortest path by geographic distance (haversine).
-  // Plain BFS uses node-count which can prefer a longer route through
-  // a branch with fewer nodes (e.g., via Beeston instead of direct to Derby).
-  const dist = new Map<string, number>();
-  const parent = new Map<string, string>();
-  dist.set(startKey, 0);
+  // Weighted A* — biases toward the destination so the path prefers
+  // branches heading toward the target. Pure Dijkstra picks the
+  // geometrically shortest path which can detour through a nearby
+  // branch (e.g. via Beeston/Nottingham instead of direct to Derby).
+  // Epsilon > 1 trades slight optimality for directness.
+  const EPSILON = 1.3;
+  const endPt = coordMap.get(endKey)!;
 
-  // Simple priority queue (array sorted on insert — fine for ~50k nodes)
-  const pq: Array<{ key: string; d: number }> = [{ key: startKey, d: 0 }];
+  const gScore = new Map<string, number>();
+  const parent = new Map<string, string>();
+  gScore.set(startKey, 0);
+
+  const startPt = coordMap.get(startKey)!;
+  const startH = haversineKm(startPt.lat, startPt.lng, endPt.lat, endPt.lng);
+  const pq: Array<{ key: string; f: number; g: number }> = [
+    { key: startKey, f: EPSILON * startH, g: 0 },
+  ];
 
   let found = false;
   while (pq.length > 0) {
-    pq.sort((a, b) => a.d - b.d);
-    const { key: current, d: currentDist } = pq.shift()!;
+    pq.sort((a, b) => a.f - b.f);
+    const { key: current, g: currentG } = pq.shift()!;
 
     if (current === endKey) {
       found = true;
       break;
     }
 
-    if (currentDist > (dist.get(current) ?? Infinity)) continue;
+    if (currentG > (gScore.get(current) ?? Infinity)) continue;
 
     const currentPt = coordMap.get(current)!;
     for (const neighbor of adj.get(current) ?? []) {
       const neighborPt = coordMap.get(neighbor);
       if (!neighborPt) continue;
       const edgeDist = haversineKm(currentPt.lat, currentPt.lng, neighborPt.lat, neighborPt.lng);
-      const newDist = currentDist + edgeDist;
-      if (newDist < (dist.get(neighbor) ?? Infinity)) {
-        dist.set(neighbor, newDist);
+      const newG = currentG + edgeDist;
+      if (newG < (gScore.get(neighbor) ?? Infinity)) {
+        gScore.set(neighbor, newG);
         parent.set(neighbor, current);
-        pq.push({ key: neighbor, d: newDist });
+        const h = haversineKm(neighborPt.lat, neighborPt.lng, endPt.lat, endPt.lng);
+        pq.push({ key: neighbor, f: newG + EPSILON * h, g: newG });
       }
     }
   }

--- a/src/lib/actions/rail-network.ts
+++ b/src/lib/actions/rail-network.ts
@@ -28,6 +28,50 @@ export async function seedRailEdges(
   return { inserted: edges.length };
 }
 
+export type RouteSegment = {
+  osm_relation_id: number;
+  route_name: string | null;
+  operator: string | null;
+  from_station_name: string;
+  to_station_name: string;
+  from_station_code: string | null;
+  to_station_code: string | null;
+  encoded_polyline: string;
+  point_count: number;
+};
+
+export async function seedRouteSegments(
+  segments: RouteSegment[],
+): Promise<{ inserted: number }> {
+  const ctx = await requireUserContext();
+  if (!ctx.isAdmin) throw new Error("Admin only");
+  if (segments.length === 0) return { inserted: 0 };
+
+  const supabase = await createClient();
+  const { error } = await supabase
+    .from("rail_named_route_segments")
+    .upsert(segments, { onConflict: "from_station_code,to_station_code" });
+  if (error) throw new Error(`seedRouteSegments: ${error.message}`);
+  return { inserted: segments.length };
+}
+
+export async function getRouteSegmentStats(): Promise<{ count: number } | null> {
+  await requireUserContext();
+  const supabase = await createClient();
+  const { count, error } = await supabase
+    .from("rail_named_route_segments")
+    .select("id", { count: "exact", head: true });
+  if (error) return null;
+  return { count: count ?? 0 };
+}
+
+export async function clearRouteSegments(): Promise<void> {
+  const ctx = await requireUserContext();
+  if (!ctx.isAdmin) throw new Error("Admin only");
+  const supabase = await createClient();
+  await supabase.from("rail_named_route_segments").delete().gte("id", "00000000-0000-0000-0000-000000000000");
+}
+
 /**
  * Return the count of stored edges (null if table is empty / not seeded).
  */

--- a/src/lib/actions/transitions.ts
+++ b/src/lib/actions/transitions.ts
@@ -657,36 +657,29 @@ function pickPoint(stop: unknown): { lat: number; lng: number } | null {
 
 export async function backfillRailPolylines(
   itineraryId: string,
+  force?: boolean,
 ): Promise<{ filled: number }> {
   await requireUserContext();
   const supabase = await createClient();
 
-  // Find locked transit transitions without polylines
-  const { data: missing } = await supabase
+  let query = supabase
     .from("transitions")
     .select("id, mode, from_stop_id, to_stop_id")
     .eq("itinerary_id", itineraryId)
-    .eq("is_locked", true)
-    .is("overview_polyline", null);
+    .eq("is_locked", true);
+  if (!force) query = query.is("overview_polyline", null);
+  const { data: targets } = await query;
 
-  console.log("[rail-routes] backfill: found", missing?.length ?? 0, "transitions missing polylines");
-  if (!missing || missing.length === 0) return { filled: 0 };
+  if (!targets || targets.length === 0) return { filled: 0 };
 
   let filled = 0;
-  for (const t of missing) {
+  for (const t of targets) {
     const { data: stops, error: stopsErr } = await supabase
       .from("stops")
-      .select("id, transport_hub_id, transport_hub:transport_hubs(latitude, longitude, code)")
+      .select("id, metadata, transport_hub_id, transport_hub:transport_hubs(latitude, longitude, code)")
       .in("id", [t.from_stop_id, t.to_stop_id]);
 
-    if (stopsErr) {
-      console.error("[rail-routes] stops query error:", stopsErr.message);
-      continue;
-    }
-    if (!stops || stops.length < 2) {
-      console.log("[rail-routes] skipping transition", t.id, "- only", stops?.length ?? 0, "stops found");
-      continue;
-    }
+    if (stopsErr || !stops || stops.length < 2) continue;
     const fromStop = stops.find((s) => s.id === t.from_stop_id);
     const toStop = stops.find((s) => s.id === t.to_stop_id);
     const fh = first(fromStop?.transport_hub) as
@@ -695,19 +688,24 @@ export async function backfillRailPolylines(
     const th = first(toStop?.transport_hub) as
       | { latitude?: number | null; longitude?: number | null; code?: string | null }
       | null;
-    console.log("[rail-routes] from hub:", fh, "to hub:", th);
-    if (!fh?.latitude || !fh?.longitude || !th?.latitude || !th?.longitude) {
-      console.log("[rail-routes] skipping - missing coordinates");
-      continue;
-    }
+    if (!fh?.latitude || !fh?.longitude || !th?.latitude || !th?.longitude) continue;
+
+    // Extract calling point waypoints from departure stop metadata
+    const fromMeta = fromStop?.metadata as Record<string, unknown> | null;
+    const rawCps = fromMeta?.calling_points;
+    const waypoints = Array.isArray(rawCps)
+      ? (rawCps as Array<{ lat?: number; lng?: number }>)
+          .filter((cp) => cp.lat && cp.lng)
+          .map((cp) => ({ lat: cp.lat!, lng: cp.lng! }))
+      : undefined;
 
     try {
       const poly = await getRailPolyline(
         Number(fh.latitude), Number(fh.longitude),
         Number(th.latitude), Number(th.longitude),
         (fh.code as string) ?? null, (th.code as string) ?? null,
+        waypoints && waypoints.length > 0 ? waypoints : undefined,
       );
-      console.log("[rail-routes] polyline result for", t.id, ":", poly ? `${poly.length} chars` : "null");
       if (poly) {
         await supabase
           .from("transitions")
@@ -715,11 +713,10 @@ export async function backfillRailPolylines(
           .eq("id", t.id);
         filled++;
       }
-    } catch (err) {
-      console.error("[rail-routes] error for transition", t.id, ":", err);
+    } catch {
+      // Best-effort
     }
   }
-  console.log("[rail-routes] backfill complete:", filled, "filled");
   return { filled };
 }
 

--- a/src/lib/gmail/parsers.ts
+++ b/src/lib/gmail/parsers.ts
@@ -151,6 +151,7 @@ function makeSegment(partial: {
   seat?: string | null;
   barcode_ref?: string | null;
   barcode_data?: string | null;
+  calling_points?: Array<{ station: string; station_code: string | null; time: string }> | null;
 }): ParsedTransportSegment {
   return {
     from_station: partial.from_station,
@@ -171,6 +172,7 @@ function makeSegment(partial: {
     seat: partial.seat ?? null,
     barcode_ref: partial.barcode_ref ?? null,
     barcode_data: partial.barcode_data ?? null,
+    calling_points: partial.calling_points ?? null,
   };
 }
 

--- a/src/lib/gmail/trainline-pdf.ts
+++ b/src/lib/gmail/trainline-pdf.ts
@@ -225,6 +225,16 @@ const SKIP_LINES = new Set([
   "standard class",
   "first class",
   "quiet coach",
+  "railway",
+  "express",
+  "trains",
+  "coast",
+]);
+
+// Individual words that are part of operator names and should never be
+// treated as station names when they appear on their own line.
+const OPERATOR_FRAGMENTS = new Set([
+  "railway", "express", "trains", "coast",
 ]);
 
 function parseItineraryCallingPoints(

--- a/src/lib/gmail/trainline-pdf.ts
+++ b/src/lib/gmail/trainline-pdf.ts
@@ -2,7 +2,7 @@
 // Each PDF represents one ticket (one leg of the journey).
 // Also extracts Aztec barcode data from PDF images using ZXing WASM.
 
-import type { ParsedTransportSegment } from "./types";
+import type { CallingPoint, ParsedTransportSegment } from "./types";
 
 // NRS station code → full name mapping (common UK stations)
 const STATION_NAMES: Record<string, string> = {
@@ -71,6 +71,7 @@ export type TrainlinePdfTicket = {
   nrs_ref: string | null;
   barcode_ref: string | null;
   barcode_data: string | null;
+  calling_points: CallingPoint[];
 };
 
 export function parseTrainlinePdfText(pdfText: string): TrainlinePdfTicket | null {
@@ -142,14 +143,16 @@ export function parseTrainlinePdfText(pdfText: string): TrainlinePdfTicket | nul
     operator = parts.join(" ");
   }
 
-  // Arrival time: last time in the itinerary section before "Ticket Details"
-  const itineraryMatch = pdfText.match(
-    /Itinerary[\s\S]*?(\d{1,2}:\d{2})\n(?:No specific seat\n)?[A-Z][a-z]+(?:\n|$)[\s\S]*?(?:Ticket Details|$)/,
-  );
-  // Get ALL times from the itinerary to find the last arrival
+  // Arrival time + calling points from the itinerary section.
+  // The itinerary lists each stop with a time and station name, e.g.:
+  //   07:13\nNo specific seat\nWellingborough\n...\n07:45\nKettering\n...\n08:15\nLeicester
+  // We extract all (time, station) pairs. First is the departure, last is the
+  // arrival, and everything between is a calling point.
   const itinerarySection = pdfText.match(/Itinerary[\s\S]*?(?=Ticket Details)/)?.[0] ?? "";
   const itineraryTimes = [...itinerarySection.matchAll(/(\d{1,2}:\d{2})/g)].map((m) => m[1]);
   const arrivalTime = itineraryTimes.length > 0 ? itineraryTimes[itineraryTimes.length - 1] : "";
+
+  const callingPoints = parseItineraryCallingPoints(itinerarySection, fromCode, toCode);
 
   // Price: "Price £19.70" (appears as "Price Â£19.70" due to encoding)
   const priceMatch = pdfText.match(/Price\s+(?:Â£|£)([\d.]+)/);
@@ -186,7 +189,106 @@ export function parseTrainlinePdfText(pdfText: string): TrainlinePdfTicket | nul
     nrs_ref: nrsRef,
     barcode_ref: barcodeRef,
     barcode_data: barcodeData,
+    calling_points: callingPoints,
   };
+}
+
+// Known operator names that appear in the itinerary section (split across lines).
+// These should NOT be treated as station names.
+const OPERATOR_NAMES = new Set([
+  "east midlands railway",
+  "avanti west coast",
+  "crosscountry",
+  "lner",
+  "great western railway",
+  "northern",
+  "transpennine express",
+  "southeastern",
+  "southern",
+  "thameslink",
+  "scotrail",
+  "chiltern railways",
+  "greater anglia",
+  "west midlands trains",
+  "c2c",
+  "gatwick express",
+  "hull trains",
+  "grand central",
+  "merseyrail",
+  "elizabeth line",
+  "heathrow express",
+]);
+
+const SKIP_LINES = new Set([
+  "no specific seat",
+  "itinerary",
+  "standard class",
+  "first class",
+  "quiet coach",
+]);
+
+function parseItineraryCallingPoints(
+  itinerarySection: string,
+  fromCode: string,
+  toCode: string,
+): CallingPoint[] {
+  if (!itinerarySection) return [];
+
+  const lines = itinerarySection.split("\n").map((l) => l.trim()).filter(Boolean);
+
+  // Build (time, station) pairs by scanning for times followed by station names.
+  // Pattern: a line with HH:MM, then skip noise lines (operator, "No specific seat"),
+  // until we hit a line that looks like a station name (capitalised, not an operator).
+  const stops: { time: string; station: string; code: string | null }[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    const timeMatch = lines[i].match(/^(\d{1,2}:\d{2})$/);
+    if (!timeMatch) { i++; continue; }
+
+    const time = timeMatch[1];
+    // Look ahead for a station name
+    let station: string | null = null;
+    let code: string | null = null;
+    for (let j = i + 1; j < Math.min(i + 5, lines.length); j++) {
+      const line = lines[j];
+      if (/^\d{1,2}:\d{2}$/.test(line)) break;
+      if (SKIP_LINES.has(line.toLowerCase())) continue;
+      // Skip if it's a partial operator name (operators span multiple lines)
+      const combined = lines.slice(j, j + 2).join(" ").toLowerCase();
+      if (OPERATOR_NAMES.has(combined) || OPERATOR_NAMES.has(line.toLowerCase())) continue;
+      // Station names start with a capital letter and are typically 3+ chars
+      if (/^[A-Z][a-z]/.test(line) && line.length >= 3) {
+        station = line;
+        // Check if there's a station code in parentheses or on the next line
+        const codeMatch = line.match(/\(([A-Z]{3})\)/);
+        if (codeMatch) {
+          code = codeMatch[1];
+          station = line.replace(/\s*\([A-Z]{3}\)/, "").trim();
+        }
+        break;
+      }
+    }
+    if (station) {
+      // Try to resolve to a CRS code if we don't already have one
+      if (!code) {
+        const entry = Object.entries(STATION_NAMES).find(
+          ([, name]) => name.toLowerCase() === station!.toLowerCase(),
+        );
+        if (entry) code = entry[0];
+      }
+      stops.push({ time, station, code });
+    }
+    i++;
+  }
+
+  if (stops.length <= 2) return [];
+
+  // First stop is the departure origin, last is arrival destination — exclude both.
+  return stops.slice(1, -1).map((s) => ({
+    station: s.station,
+    station_code: s.code,
+    time: s.time,
+  }));
 }
 
 // Extract barcode data from .pkpass wallet pass files.
@@ -349,5 +451,6 @@ export function pdfTicketsToSegments(
     seat: t.seat,
     barcode_ref: t.barcode_ref,
     barcode_data: t.barcode_data,
+    calling_points: t.calling_points.length > 0 ? t.calling_points : null,
   }));
 }

--- a/src/lib/gmail/types.ts
+++ b/src/lib/gmail/types.ts
@@ -1,5 +1,11 @@
 // Shared types for Gmail booking import.
 
+export type CallingPoint = {
+  station: string;
+  station_code: string | null;
+  time: string; // HH:MM — arrival time at this calling point
+};
+
 export type ParsedTransportSegment = {
   from_station: string;
   to_station: string;
@@ -19,6 +25,7 @@ export type ParsedTransportSegment = {
   seat: string | null;
   barcode_ref: string | null;
   barcode_data: string | null; // Full Aztec/barcode payload for regeneration
+  calling_points: CallingPoint[] | null;
 };
 
 export type ParsedTransportBooking = {

--- a/src/lib/osm/rail-routes.ts
+++ b/src/lib/osm/rail-routes.ts
@@ -36,8 +36,20 @@ export async function getRailPolyline(
       if (data?.encoded_polyline) return data.encoded_polyline;
     }
 
+    // Auto-discover intermediate stations when no calling points provided.
+    // Finds rail stations along the direct line between origin and
+    // destination, then uses them as waypoints to force the path through
+    // the correct branch at junctions.
+    let effectiveWaypoints = waypoints;
+    if (!hasWaypoints) {
+      const discovered = await discoverIntermediateStations(
+        supabase, fromLat, fromLng, toLat, toLng, fromCode, toCode,
+      );
+      if (discovered.length > 0) effectiveWaypoints = discovered;
+    }
+
     const polyline = await routeRailPath(
-      fromLat, fromLng, toLat, toLng, waypoints,
+      fromLat, fromLng, toLat, toLng, effectiveWaypoints,
     );
     if (!polyline) return null;
 

--- a/src/lib/osm/rail-routes.ts
+++ b/src/lib/osm/rail-routes.ts
@@ -7,10 +7,10 @@ type LatLng = { lat: number; lng: number };
  * Get an encoded polyline for a rail route between two stations.
  *
  * 1. Check the `rail_route_cache` table (L1 — keyed by CRS code pair).
- * 2. On miss, call `routeRailPath` which BFS-routes through the stored
- *    rail_network_edges graph (seeded from the admin page).
- * 3. If the graph produces a result, cache it for next time.
- * 4. If the network hasn't been seeded, return null gracefully.
+ * 2. On miss, auto-discover intermediate stations along the direct line
+ *    to use as waypoints (prevents wrong-branch routing at junctions).
+ * 3. Call `routeRailPath` (weighted A*) through the stored rail network.
+ * 4. Cache the result for next time.
  */
 export async function getRailPolyline(
   fromLat: number,
@@ -36,13 +36,23 @@ export async function getRailPolyline(
       if (data?.encoded_polyline) return data.encoded_polyline;
     }
 
-    // L2: Dijkstra through the stored rail network graph
+    // Auto-discover intermediate stations when no calling points provided.
+    // Finds rail stations along the direct line between origin and
+    // destination, then uses them as waypoints to force the path through
+    // the correct branch at junctions.
+    let effectiveWaypoints = waypoints;
+    if (!hasWaypoints) {
+      const discovered = await discoverIntermediateStations(
+        supabase, fromLat, fromLng, toLat, toLng, fromCode, toCode,
+      );
+      if (discovered.length > 0) effectiveWaypoints = discovered;
+    }
+
     const polyline = await routeRailPath(
-      fromLat, fromLng, toLat, toLng, waypoints,
+      fromLat, fromLng, toLat, toLng, effectiveWaypoints,
     );
     if (!polyline) return null;
 
-    // Cache the result for next time
     if (fromCode && toCode) {
       await supabase.from("rail_route_cache").upsert(
         {
@@ -59,6 +69,105 @@ export async function getRailPolyline(
   } catch {
     return null;
   }
+}
+
+/**
+ * Find rail stations that lie along the corridor between two points.
+ * Returns stations sorted by progress along the line, excluding the
+ * origin and destination themselves. Used as synthetic waypoints
+ * when no calling points are available from ticket data.
+ */
+async function discoverIntermediateStations(
+  supabase: Awaited<ReturnType<typeof createSupabaseClient>>,
+  fromLat: number,
+  fromLng: number,
+  toLat: number,
+  toLng: number,
+  fromCode?: string | null,
+  toCode?: string | null,
+): Promise<Array<{ lat: number; lng: number }>> {
+  const directDistKm = haversineKm(fromLat, fromLng, toLat, toLng);
+  if (directDistKm < 10) return [];
+
+  const pad = 0.05;
+  const minLat = Math.min(fromLat, toLat) - pad;
+  const maxLat = Math.max(fromLat, toLat) + pad;
+  const minLng = Math.min(fromLng, toLng) - pad;
+  const maxLng = Math.max(fromLng, toLng) + pad;
+
+  const { data: stations } = await supabase
+    .from("transport_hubs")
+    .select("code, latitude, longitude")
+    .eq("kind", "rail_station")
+    .gte("latitude", minLat)
+    .lte("latitude", maxLat)
+    .gte("longitude", minLng)
+    .lte("longitude", maxLng);
+
+  if (!stations || stations.length === 0) return [];
+
+  // Direction vector from origin to destination
+  const dLat = toLat - fromLat;
+  const dLng = toLng - fromLng;
+  const len2 = dLat * dLat + dLng * dLng;
+  if (len2 === 0) return [];
+
+  // Corridor width scales with route distance — wider for longer routes
+  const corridorKm = Math.min(8, Math.max(3, directDistKm * 0.08));
+
+  const candidates: Array<{ lat: number; lng: number; t: number }> = [];
+
+  for (const s of stations) {
+    const sLat = Number(s.latitude);
+    const sLng = Number(s.longitude);
+    if (!sLat || !sLng) continue;
+
+    // Skip origin/destination
+    if (s.code === fromCode || s.code === toCode) continue;
+
+    // Project station onto the origin→destination line
+    const t = ((sLat - fromLat) * dLat + (sLng - fromLng) * dLng) / len2;
+    if (t <= 0.05 || t >= 0.95) continue;
+
+    // Perpendicular distance from the direct line
+    const projLat = fromLat + t * dLat;
+    const projLng = fromLng + t * dLng;
+    const perpDist = haversineKm(sLat, sLng, projLat, projLng);
+
+    if (perpDist <= corridorKm) {
+      candidates.push({ lat: sLat, lng: sLng, t });
+    }
+  }
+
+  // Sort by progress along the line
+  candidates.sort((a, b) => a.t - b.t);
+
+  // For long routes with many candidates, keep only a few well-spaced ones
+  if (candidates.length > 5) {
+    const kept: typeof candidates = [];
+    let lastT = -0.2;
+    for (const c of candidates) {
+      if (c.t - lastT >= 0.15) {
+        kept.push(c);
+        lastT = c.t;
+      }
+    }
+    return kept.map(({ lat, lng }) => ({ lat, lng }));
+  }
+
+  return candidates.map(({ lat, lng }) => ({ lat, lng }));
+}
+
+function haversineKm(lat1: number, lng1: number, lat2: number, lng2: number): number {
+  const R = 6371;
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLng = ((lng2 - lng1) * Math.PI) / 180;
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos((lat1 * Math.PI) / 180) *
+      Math.cos((lat2 * Math.PI) / 180) *
+      Math.sin(dLng / 2) ** 2;
+  return 2 * R * Math.asin(Math.sqrt(a));
 }
 
 // Google's encoded polyline algorithm — kept here for shared use.

--- a/src/lib/osm/rail-routes.ts
+++ b/src/lib/osm/rail-routes.ts
@@ -19,12 +19,14 @@ export async function getRailPolyline(
   toLng: number,
   fromCode?: string | null,
   toCode?: string | null,
+  waypoints?: Array<{ lat: number; lng: number }>,
 ): Promise<string | null> {
   try {
     const supabase = await createSupabaseClient();
+    const hasWaypoints = waypoints && waypoints.length > 0;
 
-    // L1: code-pair cache lookup
-    if (fromCode && toCode) {
+    // L1: code-pair cache lookup (skip when waypoints constrain the route)
+    if (fromCode && toCode && !hasWaypoints) {
       const { data } = await supabase
         .from("rail_route_cache")
         .select("encoded_polyline")
@@ -34,11 +36,13 @@ export async function getRailPolyline(
       if (data?.encoded_polyline) return data.encoded_polyline;
     }
 
-    // L2: BFS through the stored rail network graph
-    const polyline = await routeRailPath(fromLat, fromLng, toLat, toLng);
+    // L2: Dijkstra through the stored rail network graph
+    const polyline = await routeRailPath(
+      fromLat, fromLng, toLat, toLng, waypoints,
+    );
     if (!polyline) return null;
 
-    // Cache the result for next time (best-effort, don't fail the caller)
+    // Cache the result for next time
     if (fromCode && toCode) {
       await supabase.from("rail_route_cache").upsert(
         {

--- a/src/lib/osm/rail-routes.ts
+++ b/src/lib/osm/rail-routes.ts
@@ -25,6 +25,18 @@ export async function getRailPolyline(
     const supabase = await createSupabaseClient();
     const hasWaypoints = waypoints && waypoints.length > 0;
 
+    // L0: named route lookup — authoritative OSM route relation geometry.
+    // No routing needed; the polyline comes directly from the relation.
+    if (fromCode && toCode) {
+      const { data: named } = await supabase
+        .from("rail_named_route_segments")
+        .select("encoded_polyline")
+        .eq("from_station_code", fromCode)
+        .eq("to_station_code", toCode)
+        .maybeSingle();
+      if (named?.encoded_polyline) return named.encoded_polyline;
+    }
+
     // L1: code-pair cache lookup (skip when waypoints constrain the route)
     if (fromCode && toCode && !hasWaypoints) {
       const { data } = await supabase

--- a/src/lib/osm/rail-routes.ts
+++ b/src/lib/osm/rail-routes.ts
@@ -36,20 +36,8 @@ export async function getRailPolyline(
       if (data?.encoded_polyline) return data.encoded_polyline;
     }
 
-    // Auto-discover intermediate stations when no calling points provided.
-    // Finds rail stations along the direct line between origin and
-    // destination, then uses them as waypoints to force the path through
-    // the correct branch at junctions.
-    let effectiveWaypoints = waypoints;
-    if (!hasWaypoints) {
-      const discovered = await discoverIntermediateStations(
-        supabase, fromLat, fromLng, toLat, toLng, fromCode, toCode,
-      );
-      if (discovered.length > 0) effectiveWaypoints = discovered;
-    }
-
     const polyline = await routeRailPath(
-      fromLat, fromLng, toLat, toLng, effectiveWaypoints,
+      fromLat, fromLng, toLat, toLng, waypoints,
     );
     if (!polyline) return null;
 

--- a/src/lib/osm/rail-routes.ts
+++ b/src/lib/osm/rail-routes.ts
@@ -112,8 +112,12 @@ async function discoverIntermediateStations(
   const len2 = dLat * dLat + dLng * dLng;
   if (len2 === 0) return [];
 
-  // Corridor width scales with route distance — wider for longer routes
-  const corridorKm = Math.min(8, Math.max(3, directDistKm * 0.08));
+  // UK rail lines curve significantly — the Midland Main Line deviates
+  // up to 10km from the Leicester→Derby straight line. Scale corridor
+  // with route length, generous enough to capture real intermediate
+  // stations but tight enough to exclude parallel lines (Beeston is
+  // 16km off the LEI→DBY direct line).
+  const corridorKm = Math.max(5, Math.min(15, directDistKm * 0.3));
 
   const candidates: Array<{ lat: number; lng: number; t: number }> = [];
 

--- a/supabase/migrations/0027_segment_calling_points.sql
+++ b/supabase/migrations/0027_segment_calling_points.sql
@@ -1,0 +1,5 @@
+-- Add calling_points to travel_booking_segments.
+-- Stores intermediate station stops parsed from Trainline PDF itineraries.
+-- Format: [{station, station_code, time}]
+ALTER TABLE travel_booking_segments
+  ADD COLUMN IF NOT EXISTS calling_points jsonb;

--- a/supabase/migrations/0028_rail_named_route_segments.sql
+++ b/supabase/migrations/0028_rail_named_route_segments.sql
@@ -1,0 +1,14 @@
+CREATE TABLE rail_named_route_segments (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  osm_relation_id bigint NOT NULL,
+  route_name text,
+  operator text,
+  from_station_name text NOT NULL,
+  to_station_name text NOT NULL,
+  from_station_code text,
+  to_station_code text,
+  encoded_polyline text NOT NULL,
+  point_count integer DEFAULT 0,
+  created_at timestamptz DEFAULT now(),
+  UNIQUE (from_station_code, to_station_code)
+);


### PR DESCRIPTION
## Summary

- **Calling points**: parse intermediate stations from Trainline PDF etickets, display on map as waypoint markers and on timeline as a subtle station strip on TrainTicketCards
- **Planning-page transport bookings**: `+ Transport` now creates full booking entities (not bare stops) — same capabilities as the brief. `addFullTransportBooking` server action handles the complete pipeline
- **Re-enrich from Gmail**: "Refresh ticket details" button re-fetches Trainline PDFs, re-parses with updated parser, patches existing stop metadata with calling points + coordinates, regenerates rail polylines
- **Map expand button**: desktop-only expand/collapse for the route map card
- **OSM route relations seeder**: new admin page at `/settings/rail-routes` — upload Overpass JSON, client-side processing extracts station-to-station polylines from named route relations. `getRailPolyline` checks this table first (L0) before falling back to algorithmic routing
- **Rail routing improvements**: weighted A*, corridor pruning, auto-discovered waypoints, per-segment endpoint chaining (fallbacks for routes not yet covered by named relations)

### After merging

1. Deploy
2. Drop the Overpass JSON file into the repo (e.g. `data/osm-rail-routes.json`)
3. Go to `/settings/rail-routes` and upload it — the seeder page processes it client-side and stores station-to-station polylines
4. Hit "Refresh ticket details" on any itinerary — polylines will now come from named OSM route relations instead of algorithmic routing

### Key architectural insight

Rail polylines can't be solved by smarter graph algorithms on raw OSM ways. Junctions like Trent Junction have multiple valid paths and the algorithm doesn't know which branch belongs to which service. The fix is using **OSM route relations** (`type=route, route=train`) which explicitly group ways into named lines. The Midland Main Line IS its relation — no routing needed, just a geometry lookup.

The seeder page + `rail_named_route_segments` table + L0 lookup in `getRailPolyline` implement this. The Dijkstra/A* fallback remains for routes not yet covered by relations.

### Files changed (24 files, +1700 lines)

| Area | Files | What |
|------|-------|------|
| Calling points | `trainline-pdf.ts`, `gmail/types.ts`, `train-ticket-card.tsx`, `journey-spine.tsx`, `transport-booking-card.tsx` | Parse from PDFs, display on timeline |
| Map | `journey-map.tsx`, `itinerary-editor.tsx`, `globals.css` | Waypoint markers, expand button, coordinate guards |
| Planning bookings | `bookings.ts`, `itinerary-editor.tsx`, `gmail-import-panel.tsx` | `addFullTransportBooking`, upgraded submit, calling_points in import |
| Re-enrich | `gmail.ts`, `itinerary-editor.tsx`, `transitions.ts` | `reEnrichItineraryFromGmail`, forced polyline regen |
| Rail routing | `rail-network.ts`, `rail-routes.ts` | A*, corridor pruning, auto-discovery, named route L0 lookup |
| Route seeder | `settings/rail-routes/` | Admin upload page for Overpass JSON |
| Schema | `itineraries.ts`, `bookings.ts`, `build-planning-timeline.ts`, `parsers.ts` | calling_points through the full pipeline |
| Migrations | `0027`, `0028` | `calling_points` jsonb column, `rail_named_route_segments` table |

### Bug fixes
- Kettering (KET) resolved to Kengtung Airport (Myanmar) — hub lookups now filter `kind='rail_station'`
- "Railway" parsed as a station name from "East Midlands Railway" — added to skip list
- Map panning to Azerbaijan — waypoints with null coordinates excluded from bounds
- Gmail import panel now passes `calling_points` through

### Test plan

- [ ] Brief page: create itinerary with transport bookings — still works end-to-end
- [ ] Planning page: timeline renders, stops editable, no regressions
- [ ] `+ Transport` on planning page creates full booking with ticket cards
- [ ] "Refresh ticket details" re-enriches calling points from Gmail
- [ ] Map expand button visible on desktop, hidden on mobile
- [ ] `/settings/rail-routes`: upload Overpass JSON, segments parsed and seeded
- [ ] After seeding: Leicester→Derby polyline uses named route (no Beeston fork)
- [ ] Calling points on TrainTicketCard (time/dot/station strip)
- [ ] Calling point waypoints on map (small gold circles)

https://claude.ai/code/session_0142KBi45Scqowo19P2UwVkV