### PR TITLE
Add EmptyStateActions and update empty states for Plan, Wallet, Expenses, Tasks, Contacts

### DIFF
--- a/src/app/(app)/expenses/page.tsx
+++ b/src/app/(app)/expenses/page.tsx
@@ -2,6 +2,7 @@ import { createClient } from "@/lib/supabase/server";
 import { requireUserContext } from "@/lib/auth";
 import { getWorkspaceConfig } from "@/lib/flags/workspace-flags";
 import { formatDateInTz } from "@/lib/types/time";
+import { EmptyStateActions } from "@/components/ui/empty-state-actions";
 
 // Expenses — Design Round 2 secondary template (.cc-total-bar + .cc-section /
 // .cc-list-row + .cc-empty). Per-month, mode-scoped.
@@ -44,12 +45,14 @@ export default async function ExpensesPage() {
       </header>
 
       {expenses.length === 0 ? (
-        <div className="cc-empty">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src="/brand/mk-ink.png" alt="" />
-          <p className="cc-empty-title">Nothing to settle</p>
-          <p className="cc-empty-sub">Tickets, mileage, parking and receipts captured against a journey land here.</p>
-        </div>
+        <EmptyStateActions
+          title="Nothing to settle"
+          description="Mileage and planned journeys capture costs here."
+          actions={[
+            { label: "Open Mileage", href: "/mileage" },
+            { label: "Open Plan", href: "/plan", variant: "secondary" },
+          ]}
+        />
       ) : (
         <>
           <div className="cc-total-bar">

--- a/src/app/(app)/plan/page.tsx
+++ b/src/app/(app)/plan/page.tsx
@@ -2,6 +2,7 @@ import { createClient } from "@/lib/supabase/server";
 import { requireUserContext } from "@/lib/auth";
 import { JourneyListCard, type JourneyVM } from "@/components/concierge";
 import { PlanCreate } from "@/components/plan/plan-create";
+import { EmptyStateActions } from "@/components/ui/empty-state-actions";
 import { RemindersStrip } from "@/components/plan/reminders-strip";
 import { DeleteEventButton } from "@/components/plan/delete-event-button";
 import { RecurringManager } from "@/components/plan/recurring-manager";
@@ -126,16 +127,18 @@ export default async function PlanIndexPage() {
       <RemindersStrip initial={reminders} />
 
       {empty ? (
-        <div className="cc-plan-empty">
-          <p className="cc-plan-empty-lead">Nothing planned yet.</p>
-          <p className="cc-plan-empty-sub">
-            Add a day by hand — your trains, stays and meetings — or import the bookings
-            from your inbox, and Khonsera threads the rest.
-          </p>
-          <div style={{ marginTop: "var(--space-3)" }}>
-            <PlanCreate label="Plan a day" />
-          </div>
-        </div>
+        <EmptyStateActions
+          className="cc-plan-empty"
+          title="Nothing planned yet"
+          description="Start a day, pull in calendar events, or scan booking emails."
+          image={false}
+          actions={[
+            { label: "Import calendar", href: "/api/auth/google/connect", variant: "secondary" },
+            { label: "Scan booking emails", href: "/api/auth/gmail/connect", variant: "secondary" },
+          ]}
+        >
+          <PlanCreate label="Plan a day" />
+        </EmptyStateActions>
       ) : (
         <>
           {liveGroups.map((g) => (

--- a/src/components/contacts/contacts-screen.tsx
+++ b/src/components/contacts/contacts-screen.tsx
@@ -1,16 +1,18 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { ContactChip } from "@/components/concierge";
 import type { ContactVM } from "@/components/concierge";
 import { createContactQuick } from "@/lib/actions/contact-search";
+import { EmptyStateActions } from "@/components/ui/empty-state-actions";
 
 // People — Design Round 2 secondary template: .cc-add + a .cc-contact-chip grid,
 // the faint-emblem empty state.
 export function ContactsScreen({ initial }: { initial: ContactVM[] }) {
   const router = useRouter();
   const [name, setName] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
   const [pending, startTransition] = useTransition();
 
   function add() {
@@ -32,6 +34,7 @@ export function ContactsScreen({ initial }: { initial: ContactVM[] }) {
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round"><path d="M12 5v14M5 12h14" /></svg>
         </span>
         <input
+          ref={inputRef}
           value={name}
           onChange={(e) => setName(e.target.value)}
           onKeyDown={(e) => e.key === "Enter" && add()}
@@ -42,12 +45,15 @@ export function ContactsScreen({ initial }: { initial: ContactVM[] }) {
       </label>
 
       {initial.length === 0 ? (
-        <div className="cc-empty">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src="/brand/mk-ink.png" alt="" />
-          <p className="cc-empty-title">No one here yet</p>
-          <p className="cc-empty-sub">Add the people you meet and travel to see — Khonsera keeps them close to the days they belong to.</p>
-        </div>
+        <EmptyStateActions
+          title="No people or clients yet"
+          description="Add them once, then attach them to visits and meeting days in Plan."
+          actions={[{ label: "Add client", href: "/customers/new", variant: "secondary" }]}
+        >
+          <button type="button" className="btn-terra" onClick={() => inputRef.current?.focus()}>
+            Add person
+          </button>
+        </EmptyStateActions>
       ) : (
         <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-2)" }}>
           {initial.map((c) => <ContactChip key={c.id} contact={c} />)}

--- a/src/components/tasks/tasks-screen.tsx
+++ b/src/components/tasks/tasks-screen.tsx
@@ -4,6 +4,7 @@ import { useState, useTransition } from "react";
 import { TaskRow } from "@/components/concierge";
 import type { TaskVM } from "@/components/concierge";
 import { createTask, setTaskDone } from "@/lib/actions/tasks";
+import { EmptyStateActions } from "@/components/ui/empty-state-actions";
 
 // Tasks — Design Round 2 secondary template (.cc-section / .cc-empty / .cc-add +
 // the .cc-task-row contract component) in a real CRUD loop.
@@ -50,12 +51,11 @@ export function TasksScreen({ initial }: { initial: TaskVM[] }) {
       </label>
 
       {open.length === 0 && done.length === 0 ? (
-        <div className="cc-empty">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src="/brand/mk-ink.png" alt="" />
-          <p className="cc-empty-title">Nothing on your list</p>
-          <p className="cc-empty-sub">Add a task and it lands on the right day.</p>
-        </div>
+        <EmptyStateActions
+          title="Nothing on your list"
+          description="Add a task and it lands on the right day."
+          image={false}
+        />
       ) : (
         <>
           <section className="cc-section">

--- a/src/components/ui/empty-state-actions.tsx
+++ b/src/components/ui/empty-state-actions.tsx
@@ -1,0 +1,60 @@
+import type { ReactNode } from "react";
+import Link from "next/link";
+import type { Route } from "next";
+import { cn } from "@/lib/utils";
+
+type EmptyStateAction = {
+  label: string;
+  href: Route | URL;
+  variant?: "primary" | "secondary";
+};
+
+export function EmptyStateActions({
+  title,
+  description,
+  actions = [],
+  children,
+  className,
+  image = true,
+}: {
+  title: string;
+  description: string;
+  actions?: EmptyStateAction[];
+  children?: ReactNode;
+  className?: string;
+  image?: boolean;
+}) {
+  return (
+    <div className={cn("cc-empty", className)}>
+      {image ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src="/brand/mk-ink.png" alt="" />
+      ) : null}
+      <p className="cc-empty-title">{title}</p>
+      <p className="cc-empty-sub">{description}</p>
+      {children || actions.length ? (
+        <div
+          className="cc-empty-actions"
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            justifyContent: "center",
+            gap: "var(--space-2)",
+            marginTop: "var(--space-3)",
+          }}
+        >
+          {children}
+          {actions.map((action) => (
+            <Link
+              key={action.label}
+              href={action.href}
+              className={action.variant === "secondary" ? "btn-ghost" : "btn-terra"}
+            >
+              {action.label}
+            </Link>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/wallet/wallet-screen.tsx
+++ b/src/components/wallet/wallet-screen.tsx
@@ -6,6 +6,7 @@ import { Pass, PassPeek, ScanView } from "@/components/concierge";
 import type { TicketVM, BarcodeVM } from "@/components/concierge";
 import { ticketUseMoment } from "@/components/concierge";
 import { deleteBookedRun } from "@/lib/actions/plan-edit";
+import { EmptyStateActions } from "@/components/ui/empty-state-actions";
 
 // The Wallet (planner master brief §7) — document-centric: every booking across
 // trips, grouped by date, ordered within a date by *time-needed* (§7.1). Round 5b
@@ -42,15 +43,12 @@ export function WalletScreen({ tickets }: { tickets: TicketVM[] }) {
   if (visible.length === 0) {
     return (
       <div className="cc-wallet cc-wallet--lux">
-        <div className="cc-wallet-empty">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src="/brand/mk-ink.png" alt="" />
-          <p className="cc-wallet-empty-lead">Your tickets will live here.</p>
-          <p className="cc-wallet-empty-sub">
-            Every booking, grouped by day, the next one you need on top — and ready
-            to scan even without signal.
-          </p>
-        </div>
+        <EmptyStateActions
+          className="cc-wallet-empty"
+          title="Your tickets will live here"
+          description="Connect Gmail and travel bookings become tickets, grouped by the day you need them."
+          actions={[{ label: "Connect Gmail", href: "/api/auth/gmail/connect" }]}
+        />
       </div>
     );
   }


### PR DESCRIPTION
### Motivation
- Provide a single, reusable pattern for compact empty-state copy and CTAs so product copy is consistent across screens. 
- Surface the most relevant actions (Plan a day, calendar import, Gmail scanning, mileage, add contacts) so users can take immediate steps from an empty view. 
- Keep empty-state copy short and action-led with no more than 2–3 CTAs per screen.

### Description
- Add a new reusable component `EmptyStateActions` at `src/components/ui/empty-state-actions.tsx` which renders a short title, description, optional brand image, child CTAs and an array of linked actions. 
- Replace the Plan empty state in `src/app/(app)/plan/page.tsx` with `EmptyStateActions` and expose actions for `Plan a day`, `Import calendar` (`/api/auth/google/connect`) and `Scan booking emails` (`/api/auth/gmail/connect`). 
- Replace the Wallet empty state in `src/components/wallet/wallet-screen.tsx` with `EmptyStateActions` linking to Gmail import and clarifying that travel bookings become tickets. 
- Replace the Expenses empty state in `src/app/(app)/expenses/page.tsx` with `EmptyStateActions` pointing to `Mileage` (`/mileage`) and `Plan` (`/plan`). 
- Update Contacts in `src/components/contacts/contacts-screen.tsx` to use `EmptyStateActions` with a primary in-place `Add person` button that focuses the input and a secondary `Add client` link to `/customers/new`. 
- Swap the Tasks empty state in `src/components/tasks/tasks-screen.tsx` to `EmptyStateActions` with a short descriptive row and no extra image.

### Testing
- Ran type checking with `npx tsc --noEmit`, which succeeded. 
- Ran `git diff --check` to validate whitespace/errors with no issues reported. 
- Ran `npm run lint` which triggered Next.js lint setup prompts in this non-interactive environment and therefore did not complete automatically (warning surfaced).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5910826b3883289946cc0831a4697d)