### PR TITLE
Fix derived leave-by for base-origin days

### DIFF
--- a/src/app/(app)/plan/[id]/page.tsx
+++ b/src/app/(app)/plan/[id]/page.tsx
@@ -38,6 +38,7 @@ import { setTransitionMode } from "@/lib/actions/transitions";
 import { ensureHomeBookend } from "@/lib/actions/plan-edit";
 import { checkLegFeasibility } from "@/lib/feasibility/check";
 import { comfortBufferMinutes, stopModeOf } from "@/lib/itinerary/buffers";
+import { deriveReviewLeaveBy } from "@/lib/actions/review-derive";
 import { foldStopsToLegTickets } from "@/lib/tickets/from-stops";
 import {
   formatClock,
@@ -703,7 +704,7 @@ export default async function PlanDetailPage({ params }: { params: Promise<{ id:
   const startStop = stops.find((s) => s.type === "start");
   const baseLabel =
     startStop?.location?.name ?? startStop?.customer_site?.name ?? startStop?.transport_hub?.name ?? null;
-  const leaveByIso = startStop?.end_time ?? null;
+  const leaveByIso = deriveReviewLeaveBy(stops, transitions);
   const firstLeg = transitions.find((tr) => tr.from_stop_id === startStop?.id);
   const firstDest = firstLeg ? stopById.get(firstLeg.to_stop_id)?.title ?? null : null;
 

--- a/src/lib/actions/review-derive.ts
+++ b/src/lib/actions/review-derive.ts
@@ -15,6 +15,11 @@ export type ReviewTransitionRow = {
 };
 
 const NON_DEPARTURE_STOP_TYPES = new Set(["end", "transit_arrival", "transit_changeover"]);
+const DEFAULT_REVIEW_BUFFER_MINUTES = 5;
+
+function subtractMinutes(iso: string, minutes: number): string {
+  return new Date(new Date(iso).getTime() - minutes * 60_000).toISOString();
+}
 
 function stopDepartureTime(stop: ReviewStopRow | undefined): string | null {
   if (!stop || NON_DEPARTURE_STOP_TYPES.has(stop.type)) return null;
@@ -27,6 +32,20 @@ export function deriveReviewLeaveBy(stops: ReviewStopRow[], transitions: ReviewT
   const home = stops.find((st) => st.type === "start");
   const homeDeparture = stopDepartureTime(home);
   if (homeDeparture) return homeDeparture;
+
+  // Some live/legacy days have a base/start stop but no stored departure time.
+  // In that case the true leave-by is still derivable from the first leg into
+  // the first commitment: arrive-by minus planned travel minus the short
+  // readiness buffer used elsewhere by the Today leave-by engine.
+  if (home) {
+    const firstLeg = transitions.find((transition) => transition.from_stop_id === home.id);
+    const firstDestination = firstLeg ? byId.get(firstLeg.to_stop_id) : null;
+    const arriveBy = firstDestination?.start_time ?? null;
+    const travelMinutes = firstLeg?.computed_duration_minutes;
+    if (arriveBy && travelMinutes != null) {
+      return subtractMinutes(arriveBy, travelMinutes + DEFAULT_REVIEW_BUFFER_MINUTES);
+    }
+  }
 
   const orderedTransitions = home
     ? [...transitions].sort((a, b) => (a.from_stop_id === home.id ? -1 : b.from_stop_id === home.id ? 1 : 0))

--- a/src/lib/actions/review.test.ts
+++ b/src/lib/actions/review.test.ts
@@ -18,6 +18,15 @@ describe("deriveReviewLeaveBy", () => {
     expect(deriveReviewLeaveBy(stops, [tr("home", "station")])).toBe(at("05:55"));
   });
 
+  it("back-calculates from the first start leg when the base has no stored departure", () => {
+    const stops: StopRow[] = [
+      { id: "office", type: "start", title: "Office", start_time: null, end_time: null },
+      { id: "breww", type: "appointment", title: "Breww Office Day", start_time: at("09:00"), end_time: at("17:00") },
+    ];
+
+    expect(deriveReviewLeaveBy(stops, [tr("office", "breww")])).toBe(at("08:25"));
+  });
+
   it("falls back to the first real departure when a legacy journey has no start bookend", () => {
     const stops: StopRow[] = [
       { id: "wel", type: "transit_departure", title: "Wellingborough", start_time: at("06:25"), end_time: null },


### PR DESCRIPTION
### Motivation
- Some plans use a `start` (home/office) stop without a stored departure time, which left the review/plan UI without a sensible leave-by for base-origin days like an Office → appointment day. 
- The intent is to surface a correct leave-by by back-calculating it from the first leg when an explicit start departure is missing so the Set Off / review hero remains useful.

### Description
- Add a small back-calculation in `deriveReviewLeaveBy` to return `arriveBy − travelMinutes − 5min` when a `start` stop exists but has no departure, using a new `DEFAULT_REVIEW_BUFFER_MINUTES` and `subtractMinutes` helper. 
- Switch the plan detail Set Off hero to call the shared `deriveReviewLeaveBy` helper instead of only reading `start.end_time`. 
- Add a unit test covering the Office → “Breww Office Day” scenario where the base has no stored departure. 
- Import changes and a tiny refactor in `src/app/(app)/plan/[id]/page.tsx` to use the derived helper.

### Testing
- Ran the focused unit tests with `npm test -- --run src/lib/actions/review.test.ts`, and all tests passed (4 tests). 
- Ran type checking with `npm run typecheck -- --pretty false`, and the typecheck completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a588485156883288ad5fe2ba9ac8b67)