### PR TITLE
Centralize navigation model and surface Wallet/Navigate in mobile tabs

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -49,6 +49,7 @@ export default async function AppLayout({
           firstName={firstName}
           initials={initials}
           isStaff={ctx.isStaff}
+          mode={ctx.activeMode}
         />
         <main
           className="paper-tex"

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -2,60 +2,14 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import type { Route } from "next";
 import { signOut } from "@/app/login/actions";
 import { PlanCreate } from "@/components/plan/plan-create";
 import type { AppMode } from "@/lib/mode";
+import { isActiveNav, navFor, navigationGlyphs, type NavigationIcon } from "@/lib/navigation";
 
 // Desktop rail — Design Round 2 (`.cc-rail`): lockup top, nav list, then a foot
-// with the create action + profile. One unified day (Edition III D1): no mode
-// toggle; `mode` only picks the People↔Clients nav variant for the user's
-// primary context.
-//
-// Coherence pass (deep review 2026-06-15): the nav is GROUPED, not a flat pile —
-// Day (the trip itself) · Money & travel (the tools) · Account. Every item has a
-// DISTINCT glyph (Mileage + Workspace no longer borrow Navigate's / Clients').
-type NavItem = { href: Route; label: string; icon: keyof typeof Glyphs };
-type NavGroup = { label: string; items: NavItem[] };
-
-function navFor(mode: AppMode): NavGroup[] {
-  return [
-    {
-      label: "Day",
-      items: [
-        { href: "/today" as Route, label: "Today", icon: "today" },
-        { href: "/plan" as Route, label: "Plan", icon: "plan" },
-        { href: "/tasks" as Route, label: "Tasks", icon: "tasks" },
-        mode === "work"
-          ? { href: "/customers" as Route, label: "Clients", icon: "clients" }
-          : { href: "/contacts" as Route, label: "People", icon: "people" },
-        { href: "/wallet" as Route, label: "Wallet", icon: "wallet" },
-      ],
-    },
-    {
-      label: "Money & travel",
-      items: [
-        { href: "/navigate" as Route, label: "Navigate", icon: "navigate" },
-        { href: "/expenses" as Route, label: "Expenses", icon: "receipt" },
-        { href: "/mileage" as Route, label: "Mileage", icon: "mileage" },
-      ],
-    },
-    {
-      label: "Downtime",
-      items: [
-        { href: "/pastimes" as Route, label: "Pastimes", icon: "pastimes" },
-      ],
-    },
-    {
-      label: "Account",
-      items: [
-        ...(mode === "work" ? [{ href: "/workspace" as Route, label: "Workspace", icon: "workspace" } as NavItem] : []),
-        { href: "/settings" as Route, label: "Settings", icon: "settings" },
-      ],
-    },
-  ];
-}
-
+// with the create action + profile. Navigation content, labels, glyphs, active
+// matching, and mode variants are shared with mobile via `@/lib/navigation`.
 export function AppSidebar({
   email,
   firstName,
@@ -74,7 +28,7 @@ export function AppSidebar({
 
   return (
     <aside className="cc-rail">
-      <Link href={"/today" as Route} className="cc-lockup" aria-label="Khonsera">
+      <Link href="/today" className="cc-lockup" aria-label="Khonsera">
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img src="/brand/mk-ink.png" alt="" />
         <span className="wm">KHONSERA</span>
@@ -85,7 +39,7 @@ export function AppSidebar({
           <div key={g.label} className="cc-rail-group">
             <span className="cc-rail-group-label">{g.label}</span>
             {g.items.map((n) => {
-              const active = pathname === n.href || pathname.startsWith(`${n.href}/`);
+              const active = isActiveNav(pathname, n.href);
               return (
                 <Link key={n.href} href={n.href} className="cc-rail-item" data-active={active ? "true" : "false"}>
                   <span className="ic"><Glyph name={n.icon} /></span>
@@ -116,29 +70,10 @@ export function AppSidebar({
   );
 }
 
-const Glyphs = {
-  today: "M12 21a9 9 0 1 0 0-18 9 9 0 0 0 0 18z M12 8v4l3 2",
-  plan: "M4 6a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2z M4 10h16M8 2v4M16 2v4",
-  tasks: "M9 11l2.5 2.5L17 8 M5 5h14a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1z",
-  people: "M12 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8z M4 21c0-4 4-7 8-7s8 3 8 7",
-  clients: "M4 8h16v11a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1z M9 8V6a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2",
-  receipt: "M6 3h12v18l-3-2-3 2-3-2-3 2z M9 8h6M9 12h6M9 16h4",
-  wallet: "M3 7a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v2 M3 7v10a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-5a1 1 0 0 0-1-1h-4a2 2 0 0 0 0 4h4 M16 12h.01",
-  settings: "M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6z M4 12h2M18 12h2M12 4v2M12 18v2M6 6l1.5 1.5M16.5 16.5L18 18M18 6l-1.5 1.5M7.5 16.5L6 18",
-  navigate: "M12 3l8 18-8-5-8 5z",
-  // Mileage — an odometer/gauge (distinct from Navigate's locator arrow).
-  mileage: "M12 14a2 2 0 1 0 0-4 2 2 0 0 0 0 4z M13.4 10.6L17 7 M4.5 16a8 8 0 1 1 15 0z",
-  // Workspace — a building/office tower (distinct from Clients' briefcase).
-  workspace: "M4 21V5a1 1 0 0 1 1-1h9a1 1 0 0 1 1 1v16 M15 21V9h4a1 1 0 0 1 1 1v11 M4 21h17 M7.5 8h1M7.5 12h1M7.5 16h1M11 8h1M11 12h1M11 16h1",
-  // Pastimes — a jigsaw puzzle piece (cards/sudoku/crosswords); distinct glyph.
-  pastimes: "M10.5 4a1.5 1.5 0 1 1 3 0v1.5h2.5a1 1 0 0 1 1 1V10h1.5a1.5 1.5 0 1 1 0 3H17v3a1 1 0 0 1-1 1h-3v-1.5a1.5 1.5 0 1 0-3 0V17H7a1 1 0 0 1-1-1v-3H4.5a1.5 1.5 0 1 1 0-3H6V6.5a1 1 0 0 1 1-1h3.5z",
-  exit: "M9 4H4v16h5 M16 17l5-5-5-5 M21 12H9",
-} as const;
-
-function Glyph({ name }: { name: keyof typeof Glyphs }) {
+function Glyph({ name }: { name: NavigationIcon }) {
   return (
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-      <path d={Glyphs[name]} />
+      <path d={navigationGlyphs[name]} />
     </svg>
   );
 }

--- a/src/components/mobile-tabbar.tsx
+++ b/src/components/mobile-tabbar.tsx
@@ -2,33 +2,18 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import type { Route } from "next";
 import type { AppMode } from "@/lib/mode";
+import { isActiveNav, navigationGlyphs, primaryNavigation, type NavigationIcon } from "@/lib/navigation";
 
-// Primary nav — Design's bottom bar (`.cc-tabbar` / `.cc-tab`): Today · Plan ·
-// Tasks · People. Mode is a toggle (in the header), not a tab; Work → Clients.
-// (Round 2 · Nav.html.)
-type Tab = { href: Route; label: string; icon: keyof typeof GLYPHS };
-
-function tabs(mode: AppMode): Tab[] {
-  return [
-    { href: "/today" as Route, label: "Today", icon: "today" },
-    { href: "/plan" as Route, label: "Plan", icon: "plan" },
-    { href: "/tasks" as Route, label: "Tasks", icon: "tasks" },
-    mode === "work"
-      ? { href: "/customers" as Route, label: "Clients", icon: "clients" }
-      : { href: "/contacts" as Route, label: "People", icon: "people" },
-    // Pastimes — a leisure surface, so it sits last after the travel core.
-    { href: "/pastimes" as Route, label: "Pastimes", icon: "pastimes" },
-  ];
-}
-
+// Primary nav — Design's bottom bar (`.cc-tabbar` / `.cc-tab`). Today, Plan,
+// Tasks, Wallet, and Navigate stay one tap away so the day's ticket and next-leg
+// tools are surfaced when Today has booked travel.
 export function MobileTabbar({ mode }: { mode: AppMode }) {
   const pathname = usePathname();
   return (
     <nav className="cc-tabbar lg:hidden" aria-label="Primary">
-      {tabs(mode).map((t) => {
-        const active = pathname === t.href || pathname.startsWith(`${t.href}/`);
+      {primaryNavigation(mode).map((t) => {
+        const active = isActiveNav(pathname, t.href);
         return (
           <Link
             key={t.href}
@@ -48,22 +33,11 @@ export function MobileTabbar({ mode }: { mode: AppMode }) {
   );
 }
 
-const GLYPHS = {
-  today: "M12 21 a9 9 0 1 0 0-18 a9 9 0 0 0 0 18 z M12 8 v4 l3 2",
-  plan: "M4 6 a2 2 0 0 1 2-2 h12 a2 2 0 0 1 2 2 v14 a2 2 0 0 1-2 2 H6 a2 2 0 0 1-2-2 z M4 10 h16 M8 2 v4 M16 2 v4",
-  tasks: "M9 11 l2.5 2.5 L17 8 M5 5 h14 a1 1 0 0 1 1 1 v12 a1 1 0 0 1-1 1 H5 a1 1 0 0 1-1-1 V6 a1 1 0 0 1 1-1 z",
-  people: "M12 12 a4 4 0 1 0 0-8 a4 4 0 0 0 0 8 z M4 21 c0-4 4-7 8-7 s8 3 8 7",
-  clients: "M4 8 h16 v11 a1 1 0 0 1-1 1 H5 a1 1 0 0 1-1-1 z M9 8 V6 a2 2 0 0 1 2-2 h2 a2 2 0 0 1 2 2 v2",
-  // Pastimes — a jigsaw puzzle piece (stands in for cards/sudoku/crosswords);
-  // distinct from every other tab glyph.
-  pastimes: "M10.5 4 a1.5 1.5 0 1 1 3 0 v1.5 h2.5 a1 1 0 0 1 1 1 V10 h1.5 a1.5 1.5 0 1 1 0 3 H17 v3 a1 1 0 0 1-1 1 h-3 v-1.5 a1.5 1.5 0 1 0-3 0 V17 H7 a1 1 0 0 1-1-1 v-3 H4.5 a1.5 1.5 0 1 1 0-3 H6 V6.5 a1 1 0 0 1 1-1 h3.5 z",
-} as const;
-
-function Glyph({ name }: { name: keyof typeof GLYPHS }) {
+function Glyph({ name }: { name: NavigationIcon }) {
   return (
     <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor"
       strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-      <path d={GLYPHS[name]} />
+      <path d={navigationGlyphs[name]} />
     </svg>
   );
 }

--- a/src/components/shell/mobile-appbar.tsx
+++ b/src/components/shell/mobile-appbar.tsx
@@ -2,32 +2,21 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import type { Route } from "next";
 import { signOut } from "@/app/login/actions";
 import { PlanCreate } from "@/components/plan/plan-create";
+import type { AppMode } from "@/lib/mode";
+import { mobileOverflowNavigation, navigationGlyphs, type NavigationIcon } from "@/lib/navigation";
 
 // Mobile app shell header — Design Round 2 (`.cc-appbar`). The fix for the live
 // pile-up: emblem-only lockup left (no wordmark → no "KHONSER" clip), exactly two
 // quiet icon actions right (Tell + overflow). The mode toggle + secondary
 // destinations live in the overflow sheet, so nothing crowds the logo.
 
-const I = {
-  plus: "M12 5v14M5 12h14",
-  more: "M5 12h.01M12 12h.01M19 12h.01",
-  receipt: "M5 3h14v18l-2.5-1.5L14 21l-2-1.5L10 21l-2-1.5L5 21z M8 8h8M8 12h6",
-  ticket: "M3 7a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v2 M3 7v10a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-5a1 1 0 0 0-1-1h-4a2 2 0 0 0 0 4h4 M16 12h.01",
-  case: "M4 8h16v11a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1z M9 8V6a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2",
-  gear: "M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6z M4 12h2M18 12h2M12 4v2M12 18v2M6 6l1.5 1.5M16.5 16.5L18 18M18 6l-1.5 1.5M7.5 16.5L6 18",
-  tell: "M4 5a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H9l-5 4z",
-  navigate: "M3 11l19-9-9 19-2-8-8-2z",
-  exit: "M16 17l5-5-5-5M21 12H9M12 21H6a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h6",
-} as const;
-
-function Ico({ d }: { d: string }) {
+function Ico({ name }: { name: NavigationIcon }) {
   return (
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7"
       strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-      <path d={d} />
+      <path d={navigationGlyphs[name]} />
     </svg>
   );
 }
@@ -37,18 +26,21 @@ export function MobileAppbar({
   firstName,
   initials,
   isStaff,
+  mode,
 }: {
   email: string;
   firstName: string;
   initials: string;
   isStaff: boolean;
+  mode: AppMode;
 }) {
   const [open, setOpen] = useState(false);
+  const overflowGroups = mobileOverflowNavigation(mode);
   return (
     <>
       <header className="cc-appbar lg:hidden" data-scrolled="false">
         <div className="cc-appbar-left">
-          <Link href={"/today" as Route} className="cc-lockup" data-compact="true" aria-label="Khonsera">
+          <Link href="/today" className="cc-lockup" data-compact="true" aria-label="Khonsera">
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img src="/brand/mk-ink.png" alt="" />
             <span className="wm">Khonsera</span>
@@ -56,10 +48,10 @@ export function MobileAppbar({
         </div>
         <div className="cc-appbar-right">
           <PlanCreate className="cc-iconbtn" title="Plan a day">
-            <span style={{ width: 20, height: 20 }}><Ico d={I.plus} /></span>
+            <span style={{ width: 20, height: 20 }}><Ico name="plus" /></span>
           </PlanCreate>
           <button type="button" className="cc-iconbtn" data-variant="ghost" aria-label="Menu" onClick={() => setOpen(true)}>
-            <span style={{ width: 20, height: 20 }}><Ico d={I.more} /></span>
+            <span style={{ width: 20, height: 20 }}><Ico name="more" /></span>
           </button>
         </div>
       </header>
@@ -85,29 +77,24 @@ export function MobileAppbar({
               </div>
             </div>
 
-            <Link href={"/wallet" as Route} className="cc-overflow-row" onClick={() => setOpen(false)}>
-              <span className="ic"><Ico d={I.ticket} /></span>Wallet
-            </Link>
-            <Link href={"/navigate" as Route} className="cc-overflow-row" onClick={() => setOpen(false)}>
-              <span className="ic"><Ico d={I.navigate} /></span>Navigate
-            </Link>
-            <Link href={"/expenses" as Route} className="cc-overflow-row" onClick={() => setOpen(false)}>
-              <span className="ic"><Ico d={I.receipt} /></span>Expenses
-            </Link>
-            <Link href={"/workspace" as Route} className="cc-overflow-row" onClick={() => setOpen(false)}>
-              <span className="ic"><Ico d={I.case} /></span>Workspace
-            </Link>
-            <Link href={"/settings" as Route} className="cc-overflow-row" onClick={() => setOpen(false)}>
-              <span className="ic"><Ico d={I.gear} /></span>Settings
-            </Link>
+            {overflowGroups.map((group) => (
+              <div key={group.label} className="cc-overflow-group">
+                <span className="cc-rail-group-label">{group.label}</span>
+                {group.items.map((item) => (
+                  <Link key={item.href} href={item.href} className="cc-overflow-row" onClick={() => setOpen(false)}>
+                    <span className="ic"><Ico name={item.icon} /></span>{item.label}
+                  </Link>
+                ))}
+              </div>
+            ))}
             {isStaff ? (
-              <Link href={"/settings" as Route} className="cc-overflow-row" data-staff="true" onClick={() => setOpen(false)}>
-                <span className="ic"><Ico d={I.gear} /></span>Demo &amp; palette (staff)
+              <Link href="/settings" className="cc-overflow-row" data-staff="true" onClick={() => setOpen(false)}>
+                <span className="ic"><Ico name="settings" /></span>Demo &amp; palette (staff)
               </Link>
             ) : null}
             <form action={signOut}>
               <button type="submit" className="cc-overflow-row" data-tone="quiet" style={{ width: "100%", background: "none", border: 0, borderTop: "1px solid var(--rule)", cursor: "pointer" }}>
-                <span className="ic"><Ico d={I.exit} /></span>Sign out
+                <span className="ic"><Ico name="exit" /></span>Sign out
               </button>
             </form>
           </div>

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -1,0 +1,83 @@
+import type { Route } from "next";
+import type { AppMode } from "@/lib/mode";
+
+export const navigationGlyphs = {
+  today: "M12 21a9 9 0 1 0 0-18 9 9 0 0 0 0 18z M12 8v4l3 2",
+  plan: "M4 6a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2z M4 10h16M8 2v4M16 2v4",
+  tasks: "M9 11l2.5 2.5L17 8 M5 5h14a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1z",
+  people: "M12 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8z M4 21c0-4 4-7 8-7s8 3 8 7",
+  clients: "M4 8h16v11a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1z M9 8V6a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2",
+  receipt: "M6 3h12v18l-3-2-3 2-3-2-3 2z M9 8h6M9 12h6M9 16h4",
+  wallet: "M3 7a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v2 M3 7v10a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-5a1 1 0 0 0-1-1h-4a2 2 0 0 0 0 4h4 M16 12h.01",
+  settings: "M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6z M4 12h2M18 12h2M12 4v2M12 18v2M6 6l1.5 1.5M16.5 16.5L18 18M18 6l-1.5 1.5M7.5 16.5L6 18",
+  navigate: "M12 3l8 18-8-5-8 5z",
+  mileage: "M12 14a2 2 0 1 0 0-4 2 2 0 0 0 0 4z M13.4 10.6L17 7 M4.5 16a8 8 0 1 1 15 0z",
+  workspace: "M4 21V5a1 1 0 0 1 1-1h9a1 1 0 0 1 1 1v16 M15 21V9h4a1 1 0 0 1 1 1v11 M4 21h17 M7.5 8h1M7.5 12h1M7.5 16h1M11 8h1M11 12h1M11 16h1",
+  pastimes: "M10.5 4a1.5 1.5 0 1 1 3 0v1.5h2.5a1 1 0 0 1 1 1V10h1.5a1.5 1.5 0 1 1 0 3H17v3a1 1 0 0 1-1 1h-3v-1.5a1.5 1.5 0 1 0-3 0V17H7a1 1 0 0 1-1-1v-3H4.5a1.5 1.5 0 1 1 0-3H6V6.5a1 1 0 0 1 1-1h3.5z",
+  exit: "M9 4H4v16h5 M16 17l5-5-5-5 M21 12H9",
+  plus: "M12 5v14M5 12h14",
+  more: "M5 12h.01M12 12h.01M19 12h.01",
+} as const;
+
+export type NavigationIcon = keyof typeof navigationGlyphs;
+export type NavigationItem = { href: Route; label: string; icon: NavigationIcon };
+export type NavigationGroup = { label: string; items: NavigationItem[] };
+
+const personalPeople = { href: "/contacts" as Route, label: "People", icon: "people" as const };
+const workPeople = { href: "/customers" as Route, label: "Clients", icon: "clients" as const };
+
+export function peopleNavItem(mode: AppMode): NavigationItem {
+  return mode === "work" ? workPeople : personalPeople;
+}
+
+export function primaryNavigation(mode: AppMode): NavigationItem[] {
+  return [
+    { href: "/today" as Route, label: "Today", icon: "today" },
+    { href: "/plan" as Route, label: "Plan", icon: "plan" },
+    { href: "/tasks" as Route, label: "Tasks", icon: "tasks" },
+    { href: "/wallet" as Route, label: "Wallet", icon: "wallet" },
+    { href: "/navigate" as Route, label: "Navigate", icon: "navigate" },
+  ];
+}
+
+export function navFor(mode: AppMode): NavigationGroup[] {
+  return [
+    {
+      label: "Day",
+      items: [
+        { href: "/today" as Route, label: "Today", icon: "today" },
+        { href: "/plan" as Route, label: "Plan", icon: "plan" },
+        { href: "/tasks" as Route, label: "Tasks", icon: "tasks" },
+        peopleNavItem(mode),
+        { href: "/wallet" as Route, label: "Wallet", icon: "wallet" },
+      ],
+    },
+    {
+      label: "Money & travel",
+      items: [
+        { href: "/navigate" as Route, label: "Navigate", icon: "navigate" },
+        { href: "/expenses" as Route, label: "Expenses", icon: "receipt" },
+        { href: "/mileage" as Route, label: "Mileage", icon: "mileage" },
+      ],
+    },
+    { label: "Downtime", items: [{ href: "/pastimes" as Route, label: "Pastimes", icon: "pastimes" }] },
+    {
+      label: "Account",
+      items: [
+        ...(mode === "work" ? [{ href: "/workspace" as Route, label: "Workspace", icon: "workspace" } satisfies NavigationItem] : []),
+        { href: "/settings" as Route, label: "Settings", icon: "settings" },
+      ],
+    },
+  ];
+}
+
+export function mobileOverflowNavigation(mode: AppMode): NavigationGroup[] {
+  const primaryHrefs = new Set(primaryNavigation(mode).map((item) => item.href));
+  return navFor(mode)
+    .map((group) => ({ ...group, items: group.items.filter((item) => !primaryHrefs.has(item.href)) }))
+    .filter((group) => group.items.length > 0);
+}
+
+export function isActiveNav(pathname: string, href: Route): boolean {
+  return pathname === href || pathname.startsWith(`${href}/`);
+}


### PR DESCRIPTION
### Motivation
- Remove duplicated navigation definitions and keep icons, labels, active matching, and mode variants in a single shared source. 
- Keep mobile bottom bar focused on core, one-tap journey actions while ensuring overflow/rail ordering matches desktop groupings. 
- Ensure `/workspace` only appears where appropriate for the active app `mode` and make Wallet/Navigate easier to reach for travel flows.

### Description
- Added `src/lib/navigation.ts` to centralize `navigationGlyphs`, `primaryNavigation`, `navFor`, `mobileOverflowNavigation`, and `isActiveNav`, plus types for items/groups and mode-aware `peopleNavItem`/`workspace` handling.  
- Updated `src/components/mobile-tabbar.tsx` to consume `primaryNavigation` and `isActiveNav` so mobile tabs now include `Wallet` and `Navigate` as primary actions.  
- Updated `src/components/shell/mobile-appbar.tsx` to accept `mode` from layout and render overflow content via `mobileOverflowNavigation`, removing duplicated glyphs and ordering overflow groups to match desktop.  
- Updated `src/components/app-sidebar.tsx` to render grouped navigation from `navFor`, reuse `navigationGlyphs`, and use `isActiveNav` for active state detection.  
- Passed `mode` into `MobileAppbar` from `src/app/(app)/layout.tsx` so mobile overflow honors work vs personal variants (including showing `/workspace` only when `mode === "work"`).

### Testing
- Ran `npm run typecheck` (`tsc --noEmit`) and it completed successfully.  
- Ran `npm run lint` but the command was blocked by Next.js' interactive ESLint configuration prompt in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a590e18d38c83288e33662be63a4342)