### PR TITLE
Add shared sheet primitive for plan dialogs

### DIFF
--- a/src/components/plan/plan-add.tsx
+++ b/src/components/plan/plan-add.tsx
@@ -20,6 +20,7 @@ import {
   type PlacePickerCustomerSite,
   type PlacePickerLocation,
 } from "@/components/place-picker";
+import { Sheet } from "@/components/ui/sheet";
 
 // Manual structured add (planner master brief §4.2) — the precise / fallback
 // capture door. Three fact types: an Appointment or Place (bound to a real,
@@ -262,12 +263,10 @@ export function PlanAdd({
       )}
 
       {open ? (
-        <div className="cc-sheet-scrim" onClick={() => setOpen(false)}>
-          <div className="cc-sheet" onClick={(e) => e.stopPropagation()} role="dialog" aria-modal>
-            <div className="cc-sheet-grip" />
+        <Sheet titleId="plan-add-sheet-title" onClose={() => setOpen(false)}>
             <header className="cc-sheet-head">
               <span className="cc-eyebrow">Add to your day</span>
-              <h3 className="cc-sheet-title">What would you like to add?</h3>
+              <h3 id="plan-add-sheet-title" className="cc-sheet-title" tabIndex={-1}>What would you like to add?</h3>
             </header>
 
             <div className="cc-kind-row">
@@ -578,8 +577,7 @@ export function PlanAdd({
                 {pending ? "Adding…" : "Add it"}
               </button>
             </div>
-          </div>
-        </div>
+        </Sheet>
       ) : null}
     </>
   );

--- a/src/components/plan/plan-base.tsx
+++ b/src/components/plan/plan-base.tsx
@@ -10,6 +10,7 @@ import {
   type PlacePickerCustomerSite,
   type PlacePickerLocation,
 } from "@/components/place-picker";
+import { Sheet } from "@/components/ui/sheet";
 
 // The day's BASE — home/office it departs from and returns to (plan elevation
 // 2026-06-15). Without it the door-to-door spine has no origin, so this is the
@@ -83,14 +84,12 @@ export function PlanBase({
       </button>
 
       {open ? (
-        <div className="cc-sheet-scrim" onClick={() => setOpen(false)}>
-          <div className="cc-sheet" onClick={(e) => e.stopPropagation()} role="dialog" aria-modal>
-            <div className="cc-sheet-grip" />
+        <Sheet titleId="plan-base-sheet-title" descriptionId="plan-base-sheet-description" onClose={() => setOpen(false)}>
             <header className="cc-sheet-head">
               <span className="cc-eyebrow">The day&rsquo;s base</span>
-              <h3 className="cc-sheet-title">Where do you start &amp; end?</h3>
+              <h3 id="plan-base-sheet-title" className="cc-sheet-title" tabIndex={-1}>Where do you start &amp; end?</h3>
             </header>
-            <p className="cc-sheet-note">Home or the office — Khonsera threads the door-to-door from here, and back.</p>
+            <p id="plan-base-sheet-description" className="cc-sheet-note">Home or the office — Khonsera threads the door-to-door from here, and back.</p>
             <div className="cc-time-field">
               <span className="cc-var-label">Base</span>
               <PlacePicker
@@ -107,8 +106,7 @@ export function PlanBase({
               <button type="button" className="cc-btn cc-btn-ghost" onClick={() => setOpen(false)}>Cancel</button>
               <button type="button" className="cc-btn cc-btn-gold" onClick={save}>Set base</button>
             </div>
-          </div>
-        </div>
+        </Sheet>
       ) : null}
     </>
   );

--- a/src/components/plan/plan-calendar-import.tsx
+++ b/src/components/plan/plan-calendar-import.tsx
@@ -7,6 +7,7 @@ import {
   importCalendarEvents,
   type CalendarProposal,
 } from "@/lib/actions/calendar-import";
+import { Sheet } from "@/components/ui/sheet";
 
 // Calendar capture (C1, method 3): pull the structured fields as confirmable
 // proposals — the user ticks which land as appointments. Nothing auto-inserts.
@@ -68,12 +69,10 @@ export function PlanCalendarImport({ itineraryId }: { itineraryId: string }) {
       </button>
 
       {open ? (
-        <div className="cc-sheet-scrim" onClick={() => setOpen(false)}>
-          <div className="cc-sheet" onClick={(e) => e.stopPropagation()} role="dialog" aria-modal>
-            <div className="cc-sheet-grip" />
+        <Sheet titleId="plan-calendar-import-sheet-title" onClose={() => setOpen(false)}>
             <header className="cc-sheet-head">
               <span className="cc-eyebrow">From your calendar</span>
-              <h3 className="cc-sheet-title">Add events to this day</h3>
+              <h3 id="plan-calendar-import-sheet-title" className="cc-sheet-title" tabIndex={-1}>Add events to this day</h3>
             </header>
 
             {loading ? (
@@ -112,8 +111,7 @@ export function PlanCalendarImport({ itineraryId }: { itineraryId: string }) {
                 {pending ? "Adding…" : "Add selected"}
               </button>
             </div>
-          </div>
-        </div>
+        </Sheet>
       ) : null}
     </>
   );

--- a/src/components/plan/plan-create.tsx
+++ b/src/components/plan/plan-create.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import type { Route } from "next";
 import { createEvent } from "@/lib/actions/events";
+import { Sheet } from "@/components/ui/sheet";
 
 // Start a new Event from any "plan a day" entry point (proposal §3a; unified
 // 2026-06-15). Needs a start date (the hinge) + an optional name; opens straight
@@ -65,12 +66,10 @@ export function PlanCreate({
       )}
 
       {open ? (
-        <div className="cc-sheet-scrim" onClick={() => setOpen(false)}>
-          <div className="cc-sheet" onClick={(e) => e.stopPropagation()} role="dialog" aria-modal>
-            <div className="cc-sheet-grip" />
+        <Sheet titleId="plan-create-sheet-title" onClose={() => setOpen(false)}>
             <header className="cc-sheet-head">
               <span className="cc-eyebrow">A new day or trip</span>
-              <h3 className="cc-sheet-title">When does it start?</h3>
+              <h3 id="plan-create-sheet-title" className="cc-sheet-title" tabIndex={-1}>When does it start?</h3>
             </header>
 
             <label className="cc-time-field">
@@ -98,8 +97,7 @@ export function PlanCreate({
                 {pending ? "Starting…" : "Start"}
               </button>
             </div>
-          </div>
-        </div>
+        </Sheet>
       ) : null}
     </>
   );

--- a/src/components/plan/plan-spine.tsx
+++ b/src/components/plan/plan-spine.tsx
@@ -19,6 +19,7 @@ import { AccommodationCard } from "@/components/plan/accommodation-card";
 import { NotesPanel } from "@/components/plan/notes-panel";
 import { TflLegPlan } from "@/components/plan/tfl-leg-plan";
 import { PlanAdd } from "@/components/plan/plan-add";
+import { Sheet } from "@/components/ui/sheet";
 import type {
   PlacePickerCustomer,
   PlacePickerCustomerSite,
@@ -304,12 +305,10 @@ function RenameSheet({ target, onClose }: { target: RenameTarget; onClose: () =>
   }
 
   return (
-    <div className="cc-sheet-scrim" onClick={onClose}>
-      <div className="cc-sheet" onClick={(e) => e.stopPropagation()} role="dialog" aria-modal>
-        <div className="cc-sheet-grip" />
+    <Sheet titleId="rename-sheet-title" onClose={onClose}>
         <header className="cc-sheet-head">
           <span className="cc-eyebrow">This stop</span>
-          <h3 className="cc-sheet-title">Rename</h3>
+          <h3 id="rename-sheet-title" className="cc-sheet-title" tabIndex={-1}>Rename</h3>
         </header>
         <label className="cc-time-field">
           <span className="cc-var-label">Name</span>
@@ -327,8 +326,7 @@ function RenameSheet({ target, onClose }: { target: RenameTarget; onClose: () =>
           <button type="button" className="cc-btn cc-btn-ghost" onClick={onClose} disabled={pending}>Cancel</button>
           <button type="button" className="cc-btn cc-btn-gold" onClick={save} disabled={pending}>{pending ? "Saving…" : "Save"}</button>
         </div>
-      </div>
-    </div>
+    </Sheet>
   );
 }
 
@@ -376,12 +374,10 @@ function CompareSheet({ target, onClose }: { target: CompareTarget; onClose: () 
   }
 
   return (
-    <div className="cc-sheet-scrim" onClick={onClose}>
-      <div className="cc-sheet" onClick={(e) => e.stopPropagation()} role="dialog" aria-modal>
-        <div className="cc-sheet-grip" />
+    <Sheet titleId="compare-sheet-title" onClose={onClose}>
         <header className="cc-sheet-head">
           <span className="cc-eyebrow">How you get there</span>
-          <h3 className="cc-sheet-title">Fastest first</h3>
+          <h3 id="compare-sheet-title" className="cc-sheet-title" tabIndex={-1}>Fastest first</h3>
         </header>
 
         {loading ? (
@@ -414,8 +410,7 @@ function CompareSheet({ target, onClose }: { target: CompareTarget; onClose: () 
             Close
           </button>
         </div>
-      </div>
-    </div>
+    </Sheet>
   );
 }
 
@@ -511,12 +506,10 @@ function VariableEditor({
   }
 
   return (
-    <div className="cc-sheet-scrim" onClick={onClose}>
-      <div className="cc-sheet" onClick={(e) => e.stopPropagation()} role="dialog" aria-modal>
-        <div className="cc-sheet-grip" />
+    <Sheet titleId="variable-editor-sheet-title" descriptionId={!needsValue ? "variable-editor-sheet-description" : undefined} onClose={onClose}>
         <header className="cc-sheet-head">
           <span className="cc-eyebrow">{anchor.title}</span>
-          <h3 className="cc-sheet-title">{SLOT_TITLE[slot]}</h3>
+          <h3 id="variable-editor-sheet-title" className="cc-sheet-title" tabIndex={-1}>{SLOT_TITLE[slot]}</h3>
         </header>
 
         <div className="cc-kind-row">
@@ -554,7 +547,7 @@ function VariableEditor({
             </label>
           )
         ) : (
-          <p className="cc-sheet-note">
+          <p id="variable-editor-sheet-description" className="cc-sheet-note">
             Khonsera will hold this as elastic and bound it by your constraints.
           </p>
         )}
@@ -569,8 +562,7 @@ function VariableEditor({
             {pending ? "Saving…" : "Set"}
           </button>
         </div>
-      </div>
-    </div>
+    </Sheet>
   );
 }
 

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useEffect, useRef, type ReactNode } from "react";
+
+type SheetProps = {
+  titleId: string;
+  descriptionId?: string;
+  onClose: () => void;
+  children: ReactNode;
+  className?: string;
+};
+
+const ACTIONABLE_SELECTOR = [
+  "button:not([disabled])",
+  "[href]",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+export function Sheet({ titleId, descriptionId, onClose, children, className = "cc-sheet" }: SheetProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const openerRef = useRef<HTMLElement | null>(null);
+  const closeRef = useRef(onClose);
+
+  useEffect(() => {
+    closeRef.current = onClose;
+  }, [onClose]);
+
+  useEffect(() => {
+    openerRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
+    const dialog = dialogRef.current;
+    const title = document.getElementById(titleId);
+    const focusTarget = title instanceof HTMLElement ? title : dialog?.querySelector<HTMLElement>(ACTIONABLE_SELECTOR);
+    focusTarget?.focus({ preventScroll: true });
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        closeRef.current();
+      }
+    }
+
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      openerRef.current?.focus({ preventScroll: true });
+    };
+  }, [titleId]);
+
+  return (
+    <div className="cc-sheet-scrim" onClick={onClose}>
+      <div
+        ref={dialogRef}
+        className={className}
+        onClick={(event) => event.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+      >
+        <div className="cc-sheet-grip" />
+        {children}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Reduce duplication by extracting the repeated sheet scrim/dialog markup used across several plan screens into a single reusable primitive. 
- Improve accessibility and consistency by centralising ARIA attributes, focus handling, and close behaviour for all plan sheets. 

### Description
- Add `src/components/ui/sheet.tsx`, a `Sheet` component that renders the scrim and dialog container, sets `role="dialog"`, `aria-modal`, accepts `aria-labelledby`/optional `aria-describedby`, moves focus to the title or first actionable control on open, closes on Escape or scrim click, and restores focus to the opener on unmount. 
- Replace repeated `cc-sheet-scrim` / `cc-sheet` blocks with the `Sheet` primitive in `src/components/plan/plan-create.tsx`, `src/components/plan/plan-base.tsx`, `src/components/plan/plan-calendar-import.tsx`, `src/components/plan/plan-add.tsx`, and `src/components/plan/plan-spine.tsx`. 
- Ensure each sheet now includes a visible title element with an `id` that is passed into `aria-labelledby`, and add `aria-describedby` ids where a descriptive paragraph is present. 

### Testing
- Ran `npm run typecheck` (`tsc --noEmit`) and it completed successfully. 
- Ran the test suite with `npm test` (Vitest) and all tests passed. 
- Attempted `npm run lint`, but `next lint` launched an interactive ESLint setup in this environment and did not run non-interactive checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a591083750c83289f688f3115923ad3)