### PR TITLE
Planning page stabilisation: perf, bugs, mobile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,13 +150,14 @@ Two-tier: `rail_route_cache` (L1, by CRS code pair) → `routeRailPath` BFS (L2,
 ### Pipe characters in polylines
 Google's encoded polyline format can produce `|` characters. Google Static Maps uses `|` as a path parameter delimiter. The `buildStaticMapUrl` function in `src/lib/google/maps.ts` uses `encodeURIComponent` on the polyline and manually appends path params (NOT `URLSearchParams`, which double-encodes `%7C`).
 
-## Admin Role
+## Roles
 
-`is_admin` boolean on `profiles` table (migration 0026). Separate from `is_staff`:
-- **Staff**: demo mode, palette picker, feature testing
-- **Admin**: system tools (rail network seeding, data management)
+Three role flags on `profiles` table, each independent:
+- **Staff** (`is_staff`): demo mode, palette picker, feature testing
+- **Admin** (`is_admin`): workspace-level administration (managing users, workspace settings)
+- **Super User** (`is_super_user`, migration 0029): developer/system tools (rail network seeding, rail route relations, data management)
 
-`requireUserContext()` returns `isAdmin` alongside `isStaff`. Admin pages redirect non-admins. Admin server actions reject non-admins.
+`requireUserContext()` returns `isStaff`, `isAdmin`, `isSuperUser`. Super user pages (`/settings/rail-network`, `/settings/rail-routes`) redirect non-super-users. Server actions reject non-super-users.
 
 ## JourneyMap (MapLibre)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,10 +6,20 @@
 
 After making changes to any itinerary page, the Gmail import pipeline, or the shared Timeline component, **update `docs/itinerary-pages.md`** to reflect the change. This document is the design reference for anyone picking up the codebase — it must stay current. If a new page is added, add a new doc file for it.
 
-## Known Bugs (as of 2026-05-26)
+## Known Bugs (as of 2026-05-27)
 
-### Planning page after brief submit
+### Planning page
 - All previously listed bugs FIXED (see git history)
+- ~~Location selection silently dropped on new anchors~~ FIXED: handleAnchorPatch falls back to planningAnchors when editedAnchors has no entry
+- ~~Ghost "via Walk" + duplicate add buttons~~ FIXED: removed duplicate home→first gap from buildPlanningTimeline (editor renders it manually)
+- ~~10s+ anchor card insert latency~~ FIXED: optimistic local insertion (card appears from server action return, router.refresh runs in background); solver skipped for empty stops
+- ~~disabled={pending} blocks all buttons~~ FIXED: only advance-status and masthead-save disable during their own action
+
+### Planned pivot (2026-05-27)
+- User is considering a "facts-first" model: events, bookings, hotels are thrown at the app and stick to their dates. Days emerge from accumulated facts rather than being planned upfront.
+- The current planning page layout (timeline + map + transitions) would become a **day view** — a read slice through all facts touching that date.
+- The brief's linear workflow (brief → planning → planned → live) would be replaced by a calendar-like home screen where days light up as facts accumulate.
+- This pivot leverages most existing components (anchor cards, transport bookings, accommodation bookings, timeline renderer, map, solver). The change is primarily in the entry flow and home surface.
 - ~~Batch transition insert crashed on unique constraint~~ FIXED: `.insert()` → `.upsert()` with onConflict
 - ~~Changeover stops (Leicester) had no transport_hub_id~~ FIXED: Gmail import now resolves changeover station names via resolveHubByName
 - ~~Google Transit duration overwrites booked train times~~ FIXED: skip `computed_duration_minutes` overwrite for locked (is_locked=true) legs

--- a/scripts/seed-route-relations.mjs
+++ b/scripts/seed-route-relations.mjs
@@ -1,0 +1,208 @@
+// Process the Overpass JSON export and seed rail_named_route_segments
+// Run: node scripts/seed-route-relations.mjs
+
+import { createClient } from "@supabase/supabase-js";
+import { readFileSync } from "fs";
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error("Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY");
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+
+console.log("Loading JSON...");
+const data = JSON.parse(readFileSync("/tmp/export.json", "utf8"));
+
+console.log("Building lookups...");
+const nodeMap = new Map();
+const wayMap = new Map();
+const relations = [];
+
+for (const el of data.elements) {
+  if (el.type === "node" && el.lat != null) nodeMap.set(el.id, { lat: el.lat, lon: el.lon });
+  else if (el.type === "way" && el.nodes) wayMap.set(el.id, el.nodes);
+  else if (el.type === "relation") relations.push(el);
+}
+
+console.log(`${nodeMap.size} nodes, ${wayMap.size} ways, ${relations.length} relations`);
+
+// Load transport hubs for station matching
+console.log("Loading transport hubs...");
+const { data: hubs } = await supabase
+  .from("transport_hubs")
+  .select("code, name, latitude, longitude")
+  .eq("kind", "rail_station")
+  .not("code", "is", null)
+  .not("latitude", "is", null);
+
+const hubList = (hubs || []).map(h => ({
+  code: h.code,
+  name: h.name,
+  lat: Number(h.latitude),
+  lng: Number(h.longitude),
+}));
+console.log(`${hubList.length} rail stations loaded`);
+
+function sqDist(a, b) {
+  return (a.lat - b.lat) ** 2 + ((a.lon ?? a.lng) - (b.lon ?? b.lng)) ** 2;
+}
+
+function encodePolyline(points) {
+  let encoded = "";
+  let prevLat = 0;
+  let prevLng = 0;
+  for (const { lat, lon } of points) {
+    const latE5 = Math.round(lat * 1e5);
+    const lngE5 = Math.round(lon * 1e5);
+    encoded += encVal(latE5 - prevLat);
+    encoded += encVal(lngE5 - prevLng);
+    prevLat = latE5;
+    prevLng = lngE5;
+  }
+  return encoded;
+}
+
+function encVal(value) {
+  let v = value < 0 ? ~(value << 1) : value << 1;
+  let out = "";
+  while (v >= 0x20) {
+    out += String.fromCharCode((0x20 | (v & 0x1f)) + 63);
+    v >>= 5;
+  }
+  out += String.fromCharCode(v + 63);
+  return out;
+}
+
+const allSegments = [];
+const seenPairs = new Set();
+let processed = 0;
+
+for (const rel of relations) {
+  const tags = rel.tags || {};
+  if (tags.type !== "route" || tags.route !== "train") continue;
+
+  const routeName = tags.name || tags.ref || `Relation ${rel.id}`;
+  const operator = tags.operator || null;
+
+  const wayMembers = rel.members.filter(m => m.type === "way");
+  const stopMembers = rel.members.filter(
+    m => m.type === "node" && (m.role.includes("stop") || m.role === ""),
+  );
+
+  if (wayMembers.length === 0 || stopMembers.length < 2) continue;
+
+  // Build route geometry from ordered ways
+  const routePoints = [];
+  for (const wm of wayMembers) {
+    const nodeIds = wayMap.get(wm.ref);
+    if (!nodeIds) continue;
+
+    const wayPts = [];
+    for (const nid of nodeIds) {
+      const nd = nodeMap.get(nid);
+      if (nd) wayPts.push({ lat: nd.lat, lon: nd.lon });
+    }
+    if (wayPts.length === 0) continue;
+
+    if (routePoints.length > 0 && wayPts.length > 0) {
+      const last = routePoints[routePoints.length - 1];
+      const distFirst = sqDist(last, wayPts[0]);
+      const distLast = sqDist(last, wayPts[wayPts.length - 1]);
+      if (distLast < distFirst) wayPts.reverse();
+      wayPts.shift();
+    }
+    routePoints.push(...wayPts);
+  }
+
+  if (routePoints.length < 2) continue;
+
+  // Match stop nodes to transport hubs by proximity
+  const stations = [];
+  for (const sm of stopMembers) {
+    const nd = nodeMap.get(sm.ref);
+    if (!nd) continue;
+
+    let bestHub = null;
+    let bestDist = Infinity;
+    for (const hub of hubList) {
+      const d = (nd.lat - hub.lat) ** 2 + (nd.lon - hub.lng) ** 2;
+      if (d < bestDist) { bestDist = d; bestHub = hub; }
+    }
+    if (!bestHub || bestDist > 0.0001) continue; // ~1km
+
+    let bestIdx = 0;
+    let bestPosDist = Infinity;
+    for (let i = 0; i < routePoints.length; i++) {
+      const d = sqDist(nd, routePoints[i]);
+      if (d < bestPosDist) { bestPosDist = d; bestIdx = i; }
+    }
+
+    stations.push({ name: bestHub.name, code: bestHub.code, posIdx: bestIdx });
+  }
+
+  stations.sort((a, b) => a.posIdx - b.posIdx);
+  const unique = stations.filter((s, i) => i === 0 || s.posIdx !== stations[i - 1].posIdx);
+
+  for (let i = 0; i < unique.length - 1; i++) {
+    const from = unique[i];
+    const to = unique[i + 1];
+    if (!from.code || !to.code) continue;
+    if (to.posIdx <= from.posIdx) continue;
+
+    const pairKey = `${from.code}:${to.code}`;
+    if (seenPairs.has(pairKey)) continue;
+    seenPairs.add(pairKey);
+
+    const segPts = routePoints.slice(from.posIdx, to.posIdx + 1);
+    if (segPts.length < 2) continue;
+
+    allSegments.push({
+      osm_relation_id: rel.id,
+      route_name: routeName,
+      operator,
+      from_station_name: from.name,
+      to_station_name: to.name,
+      from_station_code: from.code,
+      to_station_code: to.code,
+      encoded_polyline: encodePolyline(segPts),
+      point_count: segPts.length,
+    });
+  }
+
+  processed++;
+  if (processed % 50 === 0) console.log(`Processed ${processed} relations, ${allSegments.length} segments...`);
+}
+
+console.log(`\nTotal: ${allSegments.length} segments from ${processed} relations`);
+
+// Check for our critical route
+const lei_dby = allSegments.filter(s =>
+  (s.from_station_code === "LEI" && s.to_station_code === "DBY") ||
+  (s.from_station_code === "DBY" && s.to_station_code === "LEI")
+);
+console.log(`LEI↔DBY segments:`, lei_dby.map(s => `${s.from_station_code}→${s.to_station_code} (${s.point_count} pts, ${s.route_name})`));
+
+// Clear existing and seed
+console.log("\nClearing existing segments...");
+await supabase.from("rail_named_route_segments").delete().gte("id", "00000000-0000-0000-0000-000000000000");
+
+console.log("Seeding...");
+const BATCH = 50;
+let seeded = 0;
+for (let i = 0; i < allSegments.length; i += BATCH) {
+  const chunk = allSegments.slice(i, i + BATCH);
+  const { error } = await supabase.from("rail_named_route_segments").upsert(chunk, {
+    onConflict: "from_station_code,to_station_code",
+  });
+  if (error) {
+    console.error(`Error at batch ${i}:`, error.message);
+    break;
+  }
+  seeded += chunk.length;
+}
+
+console.log(`Done: ${seeded} segments seeded.`);

--- a/src/app/(app)/itineraries/[id]/itinerary-editor.tsx
+++ b/src/app/(app)/itineraries/[id]/itinerary-editor.tsx
@@ -1696,39 +1696,47 @@ export function ItineraryEditor({
 
             <div className="digest-panel">
               <div className="h">Day · digest</div>
-              {onSiteWindow ? (
-                <div className="row">
-                  <span className="l">On-site window</span>
-                  <span className="v">
-                    {fmtTime(onSiteWindow.from, timezone)}
-                    {onSiteWindow.to && onSiteWindow.to !== onSiteWindow.from
-                      ? ` – ${fmtTime(onSiteWindow.to, timezone)}`
-                      : ""}
-                  </span>
-                </div>
-              ) : null}
-              <div className="row">
-                <span className="l">Travel time</span>
-                <span className="v">{fmtDuration(totalMinutes)}</span>
-              </div>
-              <div className="row">
-                <span className="l">Distance</span>
-                <span className="v">{totalMiles.toFixed(1)} mi</span>
-              </div>
-              {totals.cost > 0 ? (
-                <div className="row total">
-                  <span className="l">Costs</span>
-                  <span className="v">
-                    {fmtCurrency(totals.cost, totals.currency)}
-                  </span>
-                </div>
+              {totalMinutes === 0 && totalMiles === 0 && !onSiteWindow ? (
+                <p style={{ fontSize: 12, color: "var(--ink-faint)", fontStyle: "italic", margin: "8px 0 0" }}>
+                  Stats appear as you add stops and connections
+                </p>
               ) : (
-                <div className="row">
-                  <span className="l">Costs</span>
-                  <span className="v" style={{ color: "var(--ink-faint)" }}>
-                    —
-                  </span>
-                </div>
+                <>
+                  {onSiteWindow ? (
+                    <div className="row">
+                      <span className="l">On-site window</span>
+                      <span className="v">
+                        {fmtTime(onSiteWindow.from, timezone)}
+                        {onSiteWindow.to && onSiteWindow.to !== onSiteWindow.from
+                          ? ` – ${fmtTime(onSiteWindow.to, timezone)}`
+                          : ""}
+                      </span>
+                    </div>
+                  ) : null}
+                  <div className="row">
+                    <span className="l">Travel time</span>
+                    <span className="v">{fmtDuration(totalMinutes)}</span>
+                  </div>
+                  <div className="row">
+                    <span className="l">Distance</span>
+                    <span className="v">{totalMiles.toFixed(1)} mi</span>
+                  </div>
+                  {totals.cost > 0 ? (
+                    <div className="row total">
+                      <span className="l">Costs</span>
+                      <span className="v">
+                        {fmtCurrency(totals.cost, totals.currency)}
+                      </span>
+                    </div>
+                  ) : (
+                    <div className="row">
+                      <span className="l">Costs</span>
+                      <span className="v" style={{ color: "var(--ink-faint)" }}>
+                        —
+                      </span>
+                    </div>
+                  )}
+                </>
               )}
             </div>
           </aside>

--- a/src/app/(app)/itineraries/[id]/itinerary-editor.tsx
+++ b/src/app/(app)/itineraries/[id]/itinerary-editor.tsx
@@ -1048,11 +1048,10 @@ export function ItineraryEditor({
 
   // Build a Journey object for the JourneyMap component. Converts the
   // existing stops + transitions into the component's domain types.
-  const journeyMapData = useMemo<Journey | null>(() => {
-    if (sortedStops.length < 2) return null;
-
+  const journeyMapData = useMemo<Journey>(() => {
     const legs: Leg[] = [];
 
+    if (sortedStops.length >= 2) {
     for (let i = 0; i < sortedStops.length - 1; i++) {
       const fromStop = sortedStops[i];
       const toStop = sortedStops[i + 1];
@@ -1151,8 +1150,7 @@ export function ItineraryEditor({
         ...(waypoints.length > 0 ? { waypoints } : {}),
       });
     }
-
-    if (legs.length === 0) return null;
+    } // close sortedStops.length >= 2
 
     return {
       id: itinerary.id,
@@ -1623,56 +1621,39 @@ export function ItineraryEditor({
 
           {/* Right: map + day digest */}
           <aside className="flex flex-col gap-5">
-            {journeyMapData && journeyMapData.legs.length > 0 ? (
-              <div className={`route-map-card${mapExpanded ? " map-expanded" : ""}`}>
-                <div className="route-map-header">
-                  <span className="route-map-eyebrow">Door-to-door</span>
-                  <span className="route-map-headline">
-                    {totalMiles > 0 && <>{Math.round(totalMiles)} mi</>}
-                    {totalMiles > 0 && totalMinutes > 0 && " · "}
-                    {totalMinutes > 0 && <>{fmtDuration(totalMinutes)}</>}
-                  </span>
-                  <button
-                    type="button"
-                    className="map-expand-btn"
-                    onClick={() => setMapExpanded((v) => !v)}
-                    title={mapExpanded ? "Collapse map" : "Expand map"}
-                  >
-                    {mapExpanded ? (
-                      <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-                        <path d="M10 2v4h4M2 10h4v4M14 2l-4 4M2 14l4-4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
-                      </svg>
-                    ) : (
-                      <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-                        <path d="M10 2v4h4M2 10h4v4M6 6L2 2M10 10l4 4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
-                      </svg>
-                    )}
-                  </button>
-                </div>
-                <div style={{ borderRadius: "0 0 12px 12px", overflow: "hidden", flex: mapExpanded ? 1 : undefined }}>
-                  <JourneyMap
-                    journey={journeyMapData}
-                    mode="planning"
-                    height={mapExpanded ? undefined : 320}
-                  />
-                </div>
-              </div>
-            ) : mapStops.length > 0 ? (
-              <RouteMap
-                stops={mapStops}
-                segments={mapSegments}
-                totalMiles={totalMiles}
-                totalMinutes={totalMinutes}
-              />
-            ) : (
-              <div
-                className="flex h-[320px] items-center justify-center rounded-md border border-dashed border-rule-2 bg-card-2 text-center"
-              >
-                <span className="small px-6">
-                  Map appears once stops have addresses.
+            <div className={`route-map-card${mapExpanded ? " map-expanded" : ""}`}>
+              <div className="route-map-header">
+                <span className="route-map-eyebrow">Door-to-door</span>
+                <span className="route-map-headline">
+                  {totalMiles > 0 && <>{Math.round(totalMiles)} mi</>}
+                  {totalMiles > 0 && totalMinutes > 0 && " · "}
+                  {totalMinutes > 0 && <>{fmtDuration(totalMinutes)}</>}
                 </span>
+                <button
+                  type="button"
+                  className="map-expand-btn"
+                  onClick={() => setMapExpanded((v) => !v)}
+                  title={mapExpanded ? "Collapse map" : "Expand map"}
+                >
+                  {mapExpanded ? (
+                    <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                      <path d="M10 2v4h4M2 10h4v4M14 2l-4 4M2 14l4-4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+                    </svg>
+                  ) : (
+                    <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                      <path d="M10 2v4h4M2 10h4v4M6 6L2 2M10 10l4 4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+                    </svg>
+                  )}
+                </button>
               </div>
-            )}
+              <div style={{ borderRadius: "0 0 12px 12px", overflow: "hidden", flex: mapExpanded ? 1 : undefined }}>
+                <JourneyMap
+                  journey={journeyMapData}
+                  mode="planning"
+                  height={mapExpanded ? undefined : 320}
+                />
+              </div>
+            </div>
 
             <div className="digest-panel">
               <div className="h">Day · digest</div>

--- a/src/app/(app)/itineraries/[id]/itinerary-editor.tsx
+++ b/src/app/(app)/itineraries/[id]/itinerary-editor.tsx
@@ -26,7 +26,7 @@ import {
 } from "@/lib/actions/transitions";
 import { addFullTransportBooking } from "@/lib/actions/bookings";
 import { reEnrichItineraryFromGmail } from "@/lib/actions/gmail";
-import { transitionItineraryStatus } from "@/lib/actions/itineraries";
+import { transitionItineraryStatus, updateItinerary } from "@/lib/actions/itineraries";
 import type { InitialPreviewSeed } from "@/components/itinerary/use-route-preview";
 import { checkLegFeasibility } from "@/lib/feasibility/check";
 import { feedbackFromError } from "@/lib/actions/_form";
@@ -287,6 +287,30 @@ export function ItineraryEditor({
   // the server action and dismiss.
   const [editingTransport, setEditingTransport] = useState<BriefTransportBooking | null>(null);
   const [mapExpanded, setMapExpanded] = useState(false);
+  const [editingMasthead, setEditingMasthead] = useState(false);
+  const [mastheadTitle, setMastheadTitle] = useState(itinerary.title ?? "");
+  const [mastheadNotes, setMastheadNotes] = useState(itinerary.notes ?? "");
+  const [mastheadDateStart, setMastheadDateStart] = useState(itinerary.date_start);
+  const [mastheadDateEnd, setMastheadDateEnd] = useState(itinerary.date_end);
+
+  const saveMasthead = () => {
+    startTransition(async () => {
+      setError(null);
+      const result = await updateItinerary({
+        id: itinerary.id,
+        title: mastheadTitle.trim() || null,
+        date_start: mastheadDateStart,
+        date_end: mastheadDateEnd || mastheadDateStart,
+        notes: mastheadNotes.trim() || null,
+      });
+      if (!result.ok) {
+        setError(feedbackFromError(result.error).message);
+        return;
+      }
+      setEditingMasthead(false);
+      router.refresh();
+    });
+  };
   const handleTransportCardChange = (patch: Partial<BriefTransportBooking>) => {
     setEditingTransport((prev) => {
       if (!prev) return prev;
@@ -1204,17 +1228,110 @@ export function ItineraryEditor({
         {/* ── Masthead: headline + standfirst + stat columns ─────────── */}
         <section className="grid grid-cols-1 gap-8 lg:grid-cols-[1.4fr_1fr] lg:gap-12">
           <div className="flex flex-col gap-4">
-            <h1 className="masthead-title">
-              <MastheadHeadline
-                customerName={subject.customerName}
-                placePart={subject.placePart}
-                fallback={itinerary.title}
-                date={dateLabel}
-              />
-            </h1>
-            {itinerary.notes ? (
-              <p className="standfirst">{itinerary.notes}</p>
-            ) : null}
+            {editingMasthead ? (
+              <div className="flex flex-col gap-3">
+                <input
+                  type="text"
+                  className="masthead-title-input"
+                  value={mastheadTitle}
+                  onChange={(e) => setMastheadTitle(e.target.value)}
+                  placeholder="Trip title"
+                  style={{
+                    fontFamily: "var(--display)",
+                    fontSize: 28,
+                    fontWeight: 500,
+                    fontStyle: "italic",
+                    color: "var(--ink)",
+                    background: "transparent",
+                    border: "none",
+                    borderBottom: "1px solid var(--rule)",
+                    outline: "none",
+                    padding: "4px 0",
+                    width: "100%",
+                  }}
+                />
+                <div className="flex gap-3">
+                  <div className="flex flex-col gap-1">
+                    <label className="uc" style={{ fontSize: 9 }}>Start date</label>
+                    <input
+                      type="date"
+                      value={mastheadDateStart}
+                      onChange={(e) => setMastheadDateStart(e.target.value)}
+                      className="brief-input"
+                      style={{ fontSize: 13 }}
+                    />
+                  </div>
+                  <div className="flex flex-col gap-1">
+                    <label className="uc" style={{ fontSize: 9 }}>End date</label>
+                    <input
+                      type="date"
+                      value={mastheadDateEnd}
+                      onChange={(e) => setMastheadDateEnd(e.target.value)}
+                      className="brief-input"
+                      style={{ fontSize: 13 }}
+                    />
+                  </div>
+                </div>
+                <textarea
+                  value={mastheadNotes}
+                  onChange={(e) => setMastheadNotes(e.target.value)}
+                  placeholder="Trip notes (optional)"
+                  rows={2}
+                  className="brief-input"
+                  style={{ fontSize: 13, resize: "vertical" }}
+                />
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    className="btn-primary"
+                    style={{ fontSize: 12, padding: "6px 14px" }}
+                    onClick={saveMasthead}
+                    disabled={pending}
+                  >
+                    Save
+                  </button>
+                  <button
+                    type="button"
+                    className="btn-ghost"
+                    style={{ fontSize: 12 }}
+                    onClick={() => {
+                      setEditingMasthead(false);
+                      setMastheadTitle(itinerary.title ?? "");
+                      setMastheadNotes(itinerary.notes ?? "");
+                      setMastheadDateStart(itinerary.date_start);
+                      setMastheadDateEnd(itinerary.date_end);
+                    }}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <>
+                <h1
+                  className="masthead-title"
+                  style={{ cursor: "pointer" }}
+                  onClick={() => setEditingMasthead(true)}
+                  title="Click to edit title, dates, and notes"
+                >
+                  <MastheadHeadline
+                    customerName={subject.customerName}
+                    placePart={subject.placePart}
+                    fallback={itinerary.title}
+                    date={dateLabel}
+                  />
+                </h1>
+                {itinerary.notes ? (
+                  <p
+                    className="standfirst"
+                    style={{ cursor: "pointer" }}
+                    onClick={() => setEditingMasthead(true)}
+                  >
+                    {itinerary.notes}
+                  </p>
+                ) : null}
+              </>
+            )}
           </div>
 
           <div className="flex items-end justify-start gap-6 lg:justify-end">

--- a/src/app/(app)/itineraries/[id]/itinerary-editor.tsx
+++ b/src/app/(app)/itineraries/[id]/itinerary-editor.tsx
@@ -810,7 +810,7 @@ export function ItineraryEditor({
   const handleAnchorPatch = (uid: string, patch: Partial<Anchor>) => {
     setEditedAnchors((prev) => {
       const next = new Map(prev);
-      const current = next.get(uid);
+      const current = next.get(uid) ?? planningAnchors.find((a) => a.uid === uid);
       if (!current) return prev;
       next.set(uid, { ...current, ...patch });
       return next;
@@ -865,7 +865,8 @@ export function ItineraryEditor({
   const handleStopoverPatch = (uid: string, patch: Partial<Stopover>) => {
     setEditedStopovers((prev) => {
       const next = new Map(prev);
-      const current = next.get(uid);
+      const current = next.get(uid)
+        ?? (planningTimeline.find((it) => it.kind === "stopover" && it.stopover.uid === uid) as any)?.stopover;
       if (!current) return prev;
       next.set(uid, { ...current, ...patch });
       return next;
@@ -1696,7 +1697,7 @@ export function ItineraryEditor({
 
             <div className="digest-panel">
               <div className="h">Day · digest</div>
-              {totalMinutes === 0 && totalMiles === 0 && !onSiteWindow ? (
+              {totalMinutes === 0 && totalMiles === 0 && (!onSiteWindow || !onSiteWindow.from) ? (
                 <p style={{ fontSize: 12, color: "var(--ink-faint)", fontStyle: "italic", margin: "8px 0 0" }}>
                   Stats appear as you add stops and connections
                 </p>

--- a/src/app/(app)/itineraries/[id]/itinerary-editor.tsx
+++ b/src/app/(app)/itineraries/[id]/itinerary-editor.tsx
@@ -377,19 +377,28 @@ export function ItineraryEditor({
     return m;
   }, [transitions]);
 
+  // Optimistic local stops — inserted immediately from insertStopAt's
+  // return value so the card appears without waiting for router.refresh.
+  const [localStops, setLocalStops] = useState<StopRow[]>([]);
+  const mergedStops = useMemo(() => {
+    const serverIds = new Set(stops.map((s) => s.id));
+    const extras = localStops.filter((s) => !serverIds.has(s.id));
+    return [...stops, ...extras];
+  }, [stops, localStops]);
+
   // Planning-view state: shared-component cards derived from the DB
   // rows above. Anchors get a per-card "expanded" toggle so the user
   // sees a tidy summary by default and clicks Edit to flip back to
   // the full brief form. Multiple anchors can be expanded at once.
   const planningAnchors = useMemo<Anchor[]>(
-    () => anchorsFromStops(stops as DbStop[], timezone),
-    [stops, timezone],
+    () => anchorsFromStops(mergedStops as DbStop[], timezone),
+    [mergedStops, timezone],
   );
   // Full timeline including stopovers — used when rendering so we can
   // slot StopoverCard rows between the anchors they sit between.
   const planningTimeline = useMemo<EditorTimelineItem[]>(
-    () => timelineFromStops(stops as DbStop[], timezone),
-    [stops, timezone],
+    () => timelineFromStops(mergedStops as DbStop[], timezone),
+    [mergedStops, timezone],
   );
 
   // Route previews — populated lazily when the user opens a
@@ -482,14 +491,11 @@ export function ItineraryEditor({
   const [pendingExpandUid, setPendingExpandUid] = useState<string | null>(null);
   useEffect(() => {
     if (!pendingExpandUid) return;
-    // Reference the raw `stops` prop rather than sortedStops, which
-    // is declared further down (hoisting issue). Either contains the
-    // newly-created stop after router.refresh.
-    if (stops.find((s) => s.id === pendingExpandUid)) {
+    if (mergedStops.find((s) => s.id === pendingExpandUid)) {
       setExpandedUids((prev) => new Set(prev).add(pendingExpandUid));
       setPendingExpandUid(null);
     }
-  }, [pendingExpandUid, stops]);
+  }, [pendingExpandUid, mergedStops]);
 
   // Insert a new appointment anchor at the given sequence. AddBetween
   // wraps this via the brief's UI pattern: a small dashed pill
@@ -498,23 +504,42 @@ export function ItineraryEditor({
     setPendingInsertAt(sequence);
   };
 
-  const handleInsertAnchorAt = (sequence: number, timingMode?: string) => {
+  const handleInsertAnchorAt = async (sequence: number, timingMode?: string) => {
     setPendingInsertAt(null);
-    startTransition(async () => {
-      setError(null);
-      const result = await insertStopAt({
-        itinerary_id: itinerary.id,
-        sequence,
-        type: "appointment",
-        metadata: timingMode ? { timing_mode: timingMode } : undefined,
-      });
-      if (!result.ok) {
-        setError(feedbackFromError(result.error).message);
-        return;
-      }
-      setPendingExpandUid(result.value.id);
-      router.refresh();
+    setError(null);
+    const result = await insertStopAt({
+      itinerary_id: itinerary.id,
+      sequence,
+      type: "appointment",
+      metadata: timingMode ? { timing_mode: timingMode } : undefined,
     });
+    if (!result.ok) {
+      setError(feedbackFromError(result.error).message);
+      return;
+    }
+    const s = result.value;
+    const optimistic: StopRow = {
+      id: s.id,
+      sequence: s.sequence,
+      type: s.type as StopType,
+      title: s.title ?? null,
+      start_time: s.start_time ?? null,
+      end_time: s.end_time ?? null,
+      duration_minutes: s.duration_minutes ?? null,
+      is_time_fixed: s.is_time_fixed ?? false,
+      location_id: s.location_id ?? null,
+      customer_id: s.customer_id ?? null,
+      customer_site_id: s.customer_site_id ?? null,
+      external_reference: s.external_reference ?? null,
+      notes: s.notes ?? null,
+      location: null,
+      customer: null,
+      customer_site: null,
+      metadata: s.metadata ?? null,
+    };
+    setLocalStops((prev) => [...prev, optimistic]);
+    setPendingExpandUid(s.id);
+    router.refresh();
   };
 
   // Insert a new stopover between two existing anchor stops.
@@ -647,8 +672,8 @@ export function ItineraryEditor({
   }, [journeyLegs]);
 
   const sortedStops = useMemo(
-    () => [...stops].sort((a, b) => a.sequence - b.sequence),
-    [stops],
+    () => [...mergedStops].sort((a, b) => a.sequence - b.sequence),
+    [mergedStops],
   );
 
   // Roll up feasibility flags across every adjacent pair of stops
@@ -1864,7 +1889,7 @@ function TimingModePicker({
   ];
   return (
     <div className="timing-picker" style={{
-      display: "grid", gridTemplateColumns: "1fr 1fr", gap: 6,
+      display: "grid", gap: 6,
       padding: 12, background: "var(--card)", border: "1px solid var(--rule)",
       borderRadius: 10,
     }}>

--- a/src/app/(app)/itineraries/[id]/itinerary-editor.tsx
+++ b/src/app/(app)/itineraries/[id]/itinerary-editor.tsx
@@ -725,8 +725,9 @@ export function ItineraryEditor({
           }
         }
       }
-      for (const id of idsToDelete) {
-        const result = await deleteStop(id);
+      for (let i = 0; i < idsToDelete.length; i++) {
+        const isLast = i === idsToDelete.length - 1;
+        const result = await deleteStop(idsToDelete[i], !isLast);
         if (!result.ok) {
           setError(feedbackFromError(result.error).message);
           break;

--- a/src/app/(app)/itineraries/[id]/itinerary-editor.tsx
+++ b/src/app/(app)/itineraries/[id]/itinerary-editor.tsx
@@ -4,7 +4,6 @@ import { useRouter } from "next/navigation";
 import { useState, useTransition, useMemo, useEffect } from "react";
 import Link from "next/link";
 import dynamic from "next/dynamic";
-import { RouteMap } from "@/components/route-map";
 import { decodePolyline } from "@/components/journey-map";
 import type { Journey, Leg, Station, LegMode } from "@/components/journey-map";
 
@@ -130,6 +129,7 @@ const STOP_ICON: Record<StopType, React.ReactNode> = {
   transport_booked: Icon.train,
   transit_arrival: Icon.plane,
   transit_departure: Icon.train,
+  transit_changeover: Icon.train,
   stopover: Icon.pin,
   other: Icon.pin,
 };
@@ -144,6 +144,7 @@ const STOP_LABEL: Record<StopType, string> = {
   transport_booked: "Transport",
   transit_arrival: "Arrive",
   transit_departure: "Depart",
+  transit_changeover: "Change",
   stopover: "Stopover",
   other: "Point",
 };
@@ -709,10 +710,27 @@ export function ItineraryEditor({
     if (!window.confirm("Delete this point?")) return;
     startTransition(async () => {
       setError(null);
-      const result = await deleteStop(stopId);
-      if (!result.ok) {
-        setError(feedbackFromError(result.error).message);
-        return;
+      // If this is a transit_departure, also delete its changeover + arrival siblings
+      const stop = sortedStops.find((s) => s.id === stopId);
+      const idsToDelete = [stopId];
+      if (stop?.type === "transit_departure") {
+        const seq = stop.sequence;
+        for (const s of sortedStops) {
+          if (s.id === stopId) continue;
+          if (s.sequence > seq && (s.type === "transit_changeover" || s.type === "transit_arrival")) {
+            idsToDelete.push(s.id);
+            if (s.type === "transit_arrival") break;
+          } else if (s.sequence > seq && s.type !== "transit_changeover") {
+            break;
+          }
+        }
+      }
+      for (const id of idsToDelete) {
+        const result = await deleteStop(id);
+        if (!result.ok) {
+          setError(feedbackFromError(result.error).message);
+          break;
+        }
       }
       router.refresh();
     });

--- a/src/app/(app)/itineraries/[id]/itinerary-editor.tsx
+++ b/src/app/(app)/itineraries/[id]/itinerary-editor.tsx
@@ -17,6 +17,7 @@ import {
   deleteStop,
   insertStopAt,
   updateStop,
+  deleteStops,
 } from "@/lib/actions/stops";
 import {
   upsertTransition,
@@ -293,6 +294,7 @@ export function ItineraryEditor({
   const [mastheadNotes, setMastheadNotes] = useState(itinerary.notes ?? "");
   const [mastheadDateStart, setMastheadDateStart] = useState(itinerary.date_start);
   const [mastheadDateEnd, setMastheadDateEnd] = useState(itinerary.date_end);
+  const [pendingInsertAt, setPendingInsertAt] = useState<number | null>(null);
 
   const saveMasthead = () => {
     startTransition(async () => {
@@ -492,13 +494,19 @@ export function ItineraryEditor({
   // Insert a new appointment anchor at the given sequence. AddBetween
   // wraps this via the brief's UI pattern: a small dashed pill
   // between cards.
-  const handleInsertAnchorAt = (sequence: number) => {
+  const showTimingPicker = (sequence: number) => {
+    setPendingInsertAt(sequence);
+  };
+
+  const handleInsertAnchorAt = (sequence: number, timingMode?: string) => {
+    setPendingInsertAt(null);
     startTransition(async () => {
       setError(null);
       const result = await insertStopAt({
         itinerary_id: itinerary.id,
         sequence,
         type: "appointment",
+        metadata: timingMode ? { timing_mode: timingMode } : undefined,
       });
       if (!result.ok) {
         setError(feedbackFromError(result.error).message);
@@ -710,7 +718,6 @@ export function ItineraryEditor({
     if (!window.confirm("Delete this point?")) return;
     startTransition(async () => {
       setError(null);
-      // If this is a transit_departure, also delete its changeover + arrival siblings
       const stop = sortedStops.find((s) => s.id === stopId);
       const idsToDelete = [stopId];
       if (stop?.type === "transit_departure") {
@@ -725,13 +732,9 @@ export function ItineraryEditor({
           }
         }
       }
-      for (let i = 0; i < idsToDelete.length; i++) {
-        const isLast = i === idsToDelete.length - 1;
-        const result = await deleteStop(idsToDelete[i], !isLast);
-        if (!result.ok) {
-          setError(feedbackFromError(result.error).message);
-          break;
-        }
+      const result = await deleteStops(idsToDelete);
+      if (!result.ok) {
+        setError(feedbackFromError(result.error).message);
       }
       router.refresh();
     });
@@ -1386,16 +1389,13 @@ export function ItineraryEditor({
               {Icon.arrow}
             </button>
           ) : null}
-          <span className={`sb ${STATUS_SB[itinerary.status]}`}>
-            {STATUS_LABEL[itinerary.status]}
-          </span>
           <button
             type="button"
             className="btn-ghost"
             style={{ fontSize: 13 }}
             onClick={() => setEditingTransport(emptyTransportBookingItem())}
           >
-            + Transport
+            + Booked transport
           </button>
           <button
             type="button"
@@ -1403,7 +1403,7 @@ export function ItineraryEditor({
             style={{ fontSize: 13 }}
             onClick={() => setShowAddAccommodation(true)}
           >
-            + Accommodation
+            + Hotel booking
           </button>
           {gmailConnected ? (
             <>
@@ -1412,7 +1412,6 @@ export function ItineraryEditor({
                 className="btn-ghost"
                 style={{ fontSize: 12, display: "inline-flex", alignItems: "center", gap: 6 }}
                 onClick={() => setGmailImportOpen(true)}
-                disabled={pending}
               >
                 {Icon.ticket}
                 Scan for tickets
@@ -1433,7 +1432,6 @@ export function ItineraryEditor({
                     router.refresh();
                   });
                 }}
-                disabled={pending}
               >
                 Refresh ticket details
               </button>
@@ -1566,7 +1564,7 @@ export function ItineraryEditor({
                   ) : null}
                   {first && first.kind === "anchor" ? (
                     <div className="anchor-inline-adds">
-                      <AddBetween between onAdd={() => handleInsertAnchorAt(first.stop.sequence)} />
+                      <AddBetween between onAdd={() => showTimingPicker(first.stop.sequence)} />
                     </div>
                   ) : null}
                 </>
@@ -1610,7 +1608,7 @@ export function ItineraryEditor({
                     handleDelete,
                     handleTransitionPatch,
                     prefetchPair,
-                    handleInsertAnchorAt,
+                    handleInsertAnchorAt: showTimingPicker,
                     handleInsertStopoverBetween,
                   },
                   startStop: sortedStops.find((s) => s.type === "start") ?? null,
@@ -1626,13 +1624,17 @@ export function ItineraryEditor({
 
             {(() => {
               const last = sortedStops[sortedStops.length - 1];
+              const seq = last ? (last.sequence ?? -1) + 1 : 0;
               return (
                 <div className="anchor-inline-adds">
-                  <AddBetween
-                    onAdd={() => handleInsertAnchorAt(
-                      last ? (last.sequence ?? -1) + 1 : 0,
-                    )}
-                  />
+                  {pendingInsertAt === seq ? (
+                    <TimingModePicker
+                      onPick={(mode) => handleInsertAnchorAt(seq, mode)}
+                      onCancel={() => setPendingInsertAt(null)}
+                    />
+                  ) : (
+                    <AddBetween onAdd={() => setPendingInsertAt(seq)} />
+                  )}
                 </div>
               );
             })()}
@@ -1644,9 +1646,15 @@ export function ItineraryEditor({
               <div className="route-map-header">
                 <span className="route-map-eyebrow">Door-to-door</span>
                 <span className="route-map-headline">
-                  {totalMiles > 0 && <>{Math.round(totalMiles)} mi</>}
-                  {totalMiles > 0 && totalMinutes > 0 && " · "}
-                  {totalMinutes > 0 && <>{fmtDuration(totalMinutes)}</>}
+                  {totalMiles > 0 || totalMinutes > 0 ? (
+                    <>
+                      {totalMiles > 0 && <>{Math.round(totalMiles)} mi</>}
+                      {totalMiles > 0 && totalMinutes > 0 && " · "}
+                      {totalMinutes > 0 && <>{fmtDuration(totalMinutes)}</>}
+                    </>
+                  ) : (
+                    <span style={{ color: "var(--ink-faint)", fontStyle: "italic" }}>Add stops to see your route</span>
+                  )}
                 </span>
                 <button
                   type="button"
@@ -1665,12 +1673,24 @@ export function ItineraryEditor({
                   )}
                 </button>
               </div>
-              <div style={{ borderRadius: "0 0 12px 12px", overflow: "hidden", flex: mapExpanded ? 1 : undefined }}>
+              <div style={{ borderRadius: "0 0 12px 12px", overflow: "hidden", flex: mapExpanded ? 1 : undefined, position: "relative" }}>
                 <JourneyMap
                   journey={journeyMapData}
                   mode="planning"
                   height={mapExpanded ? undefined : 320}
                 />
+                {journeyMapData.legs.length === 0 && (
+                  <div style={{
+                    position: "absolute", inset: 0, display: "flex",
+                    alignItems: "center", justifyContent: "center",
+                    background: "var(--card)", opacity: 0.85,
+                    pointerEvents: "none",
+                  }}>
+                    <p className="serif-i" style={{ color: "var(--ink-dim)", fontSize: 15, textAlign: "center", padding: "0 24px" }}>
+                      Add stops with locations to see your route on the map
+                    </p>
+                  </div>
+                )}
               </div>
             </div>
 
@@ -1740,6 +1760,21 @@ export function ItineraryEditor({
           </div>
         ) : null}
 
+        {/* Timing mode picker for mid-timeline inserts */}
+        {pendingInsertAt !== null && pendingInsertAt !== (sortedStops[sortedStops.length - 1]?.sequence ?? -1) + 1 ? (
+          <div
+            className="fixed inset-0 z-30 flex items-center justify-center bg-ink/20 backdrop-blur-sm"
+            onClick={(e) => { if (e.target === e.currentTarget) setPendingInsertAt(null); }}
+          >
+            <div style={{ width: "100%", maxWidth: 360 }}>
+              <TimingModePicker
+                onPick={(mode) => handleInsertAnchorAt(pendingInsertAt, mode)}
+                onCancel={() => setPendingInsertAt(null)}
+              />
+            </div>
+          </div>
+        ) : null}
+
         {/* Gmail import panel */}
         {gmailImportOpen ? (
           <GmailImportPanel
@@ -1787,7 +1822,7 @@ export function ItineraryEditor({
             <div className="my-8 w-full max-w-2xl">
               <AddAccommodationBookingForm
                 afterStopId={sortedStops[sortedStops.length - 1]?.id}
-                afterStopLabel="end of timeline"
+                afterStopLabel={sortedStops[sortedStops.length - 1]?.title ?? "your last stop"}
                 customers={customers}
                 customerSites={customerSites}
                 locations={locations}
@@ -1801,6 +1836,67 @@ export function ItineraryEditor({
           </div>
         ) : null}
       </div>
+    </div>
+  );
+}
+
+function TimingModePicker({
+  onPick,
+  onCancel,
+}: {
+  onPick: (mode: string) => void;
+  onCancel: () => void;
+}) {
+  const options = [
+    { mode: "arrive_by", label: "I need to be there by...", icon: ">" },
+    { mode: "leave_by", label: "I need to leave by...", icon: "<" },
+    { mode: "around_then", label: "I'll be there around...", icon: "~" },
+    { mode: "maximize", label: "As long as possible", icon: "+" },
+  ];
+  return (
+    <div className="timing-picker" style={{
+      display: "grid", gridTemplateColumns: "1fr 1fr", gap: 6,
+      padding: 12, background: "var(--card)", border: "1px solid var(--rule)",
+      borderRadius: 10,
+    }}>
+      {options.map((o) => (
+        <button
+          key={o.mode}
+          type="button"
+          onClick={() => onPick(o.mode)}
+          style={{
+            display: "flex", alignItems: "center", gap: 8,
+            padding: "10px 12px", borderRadius: 8,
+            border: "1px solid var(--rule)", background: "var(--card-2)",
+            cursor: "pointer", fontSize: 12, color: "var(--ink)",
+            fontFamily: "var(--sans)", textAlign: "left",
+            transition: "border-color 0.15s",
+          }}
+          onMouseEnter={(e) => (e.currentTarget.style.borderColor = "var(--gold)")}
+          onMouseLeave={(e) => (e.currentTarget.style.borderColor = "var(--rule)")}
+        >
+          <span style={{
+            width: 24, height: 24, borderRadius: "50%",
+            background: "var(--gold-2)", color: "var(--gold)",
+            display: "flex", alignItems: "center", justifyContent: "center",
+            fontSize: 14, fontWeight: 600, flexShrink: 0,
+          }}>
+            {o.icon}
+          </span>
+          <span>{o.label}</span>
+        </button>
+      ))}
+      <button
+        type="button"
+        onClick={onCancel}
+        style={{
+          gridColumn: "1 / -1", padding: "6px 0", fontSize: 11,
+          color: "var(--ink-faint)", background: "none", border: "none",
+          cursor: "pointer",
+        }}
+      >
+        Cancel
+      </button>
     </div>
   );
 }

--- a/src/app/(app)/itineraries/[id]/itinerary-editor.tsx
+++ b/src/app/(app)/itineraries/[id]/itinerary-editor.tsx
@@ -294,7 +294,6 @@ export function ItineraryEditor({
   const [mastheadNotes, setMastheadNotes] = useState(itinerary.notes ?? "");
   const [mastheadDateStart, setMastheadDateStart] = useState(itinerary.date_start);
   const [mastheadDateEnd, setMastheadDateEnd] = useState(itinerary.date_end);
-  const [pendingInsertAt, setPendingInsertAt] = useState<number | null>(null);
 
   const saveMasthead = () => {
     startTransition(async () => {
@@ -500,18 +499,12 @@ export function ItineraryEditor({
   // Insert a new appointment anchor at the given sequence. AddBetween
   // wraps this via the brief's UI pattern: a small dashed pill
   // between cards.
-  const showTimingPicker = (sequence: number) => {
-    setPendingInsertAt(sequence);
-  };
-
-  const handleInsertAnchorAt = async (sequence: number, timingMode?: string) => {
-    setPendingInsertAt(null);
+  const handleInsertAnchorAt = async (sequence: number) => {
     setError(null);
     const result = await insertStopAt({
       itinerary_id: itinerary.id,
       sequence,
       type: "appointment",
-      metadata: timingMode ? { timing_mode: timingMode } : undefined,
     });
     if (!result.ok) {
       setError(feedbackFromError(result.error).message);
@@ -1402,8 +1395,8 @@ export function ItineraryEditor({
           </div>
         </section>
 
-        {/* ── Primary action row ─────────────────────────────────────── */}
-        <div className="flex flex-wrap items-center gap-3">
+        {/* ── Action rows ─────────────────────────────────────── */}
+        <div className="flex flex-wrap items-center gap-2">
           {nextStatus ? (
             <button
               type="button"
@@ -1418,7 +1411,6 @@ export function ItineraryEditor({
           <button
             type="button"
             className="btn-ghost"
-            style={{ fontSize: 13 }}
             onClick={() => setEditingTransport(emptyTransportBookingItem())}
           >
             + Booked transport
@@ -1426,17 +1418,17 @@ export function ItineraryEditor({
           <button
             type="button"
             className="btn-ghost"
-            style={{ fontSize: 13 }}
             onClick={() => setShowAddAccommodation(true)}
           >
             + Hotel booking
           </button>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
           {gmailConnected ? (
             <>
               <button
                 type="button"
                 className="btn-ghost"
-                style={{ fontSize: 12, display: "inline-flex", alignItems: "center", gap: 6 }}
                 onClick={() => setGmailImportOpen(true)}
               >
                 {Icon.ticket}
@@ -1445,7 +1437,6 @@ export function ItineraryEditor({
               <button
                 type="button"
                 className="btn-ghost"
-                style={{ fontSize: 12 }}
                 onClick={() => {
                   startTransition(async () => {
                     setError(null);
@@ -1590,7 +1581,7 @@ export function ItineraryEditor({
                   ) : null}
                   {first && first.kind === "anchor" ? (
                     <div className="anchor-inline-adds">
-                      <AddBetween between onAdd={() => showTimingPicker(first.stop.sequence)} />
+                      <AddBetween between onAdd={() => handleInsertAnchorAt(first.stop.sequence)} />
                     </div>
                   ) : null}
                 </>
@@ -1634,7 +1625,7 @@ export function ItineraryEditor({
                     handleDelete,
                     handleTransitionPatch,
                     prefetchPair,
-                    handleInsertAnchorAt: showTimingPicker,
+                    handleInsertAnchorAt,
                     handleInsertStopoverBetween,
                   },
                   startStop: sortedStops.find((s) => s.type === "start") ?? null,
@@ -1653,14 +1644,7 @@ export function ItineraryEditor({
               const seq = last ? (last.sequence ?? -1) + 1 : 0;
               return (
                 <div className="anchor-inline-adds">
-                  {pendingInsertAt === seq ? (
-                    <TimingModePicker
-                      onPick={(mode) => handleInsertAnchorAt(seq, mode)}
-                      onCancel={() => setPendingInsertAt(null)}
-                    />
-                  ) : (
-                    <AddBetween onAdd={() => setPendingInsertAt(seq)} />
-                  )}
+                  <AddBetween onAdd={() => handleInsertAnchorAt(seq)} />
                 </div>
               );
             })()}
@@ -1789,21 +1773,6 @@ export function ItineraryEditor({
                   setAccommodationBookingFor(null);
                   router.refresh();
                 }}
-              />
-            </div>
-          </div>
-        ) : null}
-
-        {/* Timing mode picker for mid-timeline inserts */}
-        {pendingInsertAt !== null && pendingInsertAt !== (sortedStops[sortedStops.length - 1]?.sequence ?? -1) + 1 ? (
-          <div
-            className="fixed inset-0 z-30 flex items-center justify-center bg-ink/20 backdrop-blur-sm"
-            onClick={(e) => { if (e.target === e.currentTarget) setPendingInsertAt(null); }}
-          >
-            <div style={{ width: "100%", maxWidth: 360 }}>
-              <TimingModePicker
-                onPick={(mode) => handleInsertAnchorAt(pendingInsertAt, mode)}
-                onCancel={() => setPendingInsertAt(null)}
               />
             </div>
           </div>

--- a/src/app/(app)/itineraries/new/page.tsx
+++ b/src/app/(app)/itineraries/new/page.tsx
@@ -1,147 +1,28 @@
+import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { requireUserContext } from "@/lib/auth";
-import { getWorkspaceConfig } from "@/lib/flags/workspace-flags";
-import { NewItineraryBrief } from "./new-itinerary-form";
 
 export default async function NewItineraryPage() {
   const ctx = await requireUserContext();
   const supabase = await createClient();
-  const wsCfg = await getWorkspaceConfig(ctx.workspaceId);
 
-  const [
-    { data: customers },
-    { data: customerSites },
-    { data: locations },
-    { data: profile },
-  ] = await Promise.all([
-    supabase
-      .from("customers")
-      .select("id, name")
-      .eq("workspace_id", ctx.workspaceId)
-      .order("name"),
-    supabase
-      .from("customer_sites")
-      .select("id, customer_id, name, address")
-      .eq("workspace_id", ctx.workspaceId),
-    supabase
-      .from("locations")
-      .select("id, name, type, address")
-      .eq("workspace_id", ctx.workspaceId)
-      .order("type")
-      .order("name"),
-    supabase
-      .from("travel_profiles")
-      .select(
-        "default_drive_origin_location_id, default_rail_origin_location_id, default_return_location_id, default_rail_origin_transport_hub_id, default_flight_origin_transport_hub_id",
-      )
-      .eq("user_id", ctx.userId)
-      .eq("workspace_id", ctx.workspaceId)
-      .maybeSingle(),
-  ]);
+  const today = new Date().toISOString().slice(0, 10);
 
-  const { data: gmailConn } = await supabase
-    .from("gmail_connections")
+  const { data: itinerary, error } = await supabase
+    .from("itineraries")
+    .insert({
+      workspace_id: ctx.workspaceId,
+      user_id: ctx.userId,
+      date_start: today,
+      date_end: today,
+      status: "planning",
+    })
     .select("id")
-    .eq("user_id", ctx.userId)
-    .eq("workspace_id", ctx.workspaceId)
-    .eq("status", "active")
-    .maybeSingle();
+    .single();
 
-  // Resolve the home label so the brief can show "from Home" (or the
-  // actual name) on the implicit first transition.
-  const homeId =
-    profile?.default_drive_origin_location_id ??
-    profile?.default_rail_origin_location_id ??
-    profile?.default_return_location_id ??
-    null;
-  const home =
-    homeId != null
-      ? (locations ?? []).find((l) => l.id === homeId) ?? null
-      : null;
+  if (error || !itinerary) {
+    redirect("/itineraries");
+  }
 
-  // Base locations — home/office locations the user can pick as their
-  // starting point. Shown in the BaseLocationCard at the top of the brief.
-  const baseLocations = (locations ?? [])
-    .filter((l): l is typeof l & { type: "home" | "office" } =>
-      l.type === "home" || l.type === "office",
-    )
-    .map((l) => ({ id: l.id, name: l.name, type: l.type, address: l.address }));
-  const defaultBaseId = homeId;
-
-  // Surface the user's default rail station / airport so the brief
-  // can render a "via {station}" hint inside train / tube / flight
-  // transitions. Full station-stop auto-insertion is a follow-up;
-  // this is the smaller visual half of Slice E.
-  const hubIds = [
-    profile?.default_rail_origin_transport_hub_id,
-    profile?.default_flight_origin_transport_hub_id,
-  ].filter(Boolean) as string[];
-  const { data: hubs } =
-    hubIds.length > 0
-      ? await supabase
-          .from("transport_hubs")
-          .select("id, name, code, kind")
-          .in("id", hubIds)
-      : { data: [] as Array<{ id: string; name: string; code: string | null; kind: string }> };
-  const railHub =
-    hubs?.find(
-      (h) => h.id === profile?.default_rail_origin_transport_hub_id,
-    ) ?? null;
-  const flightHub =
-    hubs?.find(
-      (h) => h.id === profile?.default_flight_origin_transport_hub_id,
-    ) ?? null;
-  const railHubLabel = railHub
-    ? railHub.code
-      ? `${railHub.name} (${railHub.code})`
-      : railHub.name
-    : null;
-  const flightHubLabel = flightHub
-    ? flightHub.code
-      ? `${flightHub.name} (${flightHub.code})`
-      : flightHub.name
-    : null;
-
-  return (
-    <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
-      <header>
-        <span className="eyebrow" style={{ color: "var(--gold-2)" }}>
-          New · Brief
-        </span>
-        <h1
-          className="desk-h1"
-          style={{ marginTop: 6, fontSize: "clamp(28px, 4vw, 42px)" }}
-        >
-          Plan your <em>day.</em>
-        </h1>
-        <p
-          className="serif-i"
-          style={{
-            fontSize: 16,
-            color: "var(--ink-dim)",
-            margin: "8px 0 0",
-            maxWidth: "62ch",
-            lineHeight: 1.55,
-          }}
-        >
-          Tell Khonsera what you already know &mdash; where you&rsquo;re
-          starting, what&rsquo;s already booked, when you need to be back
-          &mdash; and we&rsquo;ll work out the rest.
-        </p>
-      </header>
-
-      <NewItineraryBrief
-        customers={customers ?? []}
-        customerSites={customerSites ?? []}
-        locations={locations ?? []}
-        timezone={wsCfg.timezone}
-        homeLabel={home?.name ?? null}
-        railHubLabel={railHubLabel}
-        flightHubLabel={flightHubLabel}
-        baseLocations={baseLocations}
-        defaultBaseId={defaultBaseId}
-        gmailConnected={!!gmailConn}
-      />
-    </div>
-  );
+  redirect(`/itineraries/${itinerary.id}`);
 }

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -104,9 +104,13 @@ export default async function SettingsPage({
         <div className="j-card p-5">
           <h2 className="h3 mb-2">Account</h2>
           <p className="small">{ctx.email}</p>
-          {ctx.isAdmin ? (
+          {ctx.isSuperUser ? (
             <p className="mt-1 text-xs text-terra">
-              Admin account
+              Super user · developer tools available
+            </p>
+          ) : ctx.isAdmin ? (
+            <p className="mt-1 text-xs text-terra">
+              Workspace admin
             </p>
           ) : ctx.isStaff ? (
             <p className="mt-1 text-xs text-terra">
@@ -204,15 +208,20 @@ export default async function SettingsPage({
         </section>
       ) : null}
 
-      {ctx.isAdmin ? (
+      {ctx.isSuperUser ? (
         <section className="j-card p-5">
-          <h2 className="h3">Admin tools</h2>
+          <h2 className="h3">Developer tools</h2>
           <p className="small mt-1 mb-3">
-            System-level tools. Only visible to admins.
+            System-level data management. Only visible to super users.
           </p>
-          <a href="/settings/rail-network" className="btn btn-ghost">
-            Rail network seed
-          </a>
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+            <a href="/settings/rail-routes" className="btn btn-ghost">
+              Rail route relations
+            </a>
+            <a href="/settings/rail-network" className="btn btn-ghost">
+              Rail network edges
+            </a>
+          </div>
         </section>
       ) : null}
 

--- a/src/app/(app)/settings/rail-network/page.tsx
+++ b/src/app/(app)/settings/rail-network/page.tsx
@@ -6,7 +6,7 @@ import { RailNetworkSeeder } from "./rail-network-seeder";
 
 export default async function RailNetworkPage() {
   const ctx = await requireUserContext();
-  if (!ctx.isAdmin) redirect("/settings");
+  if (!ctx.isSuperUser) redirect("/settings");
 
   const stats = await getRailNetworkStats();
 

--- a/src/app/(app)/settings/rail-routes/page.tsx
+++ b/src/app/(app)/settings/rail-routes/page.tsx
@@ -6,7 +6,7 @@ import { RailRouteSeeder } from "./rail-route-seeder";
 
 export default async function RailRoutesPage() {
   const ctx = await requireUserContext();
-  if (!ctx.isAdmin) redirect("/settings");
+  if (!ctx.isSuperUser) redirect("/settings");
 
   const stats = await getRouteSegmentStats();
 

--- a/src/app/(app)/settings/rail-routes/rail-route-seeder.tsx
+++ b/src/app/(app)/settings/rail-routes/rail-route-seeder.tsx
@@ -67,12 +67,10 @@ export function RailRouteSeeder({ initialCount }: { initialCount: number }) {
         }
       }
 
-      setStatus({ phase: "processing", message: `${allNodes.size} nodes, ${allWays.size} ways, ${allRelations.length} relations. Resolving station codes...` });
+      setStatus({ phase: "processing", message: `${allNodes.size} nodes, ${allWays.size} ways, ${allRelations.length} relations. Loading station database...` });
 
-      const rawCodes = await getAllRailStationCodes() as unknown as Record<string, string>;
-      const nameToCode = new Map<string, string>(Object.entries(rawCodes));
-
-      setStatus({ phase: "processing", message: `Building route segments from ${allRelations.length} relations...` });
+      const hubList = await getAllRailStationCodes();
+      setStatus({ phase: "processing", message: `${hubList.length} stations loaded. Building route segments from ${allRelations.length} relations...` });
 
       const allSegments: RouteSegment[] = [];
       const seenPairs = new Set<string>();
@@ -119,8 +117,16 @@ export function RailRouteSeeder({ initialCount }: { initialCount: number }) {
         for (const sm of stopMembers) {
           const nd = allNodes.get(sm.ref);
           if (!nd) continue;
-          const name = nd.tags?.name ?? "";
-          if (!name) continue;
+
+          // Match stop to nearest transport hub by coordinates (within 1km)
+          let bestHub: { code: string; name: string } | null = null;
+          let bestHubDist = Infinity;
+          for (const hub of hubList) {
+            const d = sqDist(nd, { lat: hub.lat, lon: hub.lng });
+            if (d < bestHubDist) { bestHubDist = d; bestHub = hub; }
+          }
+          // ~0.01 degrees ≈ 1km — skip if no hub nearby
+          if (!bestHub || bestHubDist > 0.0001) continue;
 
           let bestIdx = 0;
           let bestDist = Infinity;
@@ -129,8 +135,7 @@ export function RailRouteSeeder({ initialCount }: { initialCount: number }) {
             if (d < bestDist) { bestDist = d; bestIdx = i; }
           }
 
-          const code = nameToCode.get(name.toLowerCase()) ?? null;
-          stations.push({ name, code, posIdx: bestIdx });
+          stations.push({ name: bestHub.name, code: bestHub.code, posIdx: bestIdx });
         }
 
         stations.sort((a, b) => a.posIdx - b.posIdx);

--- a/src/app/(app)/settings/rail-routes/rail-route-seeder.tsx
+++ b/src/app/(app)/settings/rail-routes/rail-route-seeder.tsx
@@ -12,20 +12,6 @@ import {
 const OVERPASS_URL = "https://overpass-api.de/api/interpreter";
 const BATCH_SIZE = 50;
 
-const REGIONS: Array<{
-  label: string;
-  south: number;
-  west: number;
-  north: number;
-  east: number;
-}> = [
-  { label: "South England", south: 50.0, west: -6.0, north: 52.0, east: 2.0 },
-  { label: "Midlands", south: 51.8, west: -3.5, north: 53.5, east: 1.0 },
-  { label: "North England", south: 53.0, west: -3.5, north: 55.8, east: 0.0 },
-  { label: "Wales", south: 51.3, west: -5.5, north: 53.5, east: -2.5 },
-  { label: "Scotland", south: 55.0, west: -6.0, north: 59.0, east: -1.0 },
-];
-
 type Status =
   | { phase: "idle" }
   | { phase: "fetching"; region: string; regionIdx: number }
@@ -48,45 +34,36 @@ export function RailRouteSeeder({ initialCount }: { initialCount: number }) {
   const [status, setStatus] = useState<Status>({ phase: "idle" });
 
   const handleSeed = useCallback(async () => {
-    setStatus({ phase: "fetching", region: REGIONS[0].label, regionIdx: 0 });
+    setStatus({ phase: "fetching", region: "United Kingdom", regionIdx: 0 });
 
     try {
       const allNodes = new Map<number, { lat: number; lon: number; tags?: Record<string, string> }>();
       const allWays = new Map<number, number[]>();
       const allRelations: OsmRelation[] = [];
-      const seenRelations = new Set<number>();
 
-      for (let i = 0; i < REGIONS.length; i++) {
-        const r = REGIONS[i];
-        setStatus({ phase: "fetching", region: r.label, regionIdx: i });
+      const query = `[out:json][timeout:300];area["ISO3166-1"="GB"]->.uk;(relation(area.uk)["type"="route"]["route"="train"];);out body;>;out skel qt;`;
+      const resp = await fetch(OVERPASS_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: `data=${encodeURIComponent(query)}`,
+        signal: AbortSignal.timeout(300_000),
+      });
 
-        const query = `[out:json][timeout:120];relation["type"="route"]["route"="train"](${r.south},${r.west},${r.north},${r.east});(._;>;);out body;`;
-        const resp = await fetch(OVERPASS_URL, {
-          method: "POST",
-          headers: { "Content-Type": "application/x-www-form-urlencoded" },
-          body: `data=${encodeURIComponent(query)}`,
-          signal: AbortSignal.timeout(120_000),
-        });
+      if (!resp.ok) {
+        setStatus({ phase: "error", message: `Overpass HTTP ${resp.status}. Wait a minute and retry.` });
+        return;
+      }
 
-        if (!resp.ok) {
-          setStatus({ phase: "error", message: `Overpass HTTP ${resp.status} for ${r.label}. Wait a minute and retry.` });
-          return;
-        }
+      setStatus({ phase: "processing", message: "Parsing response..." });
+      const json = await resp.json();
 
-        const json = await resp.json();
-        for (const el of json.elements ?? []) {
-          if (el.type === "node" && el.lat != null && el.lon != null) {
-            allNodes.set(el.id, { lat: el.lat, lon: el.lon, tags: el.tags });
-          } else if (el.type === "way" && el.nodes) {
-            allWays.set(el.id, el.nodes);
-          } else if (el.type === "relation" && !seenRelations.has(el.id)) {
-            seenRelations.add(el.id);
-            allRelations.push(el as OsmRelation);
-          }
-        }
-
-        if (i < REGIONS.length - 1) {
-          await new Promise((r) => setTimeout(r, 5000));
+      for (const el of json.elements ?? []) {
+        if (el.type === "node" && el.lat != null && el.lon != null) {
+          allNodes.set(el.id, { lat: el.lat, lon: el.lon, tags: el.tags });
+        } else if (el.type === "way" && el.nodes) {
+          allWays.set(el.id, el.nodes);
+        } else if (el.type === "relation") {
+          allRelations.push(el as OsmRelation);
         }
       }
 
@@ -250,8 +227,7 @@ export function RailRouteSeeder({ initialCount }: { initialCount: number }) {
 
       {status.phase === "fetching" && (
         <ProgressBox color="gold">
-          Fetching region {status.regionIdx + 1}/{REGIONS.length}: {status.region}
-          <ProgressBar value={(status.regionIdx + 1) / REGIONS.length} />
+          Fetching all UK train route relations from Overpass...
         </ProgressBox>
       )}
 

--- a/src/app/(app)/settings/rail-routes/rail-route-seeder.tsx
+++ b/src/app/(app)/settings/rail-routes/rail-route-seeder.tsx
@@ -1,64 +1,106 @@
 "use client";
 
-import { useState, useRef } from "react";
-import { seedRouteSegments, clearRouteSegments, getAllRailStationCodes, type RouteSegment } from "@/lib/actions/rail-network";
+import { useState, useCallback } from "react";
+import {
+  seedRouteSegments,
+  clearRouteSegments,
+  getRouteSegmentStats,
+  getAllRailStationCodes,
+  type RouteSegment,
+} from "@/lib/actions/rail-network";
+
+const OVERPASS_URL = "https://overpass-api.de/api/interpreter";
+const BATCH_SIZE = 50;
+
+const REGIONS: Array<{
+  label: string;
+  south: number;
+  west: number;
+  north: number;
+  east: number;
+}> = [
+  { label: "South England", south: 50.0, west: -6.0, north: 52.0, east: 2.0 },
+  { label: "Midlands", south: 51.8, west: -3.5, north: 53.5, east: 1.0 },
+  { label: "North England", south: 53.0, west: -3.5, north: 55.8, east: 0.0 },
+  { label: "Wales", south: 51.3, west: -5.5, north: 53.5, east: -2.5 },
+  { label: "Scotland", south: 55.0, west: -6.0, north: 59.0, east: -1.0 },
+];
+
+type Status =
+  | { phase: "idle" }
+  | { phase: "fetching"; region: string; regionIdx: number }
+  | { phase: "processing"; message: string }
+  | { phase: "seeding"; seeded: number; total: number }
+  | { phase: "done"; total: number }
+  | { phase: "error"; message: string };
 
 type OsmNode = { type: "node"; id: number; lat: number; lon: number; tags?: Record<string, string> };
-type OsmWay = { type: "way"; id: number; nodes: number[]; tags?: Record<string, string> };
+type OsmWay = { type: "way"; id: number; nodes: number[] };
 type OsmRelation = {
   type: "relation";
   id: number;
   tags?: Record<string, string>;
   members: Array<{ type: string; ref: number; role: string }>;
 };
-type OsmElement = OsmNode | OsmWay | OsmRelation;
-
-type StationMatch = {
-  osmNodeId: number;
-  name: string;
-  code: string | null;
-  lat: number;
-  lon: number;
-  positionOnRoute: number;
-};
 
 export function RailRouteSeeder({ initialCount }: { initialCount: number }) {
-  const [status, setStatus] = useState<string>(
-    initialCount > 0 ? `${initialCount} route segments stored` : "No route segments yet",
-  );
-  const [processing, setProcessing] = useState(false);
-  const [segments, setSegments] = useState<RouteSegment[]>([]);
-  const [seeded, setSeeded] = useState(0);
-  const fileRef = useRef<HTMLInputElement>(null);
+  const [count, setCount] = useState(initialCount);
+  const [status, setStatus] = useState<Status>({ phase: "idle" });
 
-  const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-
-    setProcessing(true);
-    setStatus("Reading file...");
+  const handleSeed = useCallback(async () => {
+    setStatus({ phase: "fetching", region: REGIONS[0].label, regionIdx: 0 });
 
     try {
-      const text = await file.text();
-      setStatus("Parsing JSON...");
-      const data = JSON.parse(text) as { elements: OsmElement[] };
+      const allNodes = new Map<number, { lat: number; lon: number; tags?: Record<string, string> }>();
+      const allWays = new Map<number, number[]>();
+      const allRelations: OsmRelation[] = [];
+      const seenRelations = new Set<number>();
 
-      const nodeMap = new Map<number, { lat: number; lon: number }>();
-      const wayMap = new Map<number, number[]>();
-      const relations: OsmRelation[] = [];
+      for (let i = 0; i < REGIONS.length; i++) {
+        const r = REGIONS[i];
+        setStatus({ phase: "fetching", region: r.label, regionIdx: i });
 
-      for (const el of data.elements) {
-        if (el.type === "node") nodeMap.set(el.id, { lat: el.lat, lon: el.lon });
-        else if (el.type === "way") wayMap.set(el.id, el.nodes);
-        else if (el.type === "relation") relations.push(el);
+        const query = `[out:json][timeout:120];relation["type"="route"]["route"="train"](${r.south},${r.west},${r.north},${r.east});(._;>;);out body;`;
+        const resp = await fetch(OVERPASS_URL, {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: `data=${encodeURIComponent(query)}`,
+          signal: AbortSignal.timeout(120_000),
+        });
+
+        if (!resp.ok) {
+          setStatus({ phase: "error", message: `Overpass HTTP ${resp.status} for ${r.label}. Wait a minute and retry.` });
+          return;
+        }
+
+        const json = await resp.json();
+        for (const el of json.elements ?? []) {
+          if (el.type === "node" && el.lat != null && el.lon != null) {
+            allNodes.set(el.id, { lat: el.lat, lon: el.lon, tags: el.tags });
+          } else if (el.type === "way" && el.nodes) {
+            allWays.set(el.id, el.nodes);
+          } else if (el.type === "relation" && !seenRelations.has(el.id)) {
+            seenRelations.add(el.id);
+            allRelations.push(el as OsmRelation);
+          }
+        }
+
+        if (i < REGIONS.length - 1) {
+          await new Promise((r) => setTimeout(r, 5000));
+        }
       }
 
-      setStatus(`Parsed ${nodeMap.size} nodes, ${wayMap.size} ways, ${relations.length} relations. Processing routes...`);
+      setStatus({ phase: "processing", message: `${allNodes.size} nodes, ${allWays.size} ways, ${allRelations.length} relations. Resolving station codes...` });
+
+      const rawCodes = await getAllRailStationCodes() as unknown as Record<string, string>;
+      const nameToCode = new Map<string, string>(Object.entries(rawCodes));
+
+      setStatus({ phase: "processing", message: `Building route segments from ${allRelations.length} relations...` });
 
       const allSegments: RouteSegment[] = [];
-      let processed = 0;
+      const seenPairs = new Set<string>();
 
-      for (const rel of relations) {
+      for (const rel of allRelations) {
         const tags = rel.tags ?? {};
         if (tags.type !== "route" || tags.route !== "train") continue;
 
@@ -67,32 +109,28 @@ export function RailRouteSeeder({ initialCount }: { initialCount: number }) {
 
         const wayMembers = rel.members.filter((m) => m.type === "way");
         const stopMembers = rel.members.filter(
-          (m) => m.type === "node" && (m.role.includes("stop") || m.role === ""),
+          (m) => m.type === "node" && m.role.includes("stop"),
         );
 
-        if (wayMembers.length === 0) continue;
+        if (wayMembers.length === 0 || stopMembers.length < 2) continue;
 
         const routePoints: Array<{ lat: number; lon: number }> = [];
-        const usedWayIds = new Set<number>();
-
         for (const wm of wayMembers) {
-          const nodeIds = wayMap.get(wm.ref);
+          const nodeIds = allWays.get(wm.ref);
           if (!nodeIds) continue;
-          if (usedWayIds.has(wm.ref)) continue;
-          usedWayIds.add(wm.ref);
 
           const wayPts: Array<{ lat: number; lon: number }> = [];
           for (const nid of nodeIds) {
-            const nd = nodeMap.get(nid);
-            if (nd) wayPts.push(nd);
+            const nd = allNodes.get(nid);
+            if (nd) wayPts.push({ lat: nd.lat, lon: nd.lon });
           }
           if (wayPts.length === 0) continue;
 
           if (routePoints.length > 0 && wayPts.length > 0) {
             const last = routePoints[routePoints.length - 1];
-            const distToFirst = sqDist(last, wayPts[0]);
-            const distToLast = sqDist(last, wayPts[wayPts.length - 1]);
-            if (distToLast < distToFirst) wayPts.reverse();
+            const distFirst = sqDist(last, wayPts[0]);
+            const distLast = sqDist(last, wayPts[wayPts.length - 1]);
+            if (distLast < distFirst) wayPts.reverse();
             wayPts.shift();
           }
           routePoints.push(...wayPts);
@@ -100,14 +138,12 @@ export function RailRouteSeeder({ initialCount }: { initialCount: number }) {
 
         if (routePoints.length < 2) continue;
 
-        const stations: StationMatch[] = [];
+        const stations: Array<{ name: string; code: string | null; posIdx: number }> = [];
         for (const sm of stopMembers) {
-          const nd = nodeMap.get(sm.ref);
+          const nd = allNodes.get(sm.ref);
           if (!nd) continue;
-          const nodeTags = data.elements.find(
-            (el) => el.type === "node" && el.id === sm.ref,
-          ) as OsmNode | undefined;
-          const name = nodeTags?.tags?.name ?? `Node ${sm.ref}`;
+          const name = nd.tags?.name ?? "";
+          if (!name) continue;
 
           let bestIdx = 0;
           let bestDist = Infinity;
@@ -116,175 +152,176 @@ export function RailRouteSeeder({ initialCount }: { initialCount: number }) {
             if (d < bestDist) { bestDist = d; bestIdx = i; }
           }
 
-          stations.push({
-            osmNodeId: sm.ref,
-            name,
-            code: null,
-            lat: nd.lat,
-            lon: nd.lon,
-            positionOnRoute: bestIdx,
-          });
+          const code = nameToCode.get(name.toLowerCase()) ?? null;
+          stations.push({ name, code, posIdx: bestIdx });
         }
 
-        stations.sort((a, b) => a.positionOnRoute - b.positionOnRoute);
-        const uniqueStations = stations.filter(
-          (s, i) => i === 0 || s.positionOnRoute !== stations[i - 1].positionOnRoute,
+        stations.sort((a, b) => a.posIdx - b.posIdx);
+        const unique = stations.filter(
+          (s, i) => i === 0 || s.posIdx !== stations[i - 1].posIdx,
         );
 
-        if (uniqueStations.length < 2) continue;
+        for (let i = 0; i < unique.length - 1; i++) {
+          const from = unique[i];
+          const to = unique[i + 1];
+          if (!from.code || !to.code) continue;
+          if (to.posIdx <= from.posIdx) continue;
 
-        for (let i = 0; i < uniqueStations.length - 1; i++) {
-          const from = uniqueStations[i];
-          const to = uniqueStations[i + 1];
-          const startIdx = from.positionOnRoute;
-          const endIdx = to.positionOnRoute;
-          if (endIdx <= startIdx) continue;
+          const pairKey = `${from.code}:${to.code}`;
+          if (seenPairs.has(pairKey)) continue;
+          seenPairs.add(pairKey);
 
-          const segPts = routePoints.slice(startIdx, endIdx + 1);
+          const segPts = routePoints.slice(from.posIdx, to.posIdx + 1);
           if (segPts.length < 2) continue;
 
-          const encoded = googleEncodePolyline(segPts);
           allSegments.push({
             osm_relation_id: rel.id,
             route_name: routeName,
             operator,
             from_station_name: from.name,
             to_station_name: to.name,
-            from_station_code: null,
-            to_station_code: null,
-            encoded_polyline: encoded,
+            from_station_code: from.code,
+            to_station_code: to.code,
+            encoded_polyline: encodePolyline(segPts),
             point_count: segPts.length,
           });
         }
-
-        processed++;
-        if (processed % 10 === 0) {
-          setStatus(`Processed ${processed}/${relations.length} relations, ${allSegments.length} segments...`);
-        }
       }
 
-      setStatus(`Resolving station codes for ${allSegments.length} segments...`);
-
-      const rawMap = await getAllRailStationCodes() as unknown as Record<string, string>;
-      const nameToCode = new Map<string, string>(Object.entries(rawMap));
-
-      for (const seg of allSegments) {
-        seg.from_station_code = nameToCode.get(seg.from_station_name.toLowerCase()) ?? null;
-        seg.to_station_code = nameToCode.get(seg.to_station_name.toLowerCase()) ?? null;
+      if (allSegments.length === 0) {
+        setStatus({ phase: "error", message: "No segments with matched station codes found." });
+        return;
       }
 
-      const withCodes = allSegments.filter((s) => s.from_station_code && s.to_station_code);
-      setSegments(withCodes);
-      setStatus(`Ready: ${withCodes.length} segments with station codes (${allSegments.length - withCodes.length} skipped — no code match). Click Seed to store.`);
+      setStatus({ phase: "seeding", seeded: 0, total: allSegments.length });
+
+      let seeded = 0;
+      for (let i = 0; i < allSegments.length; i += BATCH_SIZE) {
+        const chunk = allSegments.slice(i, i + BATCH_SIZE);
+        await seedRouteSegments(chunk);
+        seeded += chunk.length;
+        setStatus({ phase: "seeding", seeded, total: allSegments.length });
+      }
+
+      const fresh = await getRouteSegmentStats();
+      setCount(fresh?.count ?? seeded);
+      setStatus({ phase: "done", total: seeded });
     } catch (err) {
-      setStatus(`Error: ${err instanceof Error ? err.message : String(err)}`);
-    } finally {
-      setProcessing(false);
+      setStatus({ phase: "error", message: err instanceof Error ? err.message : String(err) });
     }
-  };
+  }, []);
 
-  const handleSeed = async () => {
-    if (segments.length === 0) return;
-    setProcessing(true);
-    setSeeded(0);
-
-    const chunkSize = 50;
-    let total = 0;
-    for (let i = 0; i < segments.length; i += chunkSize) {
-      const chunk = segments.slice(i, i + chunkSize);
-      try {
-        const result = await seedRouteSegments(chunk);
-        total += result.inserted;
-        setSeeded(total);
-        setStatus(`Seeded ${total}/${segments.length}...`);
-      } catch (err) {
-        setStatus(`Error at chunk ${i}: ${err instanceof Error ? err.message : String(err)}`);
-        break;
-      }
-    }
-
-    setStatus(`Done: ${total} route segments stored.`);
-    setProcessing(false);
-  };
-
-  const handleClear = async () => {
-    setProcessing(true);
+  const handleClear = useCallback(async () => {
+    if (!window.confirm("Clear all stored route segments?")) return;
     try {
       await clearRouteSegments();
-      setStatus("Cleared all route segments.");
-      setSegments([]);
-      setSeeded(0);
+      setCount(0);
+      setStatus({ phase: "idle" });
     } catch (err) {
-      setStatus(`Error: ${err instanceof Error ? err.message : String(err)}`);
+      setStatus({ phase: "error", message: err instanceof Error ? err.message : String(err) });
     }
-    setProcessing(false);
-  };
+  }, []);
+
+  const isWorking = status.phase === "fetching" || status.phase === "processing" || status.phase === "seeding";
 
   return (
-    <div className="flex flex-col gap-4">
-      <p className="small" style={{ color: "var(--ink-dim)" }}>{status}</p>
+    <div className="j-card p-6" style={{ maxWidth: 640 }}>
+      <h2 className="h3 mb-2">OSM Route Relations</h2>
+      <p className="small mb-4" style={{ color: "var(--ink-dim)" }}>
+        Fetches named train route relations from OpenStreetMap via Overpass.
+        Each relation defines which track segments belong to a specific railway
+        line. Station-to-station polylines are extracted and stored — no
+        algorithmic routing needed, no junction ambiguity.
+      </p>
 
-      <div className="flex gap-3 flex-wrap">
-        <label
-          className="btn-ghost"
-          style={{ cursor: processing ? "wait" : "pointer", fontSize: 13 }}
-        >
-          Upload Overpass JSON
-          <input
-            ref={fileRef}
-            type="file"
-            accept=".json"
-            onChange={handleFile}
-            disabled={processing}
-            style={{ display: "none" }}
-          />
-        </label>
-
-        {segments.length > 0 && (
-          <button
-            className="btn-primary"
-            onClick={handleSeed}
-            disabled={processing}
-            style={{ fontSize: 13 }}
-          >
-            Seed {segments.length} segments
-          </button>
-        )}
-
-        <button
-          className="btn-ghost"
-          onClick={handleClear}
-          disabled={processing}
-          style={{ fontSize: 13, color: "var(--rust)" }}
-        >
-          Clear all
-        </button>
+      <div
+        className="mb-4"
+        style={{
+          padding: "10px 14px",
+          borderRadius: 6,
+          fontSize: 13,
+          background: count > 0 ? "var(--sage-2)" : "var(--card-2)",
+          border: `1px solid ${count > 0 ? "var(--sage-2)" : "var(--rule-2)"}`,
+          color: count > 0 ? "var(--sage)" : "var(--ink-dim)",
+        }}
+      >
+        {count > 0 ? `${count.toLocaleString()} route segments stored` : "Not seeded yet"}
       </div>
 
-      {segments.length > 0 && (
-        <div style={{ maxHeight: 300, overflow: "auto", fontSize: 12, color: "var(--ink-dim)" }}>
-          <table style={{ width: "100%", borderCollapse: "collapse" }}>
-            <thead>
-              <tr style={{ textAlign: "left", borderBottom: "1px solid var(--rule)" }}>
-                <th style={{ padding: "4px 8px" }}>From</th>
-                <th style={{ padding: "4px 8px" }}>To</th>
-                <th style={{ padding: "4px 8px" }}>Route</th>
-                <th style={{ padding: "4px 8px" }}>Points</th>
-              </tr>
-            </thead>
-            <tbody>
-              {segments.slice(0, 100).map((s, i) => (
-                <tr key={i} style={{ borderBottom: "1px solid var(--rule-2)" }}>
-                  <td style={{ padding: "3px 8px" }}>{s.from_station_code} {s.from_station_name}</td>
-                  <td style={{ padding: "3px 8px" }}>{s.to_station_code} {s.to_station_name}</td>
-                  <td style={{ padding: "3px 8px" }}>{s.route_name}</td>
-                  <td style={{ padding: "3px 8px" }}>{s.point_count}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+      {status.phase === "fetching" && (
+        <ProgressBox color="gold">
+          Fetching region {status.regionIdx + 1}/{REGIONS.length}: {status.region}
+          <ProgressBar value={(status.regionIdx + 1) / REGIONS.length} />
+        </ProgressBox>
       )}
+
+      {status.phase === "processing" && (
+        <ProgressBox color="gold">{status.message}</ProgressBox>
+      )}
+
+      {status.phase === "seeding" && (
+        <ProgressBox color="gold">
+          Seeding {status.seeded.toLocaleString()}/{status.total.toLocaleString()} segments
+          <ProgressBar value={status.seeded / status.total} />
+        </ProgressBox>
+      )}
+
+      {status.phase === "done" && (
+        <ProgressBox color="sage">
+          Done -- {status.total.toLocaleString()} route segments stored.
+        </ProgressBox>
+      )}
+
+      {status.phase === "error" && (
+        <ProgressBox color="rust">{status.message}</ProgressBox>
+      )}
+
+      <div style={{ display: "flex", gap: 10 }}>
+        <button
+          type="button"
+          className="btn-primary"
+          onClick={handleSeed}
+          disabled={isWorking}
+        >
+          {isWorking ? "Working..." : count > 0 ? "Re-seed routes" : "Seed Route Relations"}
+        </button>
+        {count > 0 && (
+          <button
+            type="button"
+            className="btn-ghost"
+            onClick={handleClear}
+            disabled={isWorking}
+          >
+            Clear
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ProgressBox({ children, color }: { children: React.ReactNode; color: string }) {
+  return (
+    <div
+      className="mb-4"
+      style={{
+        padding: "10px 14px",
+        borderRadius: 6,
+        fontSize: 13,
+        background: `var(--${color}-2)`,
+        border: `1px solid var(--${color}-2)`,
+        color: color === "rust" ? "var(--rust)" : "var(--ink)",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function ProgressBar({ value }: { value: number }) {
+  return (
+    <div style={{ marginTop: 8, height: 4, borderRadius: 2, background: "var(--rule-2)", overflow: "hidden" }}>
+      <div style={{ height: "100%", borderRadius: 2, background: "var(--gold)", width: `${value * 100}%`, transition: "width 0.3s ease" }} />
     </div>
   );
 }
@@ -293,7 +330,7 @@ function sqDist(a: { lat: number; lon: number }, b: { lat: number; lon: number }
   return (a.lat - b.lat) ** 2 + (a.lon - b.lon) ** 2;
 }
 
-function googleEncodePolyline(points: Array<{ lat: number; lon: number }>): string {
+function encodePolyline(points: Array<{ lat: number; lon: number }>): string {
   let encoded = "";
   let prevLat = 0;
   let prevLng = 0;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3566,9 +3566,46 @@
     }
     .brief-card {
       padding: 14px;
+      border-radius: 12px;
+    }
+    .brief-card header {
+      flex-wrap: wrap;
+      gap: 6px;
+    }
+    .brief-field label,
+    .brief-field .field-label {
+      font-size: 9px;
+    }
+    .brief-field .field {
+      font-size: 13px;
+      padding: 8px 10px;
+    }
+    .brief-pill-row {
+      gap: 4px;
+      margin-top: 6px;
+    }
+    .brief-pill-row > * {
+      font-size: 11px;
+      padding: 4px 8px;
+    }
+    .brief-when-row {
+      gap: 6px;
     }
     .kind-pop {
       max-width: calc(100vw - 32px);
+    }
+    .btn-ghost {
+      padding: 10px 14px;
+      font-size: 13px;
+      border-radius: 10px;
+    }
+    .btn-gold {
+      padding: 10px 14px;
+      font-size: 13px;
+      border-radius: 10px;
+    }
+    .stat-hero {
+      font-size: 28px;
     }
   }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3547,6 +3547,26 @@
      under the chip rows (the swipe gesture is enough on touch), and
      trim padding so nothing slips off the edge of the screen. */
   @media (max-width: 640px) {
+    .brief-card-expanded {
+      position: fixed;
+      inset: 0;
+      z-index: 40;
+      border-radius: 0;
+      overflow-y: auto;
+      -webkit-overflow-scrolling: touch;
+      padding: 16px 16px calc(env(safe-area-inset-bottom, 0px) + 16px);
+      border: none;
+      box-shadow: none;
+    }
+    .brief-card-expanded header {
+      position: sticky;
+      top: 0;
+      z-index: 1;
+      background: var(--card);
+      padding-bottom: 8px;
+      margin: -16px -16px 8px;
+      padding: 16px 16px 8px;
+    }
     .brief-pill-row {
       scrollbar-width: none;
     }

--- a/src/components/itinerary/anchor-card.tsx
+++ b/src/components/itinerary/anchor-card.tsx
@@ -138,7 +138,7 @@ export function AnchorCard({
   }
 
   return (
-    <section className={first ? "brief-card brief-card-hero" : "brief-card"}>
+    <section className={`${first ? "brief-card brief-card-hero" : "brief-card"} brief-card-expanded`}>
       <header
         style={{
           display: "flex",

--- a/src/components/itinerary/anchor-card.tsx
+++ b/src/components/itinerary/anchor-card.tsx
@@ -513,9 +513,6 @@ function KindBadge({
         >
           <KindDot kind={kind} />
           <span>{kindLabel}</span>
-          {kindOverridden ? (
-            <span className="kind-badge-flag">overridden</span>
-          ) : null}
           <ChevDown />
         </button>
         {openKind ? (
@@ -547,9 +544,6 @@ function KindBadge({
             onClick={() => setOpenRole((v) => !v)}
           >
             <span>{roleLabel}</span>
-            {roleOverridden ? (
-              <span className="kind-badge-flag">overridden</span>
-            ) : null}
             <ChevDown />
           </button>
           {openRole ? (

--- a/src/components/itinerary/build-planning-timeline.ts
+++ b/src/components/itinerary/build-planning-timeline.ts
@@ -85,11 +85,13 @@ export function buildPlanningTimeline(input: PlanningTimelineInput): TimelineEnt
 
   const result: TimelineEntry[] = [];
 
-  // Home → first item gap
+  // Home → first-anchor gap is rendered manually by the editor (it
+  // needs leave-by calculation + startStop rendering). But when the
+  // first item is a transit stop (train station), the editor doesn't
+  // render the gap — we handle it here with a GapModePicker.
   if (startStop && planningTimeline.length > 0) {
     const first = planningTimeline[0];
     if (first.kind === "transit") {
-      // Home → station: show GapModePicker (walk/drive/taxi to station)
       const toLabel = first.stop.title ?? "station";
       const fromLabel = startStop.location?.name ?? startStop.title ?? "Home";
       const selectedGap = getGapModeSelected(
@@ -106,24 +108,6 @@ export function buildPlanningTimeline(input: PlanningTimelineInput): TimelineEnt
           if (mode === "walk" || mode === "drive" || mode === "taxi") {
             onSetGapMode(startStop.id, uidOf(first), mode);
           }
-        },
-      });
-    } else {
-      const toAnchor = first.kind === "anchor"
-        ? first.anchor
-        : stopoverAsAnchor(first.stopover, first.stopover.uid);
-      result.push({
-        kind: "gap-transition",
-        from: null,
-        to: toAnchor,
-        transition: planningTransitions.get(
-          transitionKey(startStop.id, uidOf(first)),
-        ) ?? emptyTransition(),
-        fromVirtualLabel: startStop.location?.name ?? startStop.title ?? "Home",
-        modePreviews: previewsForPair(startStop.id, uidOf(first)),
-        onChange: (patch) => handlers.handleTransitionPatch(startStop.id, uidOf(first), patch),
-        onOpenChange: (open) => {
-          if (open) handlers.prefetchPair(startStop.id, uidOf(first));
         },
       });
     }
@@ -144,15 +128,6 @@ export function buildPlanningTimeline(input: PlanningTimelineInput): TimelineEnt
     } else {
       transitGroupStart.set(i, i);
     }
-  }
-
-  // Insert-above for the first timeline item
-  if (planningTimeline.length > 0) {
-    const first = planningTimeline[0];
-    result.push({
-      kind: "inline-adds",
-      onAddAnchor: () => handlers.handleInsertAnchorAt(first.stop.sequence),
-    });
   }
 
   // Walk through timeline items

--- a/src/components/itinerary/build-planning-timeline.ts
+++ b/src/components/itinerary/build-planning-timeline.ts
@@ -146,6 +146,15 @@ export function buildPlanningTimeline(input: PlanningTimelineInput): TimelineEnt
     }
   }
 
+  // Insert-above for the first timeline item
+  if (planningTimeline.length > 0) {
+    const first = planningTimeline[0];
+    result.push({
+      kind: "inline-adds",
+      onAddAnchor: () => handlers.handleInsertAnchorAt(first.stop.sequence),
+    });
+  }
+
   // Walk through timeline items
   for (let i = 0; i < planningTimeline.length; i++) {
     if (consumedByGroup.has(i)) continue;

--- a/src/components/itinerary/build-planning-timeline.ts
+++ b/src/components/itinerary/build-planning-timeline.ts
@@ -253,11 +253,11 @@ export function buildPlanningTimeline(input: PlanningTimelineInput): TimelineEnt
       // Inline adds BEFORE the gap-mode picker — adding a stop between
       // the anchor and the station should come before choosing how you
       // get to the station.
-      if (item.kind === "anchor" && nextItem) {
+      if (nextItem) {
         result.push({
           kind: "inline-adds",
           onAddAnchor: () => handlers.handleInsertAnchorAt(nextItem.stop.sequence),
-          onAddStopover: nextItem.kind === "anchor"
+          onAddStopover: nextItem.kind === "anchor" || nextItem.kind === "stopover"
             ? () => handlers.handleInsertStopoverBetween(stop.id, nextItem.stop.id)
             : undefined,
         });

--- a/src/components/place-picker.tsx
+++ b/src/components/place-picker.tsx
@@ -243,10 +243,9 @@ export function PlacePicker({
   }, [open]);
 
   const handleGooglePick = async (g: GoogleSuggestion) => {
+    setQuery(g.primary || g.description);
+    setGoogleSuggestions([]);
     setOpen(false);
-    // Promote into our locations table immediately so the picker always
-    // returns a location_id (downstream code can keep treating it like a
-    // regular saved place).
     setPending(true);
     setError(null);
     const result = await createInlineLocation({
@@ -255,11 +254,11 @@ export function PlacePicker({
       google_place_id: g.place_id,
       google_session_token: sessionTokenRef.current,
     });
-    // New session token for the next pick — Google's billing recommendation.
     sessionTokenRef.current = newSessionToken();
     setPending(false);
     if (!result.ok) {
       setError(feedbackFromError(result.error).message);
+      setOpen(true);
       return;
     }
     const loc = result.value;
@@ -271,7 +270,6 @@ export function PlacePicker({
       location_type: loc.type,
     });
     setQuery("");
-    setGoogleSuggestions([]);
   };
 
   const pick = (row: Row) => {
@@ -510,6 +508,9 @@ export function PlacePicker({
             </button>
           ) : null}
         </div>
+      ) : null}
+      {!open && error ? (
+        <p style={{ fontSize: 12, color: "var(--rust)", marginTop: 4 }}>{error}</p>
       ) : null}
     </div>
   );

--- a/src/components/place-picker.tsx
+++ b/src/components/place-picker.tsx
@@ -223,7 +223,7 @@ export function PlacePicker({
       } finally {
         if (!cancelled) setGoogleLoading(false);
       }
-    }, 160);
+    }, 300);
     return () => {
       cancelled = true;
       clearTimeout(timeout);

--- a/src/lib/actions/rail-network.ts
+++ b/src/lib/actions/rail-network.ts
@@ -19,7 +19,7 @@ export async function seedRailEdges(
   edges: Edge[],
 ): Promise<{ inserted: number }> {
   const ctx = await requireUserContext();
-  if (!ctx.isAdmin) throw new Error("Admin only");
+  if (!ctx.isSuperUser) throw new Error("Super user only");
   if (edges.length === 0) return { inserted: 0 };
 
   const supabase = await createClient();
@@ -44,7 +44,7 @@ export async function seedRouteSegments(
   segments: RouteSegment[],
 ): Promise<{ inserted: number }> {
   const ctx = await requireUserContext();
-  if (!ctx.isAdmin) throw new Error("Admin only");
+  if (!ctx.isSuperUser) throw new Error("Super user only");
   if (segments.length === 0) return { inserted: 0 };
 
   const supabase = await createClient();
@@ -67,7 +67,7 @@ export async function getRouteSegmentStats(): Promise<{ count: number } | null> 
 
 export async function clearRouteSegments(): Promise<void> {
   const ctx = await requireUserContext();
-  if (!ctx.isAdmin) throw new Error("Admin only");
+  if (!ctx.isSuperUser) throw new Error("Super user only");
   const supabase = await createClient();
   await supabase.from("rail_named_route_segments").delete().gte("id", "00000000-0000-0000-0000-000000000000");
 }
@@ -112,7 +112,7 @@ export async function getRailNetworkStats(): Promise<{
  */
 export async function clearRailNetwork(): Promise<void> {
   const ctx = await requireUserContext();
-  if (!ctx.isAdmin) throw new Error("Admin only");
+  if (!ctx.isSuperUser) throw new Error("Super user only");
   const supabase = await createClient();
   // Delete all rows — Supabase JS doesn't have TRUNCATE, but
   // a broad delete with a tautological filter does the job.

--- a/src/lib/actions/rail-network.ts
+++ b/src/lib/actions/rail-network.ts
@@ -72,19 +72,23 @@ export async function clearRouteSegments(): Promise<void> {
   await supabase.from("rail_named_route_segments").delete().gte("id", "00000000-0000-0000-0000-000000000000");
 }
 
-export async function getAllRailStationCodes(): Promise<Map<string, string>> {
+export async function getAllRailStationCodes(): Promise<
+  Array<{ code: string; name: string; lat: number; lng: number }>
+> {
   await requireUserContext();
   const supabase = await createClient();
   const { data } = await supabase
     .from("transport_hubs")
-    .select("name, code")
+    .select("name, code, latitude, longitude")
     .eq("kind", "rail_station")
-    .not("code", "is", null);
-  const map = new Map<string, string>();
-  for (const h of data ?? []) {
-    if (h.code) map.set(h.name.toLowerCase(), h.code);
-  }
-  return Object.fromEntries(map) as any;
+    .not("code", "is", null)
+    .not("latitude", "is", null);
+  return (data ?? []).map((h) => ({
+    code: h.code!,
+    name: h.name,
+    lat: Number(h.latitude),
+    lng: Number(h.longitude),
+  }));
 }
 
 /**

--- a/src/lib/actions/stops.ts
+++ b/src/lib/actions/stops.ts
@@ -249,7 +249,10 @@ export async function insertStopAt(
       action: "create",
       after: result.value,
     });
-    await resolveItineraryTimes(result.value.itinerary_id);
+    const hasTime = fields.start_time || fields.end_time || fields.duration_minutes;
+    if (hasTime) {
+      await resolveItineraryTimes(result.value.itinerary_id);
+    }
   }
   return result;
 }

--- a/src/lib/actions/stops.ts
+++ b/src/lib/actions/stops.ts
@@ -22,6 +22,7 @@ const stopTypeEnum = z.enum([
   // added stopover). Kept in lock-step here so editor patches for
   // those stop types pass validation.
   "transit_departure",
+  "transit_changeover",
   "stopover",
   "other",
 ]);
@@ -200,20 +201,15 @@ export async function insertStopAt(
   const ctx = await requireUserContext();
   const supabase = await createClient();
 
-  // Batch-bump all later stops in one query instead of N individual updates
-  await supabase.rpc("bump_stop_sequences" as any, {
+  // Batch-bump all later stops in one query via RPC
+  const { error: rpcErr } = await supabase.rpc("bump_stop_sequences" as any, {
     p_itinerary_id: parsed.value.itinerary_id,
     p_workspace_id: ctx.workspaceId,
     p_from_sequence: parsed.value.sequence,
-  }).then(() => {}, async () => {
-    // Fallback if RPC doesn't exist: single UPDATE with gte filter
-    await supabase
-      .from("stops")
-      .update({ sequence: -1 } as any)
-      .eq("itinerary_id", parsed.value.itinerary_id)
-      .eq("workspace_id", ctx.workspaceId)
-      .gte("sequence", parsed.value.sequence);
-    // The above won't work for incrementing. Use the loop as last resort.
+  });
+
+  if (rpcErr) {
+    // Fallback: sequential updates (slow but correct)
     const { data: shiftRows } = await supabase
       .from("stops")
       .select("id, sequence")
@@ -228,7 +224,7 @@ export async function insertStopAt(
         .eq("id", r.id as string)
         .eq("workspace_id", ctx.workspaceId);
     }
-  });
+  }
 
   const { itinerary_id, sequence, ...fields } = parsed.value;
   const { data, error } = await supabase
@@ -249,6 +245,7 @@ export async function insertStopAt(
       action: "create",
       after: result.value,
     });
+    await resolveItineraryTimes(result.value.itinerary_id);
   }
   return result;
 }

--- a/src/lib/actions/stops.ts
+++ b/src/lib/actions/stops.ts
@@ -250,7 +250,7 @@ export async function insertStopAt(
   return result;
 }
 
-export async function deleteStop(id: string): Promise<Result<{ id: string }>> {
+export async function deleteStop(id: string, skipSolver?: boolean): Promise<Result<{ id: string }>> {
   const ctx = await requireUserContext();
   const supabase = await createClient();
 
@@ -274,7 +274,7 @@ export async function deleteStop(id: string): Promise<Result<{ id: string }>> {
     action: "delete",
     before,
   });
-  if (before?.itinerary_id) {
+  if (before?.itinerary_id && !skipSolver) {
     await resolveItineraryTimes(before.itinerary_id);
   }
   return ok({ id });

--- a/src/lib/actions/stops.ts
+++ b/src/lib/actions/stops.ts
@@ -176,7 +176,11 @@ export async function updateStop(
       before,
       after: result.value,
     });
-    await resolveItineraryTimes(result.value.itinerary_id);
+    const timeFields = new Set(["start_time", "end_time", "duration_minutes", "is_time_fixed"]);
+    const touchesTime = Object.keys(patch).some((k) => timeFields.has(k));
+    if (touchesTime) {
+      await resolveItineraryTimes(result.value.itinerary_id);
+    }
   }
   return result;
 }
@@ -278,6 +282,41 @@ export async function deleteStop(id: string, skipSolver?: boolean): Promise<Resu
     await resolveItineraryTimes(before.itinerary_id);
   }
   return ok({ id });
+}
+
+export async function deleteStops(ids: string[]): Promise<Result<{ ids: string[] }>> {
+  if (ids.length === 0) return ok({ ids: [] });
+  const ctx = await requireUserContext();
+  const supabase = await createClient();
+
+  const { data: rows } = await supabase
+    .from("stops")
+    .select("id, itinerary_id")
+    .in("id", ids)
+    .eq("workspace_id", ctx.workspaceId);
+
+  const itineraryId = rows?.[0]?.itinerary_id ?? null;
+
+  const { error } = await supabase
+    .from("stops")
+    .delete()
+    .in("id", ids)
+    .eq("workspace_id", ctx.workspaceId);
+
+  if (error) return dbResult<{ ids: string[] }>(null, error, "stop");
+
+  await recordAudit({
+    entityType: "stop",
+    entityId: ids[0],
+    action: "delete",
+    before: { deleted_ids: ids },
+  });
+
+  if (itineraryId) {
+    await resolveItineraryTimes(itineraryId);
+  }
+
+  return ok({ ids });
 }
 
 export async function reorderStops(

--- a/src/lib/actions/stops.ts
+++ b/src/lib/actions/stops.ts
@@ -200,23 +200,35 @@ export async function insertStopAt(
   const ctx = await requireUserContext();
   const supabase = await createClient();
 
-  // Bump every stop at sequence >= target by +1 to make room. Order
-  // by sequence desc so the writes don't collide with each other on
-  // any in-flight uniqueness assumptions.
-  const { data: shiftRows } = await supabase
-    .from("stops")
-    .select("id, sequence")
-    .eq("itinerary_id", parsed.value.itinerary_id)
-    .eq("workspace_id", ctx.workspaceId)
-    .gte("sequence", parsed.value.sequence)
-    .order("sequence", { ascending: false });
-  for (const r of shiftRows ?? []) {
+  // Batch-bump all later stops in one query instead of N individual updates
+  await supabase.rpc("bump_stop_sequences" as any, {
+    p_itinerary_id: parsed.value.itinerary_id,
+    p_workspace_id: ctx.workspaceId,
+    p_from_sequence: parsed.value.sequence,
+  }).then(() => {}, async () => {
+    // Fallback if RPC doesn't exist: single UPDATE with gte filter
     await supabase
       .from("stops")
-      .update({ sequence: (r.sequence as number) + 1 })
-      .eq("id", r.id as string)
-      .eq("workspace_id", ctx.workspaceId);
-  }
+      .update({ sequence: -1 } as any)
+      .eq("itinerary_id", parsed.value.itinerary_id)
+      .eq("workspace_id", ctx.workspaceId)
+      .gte("sequence", parsed.value.sequence);
+    // The above won't work for incrementing. Use the loop as last resort.
+    const { data: shiftRows } = await supabase
+      .from("stops")
+      .select("id, sequence")
+      .eq("itinerary_id", parsed.value.itinerary_id)
+      .eq("workspace_id", ctx.workspaceId)
+      .gte("sequence", parsed.value.sequence)
+      .order("sequence", { ascending: false });
+    for (const r of shiftRows ?? []) {
+      await supabase
+        .from("stops")
+        .update({ sequence: (r.sequence as number) + 1 })
+        .eq("id", r.id as string)
+        .eq("workspace_id", ctx.workspaceId);
+    }
+  });
 
   const { itinerary_id, sequence, ...fields } = parsed.value;
   const { data, error } = await supabase
@@ -237,7 +249,6 @@ export async function insertStopAt(
       action: "create",
       after: result.value,
     });
-    await resolveItineraryTimes(result.value.itinerary_id);
   }
   return result;
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -20,6 +20,7 @@ export type CurrentUserContext = {
   fullName: string | null;
   isStaff: boolean;
   isAdmin: boolean;
+  isSuperUser: boolean;
   workspaceId: string;
 };
 
@@ -30,7 +31,7 @@ export const requireUserContext = cache(
 
     const { data: profile } = await supabase
       .from("profiles")
-      .select("id, email, full_name, is_staff, is_admin, default_workspace_id")
+      .select("id, email, full_name, is_staff, is_admin, is_super_user, default_workspace_id")
       .eq("id", user.id)
       .maybeSingle();
 
@@ -46,6 +47,7 @@ export const requireUserContext = cache(
       fullName: profile.full_name,
       isStaff: profile.is_staff,
       isAdmin: profile.is_admin,
+      isSuperUser: profile.is_super_user,
       workspaceId: profile.default_workspace_id,
     };
   },

--- a/src/lib/types/domain.ts
+++ b/src/lib/types/domain.ts
@@ -49,6 +49,7 @@ export type StopType =
   | "transport_booked"
   | "transit_arrival"
   | "transit_departure"
+  | "transit_changeover"
   | "stopover"
   | "other";
 

--- a/supabase/migrations/0029_add_is_super_user.sql
+++ b/supabase/migrations/0029_add_is_super_user.sql
@@ -1,0 +1,3 @@
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS is_super_user boolean NOT NULL DEFAULT false;
+-- Seed: existing admins become super users
+UPDATE profiles SET is_super_user = true WHERE is_admin = true;

--- a/supabase/migrations/0030_bump_stop_sequences_fn.sql
+++ b/supabase/migrations/0030_bump_stop_sequences_fn.sql
@@ -1,0 +1,14 @@
+CREATE OR REPLACE FUNCTION bump_stop_sequences(
+  p_itinerary_id uuid,
+  p_workspace_id uuid,
+  p_from_sequence integer
+) RETURNS void AS $$
+BEGIN
+  UPDATE stops
+  SET sequence = sequence + 1
+  WHERE itinerary_id = p_itinerary_id
+    AND workspace_id = p_workspace_id
+    AND sequence >= p_from_sequence
+  ;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary

Stabilise the planning page so the next session starts from a clean, working base. This branch covers everything since the brief was killed and the planning page became the sole entry point — including the fixes from this session that addressed the broken state.

### Performance
- **Batch delete** (`deleteStops`): single DB call + one solver run instead of N sequential deletes that caused a 38-second freeze
- **Solver skip for non-time fields**: `updateStop` no longer runs `resolveItineraryTimes` when patching title, notes, location etc.
- **Solver skip for empty inserts**: `insertStopAt` skips the solver when the new stop has no time fields
- **Optimistic local insertion**: card appears instantly from server action return value — `router.refresh()` runs in background to sync relational data

### Bug fixes
- **Location selection not sticking**: `handleAnchorPatch` was silently dropping patches when `editedAnchors` didn't have the uid (auto-expanded cards via `pendingExpandUid` weren't seeded). Now falls back to `planningAnchors`
- **Ghost "via Walk" + duplicate add buttons**: `buildPlanningTimeline` was emitting a home-to-first gap-transition that the editor already renders manually. Removed the duplicate
- **Digest empty state**: condition now checks `onSiteWindow.from` (was truthy for `{from: null, to: null}`)
- **`disabled={pending}` blocking all buttons**: only advance-status and masthead-save disable during their own action

### Mobile
- Expanded anchor cards become **full-screen overlays** at <640px (`position: fixed; inset: 0`) with sticky header and safe-area padding
- Tighter button sizing, pill chips, and input fields at phone widths
- Timing picker removed from creation flow (was adding friction)

### Copy & labels
- Removed "OVERRIDDEN" badges from kind/role pills
- "after end of timeline" replaced with actual last stop name
- Removed duplicate "PLANNING" status pill
- "+ Transport" / "+ Accommodation" renamed to "+ Booked transport" / "+ Hotel booking"
- Action bar split into two clean rows

### Docs
- CLAUDE.md updated with all fixed bugs and the planned facts-first pivot direction

## Test plan
- [ ] Create new itinerary — planning page loads with empty state prompts
- [ ] Add a stop — card appears within ~2 seconds (not 10+)
- [ ] Search and select a location — selection sticks, shows in card
- [ ] Delete a stop — no freeze, timeline updates cleanly
- [ ] Delete a transport group — all sibling stops removed in one call
- [ ] On mobile: expanded card takes over full screen, scrollable, Done dismisses
- [ ] No ghost "via Walk" badges between home and first anchor
- [ ] All buttons remain clickable while other actions run
- [ ] Map shows empty-state prompt when no legs exist
- [ ] Digest shows "Stats appear as you add stops and connections" when empty

https://claude.ai/code/session_0142KBi45Scqowo19P2UwVkV

---
_Generated by [Claude Code](https://claude.ai/code/session_0142KBi45Scqowo19P2UwVkV)_