### PR TITLE
Add TodayActionSummary CTA and wire into Today page

### DIFF
--- a/src/app/(app)/today/page.tsx
+++ b/src/app/(app)/today/page.tsx
@@ -9,7 +9,6 @@ import { projectToday, type ProjectionStop, type TodayUrgency } from "@/lib/plan
 import { loadJourneyTickets } from "@/lib/actions/wallet";
 import { buildDayReview } from "@/lib/actions/review";
 import { DayReviewCard } from "@/components/plan/day-review";
-import { PlanCreate } from "@/components/plan/plan-create";
 import { TflLineStatus } from "@/components/today/tfl-line-status";
 import { getLocalWeather } from "@/lib/actions/weather";
 import { TodayDisruption, type TodayDisruptionItem } from "@/components/today/today-disruption";
@@ -20,7 +19,8 @@ import { TodayDocument } from "@/components/today/today-document";
 import { OfflineTicketSync } from "@/components/offline/offline-ticket-sync";
 import { LiveDay } from "@/components/today/live-day";
 import { TodaySpine } from "@/components/today/today-spine";
-import { navModeForTransition, stationLabel, roleOf, type SpineAnchor } from "@/components/today/spine-model";
+import { TodayActionSummary, type TodayActionSummaryState } from "@/components/today/today-action-summary";
+import { navigateHref, navModeForTransition, stationLabel, roleOf, type SpineAnchor } from "@/components/today/spine-model";
 import { foldStopsToLegTickets } from "@/lib/tickets/from-stops";
 import { TodayDemo } from "@/components/today/today-demo";
 import { isDemoModeActive } from "@/lib/demo-mode";
