### PR TITLE
Fix day review leave-by derivation

### DIFF
--- a/src/lib/actions/review-derive.ts
+++ b/src/lib/actions/review-derive.ts
@@ -1,0 +1,42 @@
+export type ReviewStopRow = {
+  id: string;
+  type: string;
+  title: string | null;
+  start_time: string | null;
+  end_time: string | null;
+};
+
+export type ReviewTransitionRow = {
+  from_stop_id: string;
+  to_stop_id: string;
+  mode: string;
+  is_locked: boolean | null;
+  computed_duration_minutes: number | null;
+};
+
+const NON_DEPARTURE_STOP_TYPES = new Set(["end", "transit_arrival", "transit_changeover"]);
+
+function stopDepartureTime(stop: ReviewStopRow | undefined): string | null {
+  if (!stop || NON_DEPARTURE_STOP_TYPES.has(stop.type)) return null;
+  if (stop.type === "start") return stop.end_time ?? stop.start_time ?? null;
+  return stop.start_time ?? stop.end_time ?? null;
+}
+
+export function deriveReviewLeaveBy(stops: ReviewStopRow[], transitions: ReviewTransitionRow[]): string | null {
+  const byId = new Map(stops.map((st) => [st.id, st]));
+  const home = stops.find((st) => st.type === "start");
+  const homeDeparture = stopDepartureTime(home);
+  if (homeDeparture) return homeDeparture;
+
+  const orderedTransitions = home
+    ? [...transitions].sort((a, b) => (a.from_stop_id === home.id ? -1 : b.from_stop_id === home.id ? 1 : 0))
+    : transitions;
+
+  for (const transition of orderedTransitions) {
+    const departure = stopDepartureTime(byId.get(transition.from_stop_id));
+    if (departure) return departure;
+  }
+
+  const firstDepartureStop = stops.find((stop) => stopDepartureTime(stop));
+  return stopDepartureTime(firstDepartureStop);
+}

--- a/src/lib/actions/review.test.ts
+++ b/src/lib/actions/review.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveReviewLeaveBy, type ReviewStopRow as StopRow, type ReviewTransitionRow as TransRow } from "./review-derive";
+
+const at = (clock: string) => `2026-07-16T${clock}:00.000Z`;
+
+function tr(from_stop_id: string, to_stop_id: string): TransRow {
+  return { from_stop_id, to_stop_id, mode: "train", is_locked: true, computed_duration_minutes: 30 };
+}
+
+describe("deriveReviewLeaveBy", () => {
+  it("uses the explicit start stop departure when present", () => {
+    const stops: StopRow[] = [
+      { id: "home", type: "start", title: "Home", start_time: null, end_time: at("05:55") },
+      { id: "station", type: "transit_departure", title: "Wellingborough", start_time: at("06:25"), end_time: null },
+    ];
+
+    expect(deriveReviewLeaveBy(stops, [tr("home", "station")])).toBe(at("05:55"));
+  });
+
+  it("falls back to the first real departure when a legacy journey has no start bookend", () => {
+    const stops: StopRow[] = [
+      { id: "wel", type: "transit_departure", title: "Wellingborough", start_time: at("06:25"), end_time: null },
+      { id: "lut", type: "transit_changeover", title: "Luton", start_time: at("06:55"), end_time: at("07:13") },
+      { id: "har", type: "transit_arrival", title: "Harpenden", start_time: null, end_time: at("07:21") },
+    ];
+
+    expect(deriveReviewLeaveBy(stops, [tr("wel", "lut"), tr("lut", "har")])).toBe(at("06:25"));
+  });
+
+  it("does not show a transit arrival as leave-by when only arrival-like stops are available", () => {
+    const stops: StopRow[] = [
+      { id: "har", type: "transit_arrival", title: "Harpenden", start_time: null, end_time: at("07:21") },
+    ];
+
+    expect(deriveReviewLeaveBy(stops, [])).toBeNull();
+  });
+});

--- a/src/lib/actions/review.ts
+++ b/src/lib/actions/review.ts
@@ -4,6 +4,7 @@ import { createClient } from "@/lib/supabase/server";
 import { requireUserContext } from "@/lib/auth";
 import { checkLegFeasibility } from "@/lib/feasibility/check";
 import { loadReadiness } from "@/lib/actions/readiness";
+import { deriveReviewLeaveBy, type ReviewStopRow, type ReviewTransitionRow } from "@/lib/actions/review-derive";
 
 // The night-before review (Phase 5, B3.6) — preparation's payoff. NOT a new
 // entity: a calm composition of what the day-object, the timing engine, and the
@@ -27,20 +28,8 @@ export type DayReview = {
   verdict: string;
 };
 
-type StopRow = {
-  id: string;
-  type: string;
-  title: string | null;
-  start_time: string | null;
-  end_time: string | null;
-};
-type TransRow = {
-  from_stop_id: string;
-  to_stop_id: string;
-  mode: string;
-  is_locked: boolean | null;
-  computed_duration_minutes: number | null;
-};
+type StopRow = ReviewStopRow;
+type TransRow = ReviewTransitionRow;
 
 function clock(iso: string | null): string | null {
   if (!iso) return null;
@@ -75,15 +64,10 @@ export async function buildDayReview(itineraryId: string): Promise<DayReview | n
   const transitions = (t ?? []) as TransRow[];
   const byId = new Map(stops.map((st) => [st.id, st]));
 
-  // Leave-by: when you leave home — the home stop's computed departure, else the
-  // first leg's departure.
-  const home = stops.find((st) => st.type === "start");
-  let leaveBy = home?.end_time ?? null;
-  if (!leaveBy && transitions.length) {
-    const first = transitions.find((tr) => tr.from_stop_id === home?.id) ?? transitions[0];
-    const from = byId.get(first.from_stop_id);
-    leaveBy = from?.end_time ?? from?.start_time ?? null;
-  }
+  // Leave-by is a departure from the user's base/day origin. Never derive it
+  // from a transit arrival or changeover when legacy imported journeys are
+  // missing the explicit home/start bookend.
+  const leaveBy = deriveReviewLeaveBy(stops, transitions);
 
   // Route shape + fragility (a leg with no slack the day can't absorb).
   let totalMinutes = 0;


### PR DESCRIPTION
### Motivation
- The Tomorrow/Day Review could display a transit arrival as the `leaveBy` time when an itinerary lacked an explicit `start` (home) bookend (e.g. Harpenden 08:21 leaking into the card).
- The review derivation must be defensive for legacy/ imported journeys and prefer a true departure from the user's base rather than arrival/changeover times.

### Description
- Extracted the leave-by logic into a pure helper `deriveReviewLeaveBy` in `src/lib/actions/review-derive.ts` and introduced `ReviewStopRow`/`ReviewTransitionRow` types.  
- Updated `src/lib/actions/review.ts` to call `deriveReviewLeaveBy(stops, transitions)` instead of the previous inline fallback logic.  
- The helper prefers an explicit `start` stop departure, falls back to the first real departure stop for legacy journeys, and excludes `transit_arrival`, `transit_changeover`, and `end` stop types from being used as a departure source.  
- Added regression tests in `src/lib/actions/review.test.ts` covering: explicit `start` departure, fallback to first real departure for an imported rail-only itinerary, and ensuring arrival-only data does not yield a leave-by.

### Testing
- Ran `npm test -- src/lib/actions/review.test.ts` and the new tests passed.  
- Ran `npm run typecheck` and TypeScript checks passed.  
- Ran the full test suite with `npm test` and all tests passed (55 test files, 456 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a580da990c8832887f250e47b082a8e)