@@ -385,6 +385,24 @@ export default async function TodayPage({
     (covering.length === 1 ? covering[0].title?.trim() : null) ||
     "Your day";
 
+  const missingTicketAnchor = spineAnchors.find((a) =>
+    (a.role === "departure" || a.role === "changeover") && !a.pass,
+  );
+  const actionState: TodayActionSummaryState =
+    anchors.length === 0
+      ? tomorrowReview
+        ? { kind: "upcoming-plan", title: tomorrowReview.title }
+        : { kind: "no-plan" }
+      : !baseCoord
+        ? { kind: "missing-base", title: dayPurpose }
+        : disruptions.length > 0
+          ? { kind: "disruption", title: disruptions[0].title, severe: disruptions.some((d) => d.severe) }
+          : missingTicketAnchor
+            ? { kind: "missing-ticket", title: missingTicketAnchor.title }
+            : nextSpine
+              ? { kind: "active-next-leg", title: nextSpine.title, href: navigateHref(nextSpine), detail: nextSpine.place ? `Head to ${nextSpine.place}.` : null }
+              : { kind: "completed-day" };
+
   // The day's note — the single covering plan's intention, rendered as the
   // Satoshi-light standfirst. Omitted entirely when there's no note (never
   // fabricated). Only the single-plan case has one unambiguous note.
@@ -457,16 +475,19 @@ export default async function TodayPage({
             </h1>
           )}
         </div>
-        {weather ? (
-          <div className="cc-weather" data-day={weather.isDay ? "true" : "false"}>
-            <span className="cc-weather-temp">{weather.tempC}&deg;</span>
-            <span className="cc-weather-meta">
-              <span className="cc-weather-headline">{weather.headline}</span>
-              <span className="cc-weather-place">{weather.place}</span>
-            </span>
-          </div>
-        ) : null}
       </header>
+
+      <TodayActionSummary state={actionState} />
+
+      {weather ? (
+        <div className="cc-weather" data-day={weather.isDay ? "true" : "false"}>
+          <span className="cc-weather-temp">{weather.tempC}&deg;</span>
+          <span className="cc-weather-meta">
+            <span className="cc-weather-headline">{weather.headline}</span>
+            <span className="cc-weather-place">{weather.place}</span>
+          </span>
+        </div>
+      ) : null}
 
       {weather && weather.hours.length > 0 ? (
         <div className="cc-weather-hours" aria-label="Today's forecast by the hour">
@@ -480,7 +501,7 @@ export default async function TodayPage({
         </div>
       ) : null}
 
-      <TodayDisruption items={disruptions} />
+      <div id="today-disruptions"><TodayDisruption items={disruptions} /></div>
 
       {inLondon ? <TflLineStatus /> : null}
 
@@ -579,23 +600,21 @@ export default async function TodayPage({
           </div>
         </>
       ) : (
-        <div className="cc-active-tile" data-urgency="comfortable">
-          <span className="cc-at-status">
-            <span className="cc-at-dot" />
-            At rest
-          </span>
-          <h2 className="cc-at-headline">Let&apos;s set up your day</h2>
-          <p className="cc-at-sub">
-            Add what&apos;s coming up — your trains, stays and meetings — or import the bookings
-            from your inbox, and Khonsera threads the day: the next move, the leave-by, the chain ahead.
-          </p>
-          <div style={{ marginTop: "var(--space-4)", display: "flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
-            <PlanCreate label="Plan a day" />
+        <details className="cc-plan-tools">
+          <summary className="cc-plan-tools-summary">
+            <span className="cc-plan-tools-title">How Today works</span>
+            <span className="cc-plan-tools-hint">weather · tickets · route · timeline</span>
+          </summary>
+          <div className="cc-plan-tools-body">
+            <p className="cc-at-sub">
+              Add what&apos;s coming up — your trains, stays and meetings — or import the bookings
+              from your inbox, and Khonsera threads the day: the next move, the leave-by, the chain ahead.
+            </p>
             <Link href={"/plan" as Route} className="cc-btn">
               Open the plan
             </Link>
           </div>
-        </div>
+        </details>
       )}
 
       {tomorrowReview ? <DayReviewCard review={tomorrowReview} eyebrow="Tomorrow" /> : null}

--- a/src/components/today/today-action-summary.tsx
+++ b/src/components/today/today-action-summary.tsx
@@ -1,0 +1,85 @@
+import Link from "next/link";
+import type { Route } from "next";
+import { PlanCreate } from "@/components/plan/plan-create";
+
+export type TodayActionSummaryState =
+  | { kind: "no-plan" }
+  | { kind: "upcoming-plan"; title?: string | null }
+  | { kind: "active-next-leg"; title: string; href: Route | null; detail?: string | null }
+  | { kind: "missing-base"; title?: string | null }
+  | { kind: "missing-ticket"; title?: string | null }
+  | { kind: "disruption"; title?: string | null; severe?: boolean }
+  | { kind: "completed-day" };
+
+export function TodayActionSummary({ state }: { state: TodayActionSummaryState }) {
+  const copy = actionCopy(state);
+
+  return (
+    <section className="cc-active-tile" data-urgency={state.kind === "disruption" && state.severe ? "breach" : "comfortable"}>
+      <span className="cc-at-status">
+        <span className="cc-at-dot" />
+        {copy.kicker}
+      </span>
+      <h2 className="cc-at-headline">{copy.headline}</h2>
+      {copy.detail ? <p className="cc-at-sub">{copy.detail}</p> : null}
+      <div style={{ marginTop: "var(--space-4)", display: "flex", gap: "var(--space-2)", flexWrap: "wrap" }}>{primaryAction(state)}</div>
+    </section>
+  );
+}
+
+function primaryAction(state: TodayActionSummaryState) {
+  switch (state.kind) {
+    case "no-plan":
+      return <PlanCreate label="Plan a day" />;
+    case "missing-base":
+      return (
+        <Link href={("/plan" as Route)} className="cc-btn cc-btn-gold">
+          Set base
+        </Link>
+      );
+    case "active-next-leg":
+      return state.href ? (
+        <Link href={state.href} className="cc-btn cc-btn-gold">
+          Start navigation
+        </Link>
+      ) : (
+        <Link href={("/navigate" as Route)} className="cc-btn cc-btn-gold">
+          Start navigation
+        </Link>
+      );
+    case "missing-ticket":
+      return (
+        <Link href={("/wallet" as Route)} className="cc-btn cc-btn-gold">
+          Open ticket
+        </Link>
+      );
+    case "disruption":
+      return (
+        <Link href={("#today-disruptions" as Route)} className="cc-btn cc-btn-gold">
+          Review disruption
+        </Link>
+      );
+    case "upcoming-plan":
+    case "completed-day":
+      return <PlanCreate label="Plan tomorrow" />;
+  }
+}
+
+function actionCopy(state: TodayActionSummaryState): { kicker: string; headline: string; detail?: string | null } {
+  switch (state.kind) {
+    case "no-plan":
+      return { kicker: "Next step", headline: "Plan a day", detail: "Start with the first place or booking and Khonsera will thread the rest." };
+    case "upcoming-plan":
+      return { kicker: "Next step", headline: "Plan tomorrow", detail: state.title ? `${state.title} is coming up next.` : "You are clear today — get tomorrow ready when you are." };
+    case "active-next-leg":
+      return { kicker: "Next step", headline: "Start navigation", detail: state.detail ?? `Head to ${state.title}.` };
+    case "missing-base":
+      return { kicker: "Needs base", headline: "Set base", detail: state.title ? `Add where you leave from for ${state.title}.` : "Add where you leave from so Today can compute the first move." };
+    case "missing-ticket":
+      return { kicker: "Needs ticket", headline: "Open ticket", detail: state.title ? `Check the pass for ${state.title}.` : "Keep the right pass ready before you move." };
+    case "disruption":
+      return { kicker: state.severe ? "Disruption" : "Heads up", headline: "Review disruption", detail: state.title ?? "A live service change may affect the next leg." };
+    case "completed-day":
+      return { kicker: "All done", headline: "Plan tomorrow", detail: "Your day is complete. Set up the next one when you are ready." };
+  }
+}


### PR DESCRIPTION
### Motivation
- Surface the single next step for the user at the top of Today so the immediate CTA is always visible before weather, maps, documents and the timeline. 
- Represent the projected day state (no plan, upcoming plan, active next leg, missing base, missing ticket, disruption, completed day) as a tiny view model so the UI shows one clear primary action. 
- Reuse existing plan, wallet and navigation flows rather than introducing new routes or flows.

### Description
- Add a new component `src/components/today/today-action-summary.tsx` that maps a small `TodayActionSummaryState` union to a primary CTA (`Plan a day`, `Set base`, `Start navigation`, `Open ticket`, `Review disruption`, or `Plan tomorrow`).
- Wire the summary into `src/app/(app)/today/page.tsx` and compute an `actionState` from the projected anchors, `baseCoord`, disruptions, missing inline passes, and the next spine anchor using `navigateHref` when available.
- Render `TodayActionSummary` directly below the Today header and before weather and the rest of the page content, and wrap disruptions with `id="today-disruptions"` so the CTA can link to it.
- Move the previous empty-day explanatory content into a collapsed `details` block so secondary guidance lives lower on the page while the CTA remains prominent.

### Testing
- Ran `npm run typecheck` and the TypeScript check completed successfully. 
- Ran the unit tests for the spine model with `npm test -- --run src/components/today/spine-model.test.ts` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a591082419c8328928fc738df8ec901)