### PR TITLE
Add contextual cross-links between Today, Plan and Trip tools

### DIFF
--- a/src/app/(app)/expenses/page.tsx
+++ b/src/app/(app)/expenses/page.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+import type { Route } from "next";
 import { createClient } from "@/lib/supabase/server";
 import { requireUserContext } from "@/lib/auth";
 import { getWorkspaceConfig } from "@/lib/flags/workspace-flags";
@@ -49,6 +51,11 @@ export default async function ExpensesPage() {
           <img src="/brand/mk-ink.png" alt="" />
           <p className="cc-empty-title">Nothing to settle</p>
           <p className="cc-empty-sub">Tickets, mileage, parking and receipts captured against a journey land here.</p>
+          <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap", justifyContent: "center" }}>
+            <Link href={"/plan" as Route} className="cc-btn cc-btn-gold">Open plan</Link>
+            <Link href={"/wallet" as Route} className="cc-btn cc-btn-ghost">Wallet tickets</Link>
+            <Link href={"/mileage" as Route} className="cc-btn cc-btn-ghost">Mileage</Link>
+          </div>
         </div>
       ) : (
         <>

--- a/src/app/(app)/mileage/page.tsx
+++ b/src/app/(app)/mileage/page.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+import type { Route } from "next";
 import { listTrips, mileageReport } from "@/lib/actions/mileage";
 import { MileageLedger } from "@/components/mileage/mileage-ledger";
 import { DriveRecorder } from "@/components/mileage/drive-recorder";
@@ -16,6 +18,18 @@ export default async function MileagePage() {
 
       <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-4)" }}>
         <DriveRecorder />
+        {trips.length === 0 ? (
+          <div className="cc-empty">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src="/brand/mk-ink.png" alt="" />
+            <p className="cc-empty-title">No trips yet</p>
+            <p className="cc-empty-sub">Drive legs from a plan or trips you record here become your mileage ledger.</p>
+            <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap", justifyContent: "center" }}>
+              <Link href={"/plan" as Route} className="cc-btn cc-btn-gold">Open plan</Link>
+              <Link href={"/navigate" as Route} className="cc-btn cc-btn-ghost">Navigate</Link>
+            </div>
+          </div>
+        ) : null}
         <MileageLedger trips={trips} report={report} />
       </div>
     </div>

--- a/src/app/(app)/plan/[id]/page.tsx
+++ b/src/app/(app)/plan/[id]/page.tsx
@@ -841,6 +841,13 @@ export default async function PlanDetailPage({ params }: { params: Promise<{ id:
     { id, eyebrow: `${spanLabel(dateStart, dateStart)} · DOOR TO DOOR`.toUpperCase() },
   );
 
+  const firstNavigableStop = stops.find((st) => st.type !== "start" && !!coordOfStop(st));
+  const firstNavigableCoord = coordOfStop(firstNavigableStop);
+  const relatedNavigateHref = firstNavigableStop && firstNavigableCoord
+    ? (`/navigate?${new URLSearchParams({ dlat: String(firstNavigableCoord.lat), dlng: String(firstNavigableCoord.lng), dname: firstNavigableStop.title ?? "Destination" }).toString()}` as Route)
+    : null;
+  const hasDriveLeg = transitions.some((tr) => tr.mode === "drive" || tr.mode === "taxi" || tr.mode === "car");
+
   return (
     <div className="cc-screen" data-plan-state={planState} style={{ minHeight: "100%" }}>
       {/* TopBar — a detail page keeps the ← Plan back button (founder ruling); the
@@ -949,6 +956,13 @@ export default async function PlanDetailPage({ params }: { params: Promise<{ id:
               <PlanMap journey={journeyMap} />
             </section>
           ) : null}
+
+          <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap" }} aria-label="Related tools">
+            {legTickets.length > 0 ? <Link href={"/wallet" as Route} className="cc-btn cc-btn-ghost">Wallet</Link> : null}
+            {journey.mode === "work" ? <Link href={"/expenses" as Route} className="cc-btn cc-btn-ghost">Expenses</Link> : null}
+            {hasDriveLeg ? <Link href={"/mileage" as Route} className="cc-btn cc-btn-ghost">Mileage</Link> : null}
+            {relatedNavigateHref ? <Link href={relatedNavigateHref} className="cc-btn cc-btn-ghost">Navigate</Link> : null}
+          </div>
 
           <PlanSpine
             nodes={nodes}

--- a/src/app/(app)/today/page.tsx
+++ b/src/app/(app)/today/page.tsx
@@ -20,7 +20,7 @@ import { TodayDocument } from "@/components/today/today-document";
 import { OfflineTicketSync } from "@/components/offline/offline-ticket-sync";
 import { LiveDay } from "@/components/today/live-day";
 import { TodaySpine } from "@/components/today/today-spine";
-import { navModeForTransition, stationLabel, roleOf, type SpineAnchor } from "@/components/today/spine-model";
+import { navigateHref, navModeForTransition, stationLabel, roleOf, type SpineAnchor } from "@/components/today/spine-model";
 import { foldStopsToLegTickets } from "@/lib/tickets/from-stops";
 import { TodayDemo } from "@/components/today/today-demo";
 import { isDemoModeActive } from "@/lib/demo-mode";
@@ -332,6 +332,7 @@ export default async function TodayPage({
 
   // The next obligation for the spine highlight + the ticket-surfacing window.
   const nextSpine = proj.nextIndex != null ? spineAnchors[proj.nextIndex] : null;
+  const nextNavigateHref = nextSpine ? navigateHref(nextSpine) : null;
 
   const nowMs = now.getTime();
   const nextTicket =
@@ -507,6 +508,21 @@ export default async function TodayPage({
 
           <LiveDay anchors={spineAnchors} sub={sub} base={baseCoord} />
 
+          {(tickets.length > 0 || nextNavigateHref) ? (
+            <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
+              {tickets.length > 0 ? (
+                <Link href={"/wallet" as Route} className="cc-btn cc-btn-ghost">
+                  Wallet
+                </Link>
+              ) : null}
+              {nextNavigateHref ? (
+                <Link href={nextNavigateHref} className="cc-btn cc-btn-ghost">
+                  Navigate
+                </Link>
+              ) : null}
+            </div>
+          ) : null}
+
           {/* 2 · Route map — the real JourneyMap as a restrained paper map of the
               day's door-to-door route. Omitted when nothing is routable. */}
           {todayJourney ? (
@@ -573,9 +589,11 @@ export default async function TodayPage({
             <Link href={"/plan" as Route} className="cc-btn cc-btn-gold">
               Open the plan
             </Link>
-            <Link href={"/navigate" as Route} className="cc-btn">
-              Navigate
-            </Link>
+            {nextNavigateHref ? (
+              <Link href={nextNavigateHref} className="cc-btn">
+                Navigate
+              </Link>
+            ) : null}
           </div>
         </>
       ) : (

--- a/src/components/concierge/types.ts
+++ b/src/components/concierge/types.ts
@@ -228,6 +228,7 @@ export type TicketVM = {
   price?: number; // minor units
   currency?: string;
   source: DocumentSource;
+  itineraryId?: string; // owning plan/day when the document is associated with one
   legs: TicketLegVM[]; // 1 = single · 2 = booking-pair (outbound + return)
   consequence?: string; // the live band: "this return → leave the museum by 16:10"
   // stay

--- a/src/components/wallet/wallet-screen.tsx
+++ b/src/components/wallet/wallet-screen.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import Link from "next/link";
+import type { Route } from "next";
 import { useRouter } from "next/navigation";
 import { Pass, PassPeek, ScanView } from "@/components/concierge";
 import type { TicketVM, BarcodeVM } from "@/components/concierge";
@@ -97,6 +99,7 @@ function Stack({
         {hero ? (
           <div className="cc-pass-wrap">
             <Pass ticket={hero} onShow={onScan} />
+            <PlanLink ticket={hero} />
             <button type="button" className="cc-pass-del" onClick={() => onRemove(hero)} aria-label="Remove booking" title="Remove">×</button>
           </div>
         ) : null}
@@ -105,6 +108,7 @@ function Stack({
             {openId === t.id ? (
               <>
                 <Pass ticket={t} onShow={onScan} />
+                <PlanLink ticket={t} />
                 <button type="button" className="cc-pass-collapse" onClick={() => setOpenId(null)} aria-label="Collapse" title="Collapse">Collapse</button>
               </>
             ) : (
@@ -115,6 +119,15 @@ function Stack({
         ))}
       </div>
     </section>
+  );
+}
+
+function PlanLink({ ticket }: { ticket: TicketVM }) {
+  if (!ticket.itineraryId) return null;
+  return (
+    <Link href={`/plan/${ticket.itineraryId}` as Route} className="cc-btn cc-btn-ghost" style={{ alignSelf: "center" }}>
+      Open plan
+    </Link>
   );
 }
 

--- a/src/lib/actions/wallet.ts
+++ b/src/lib/actions/wallet.ts
@@ -39,6 +39,7 @@ type SegmentRow = {
 
 type BookingRow = {
   id: string;
+  booking_intent_id: string;
   provider: string | null;
   booking_reference: string | null;
   ticket_status: string | null;
@@ -108,20 +109,21 @@ async function ticketsForItineraries(itinIds: string[]): Promise<TicketVM[]> {
     byItin.set(st.itinerary_id as string, arr);
   }
   const stopTickets: TicketVM[] = [];
-  for (const list of byItin.values()) {
-    for (const f of foldStopsToTickets(list)) stopTickets.push(f.ticket);
+  for (const [itineraryId, list] of byItin.entries()) {
+    for (const f of foldStopsToTickets(list)) stopTickets.push({ ...f.ticket, itineraryId });
   }
 
   // Secondary source: travel_bookings rows (future/affiliate path), deduped by
   // reference so we don't double-list the same booking.
-  const { data: intents } = await supabase.from("booking_intents").select("id").in("itinerary_id", itinIds);
+  const { data: intents } = await supabase.from("booking_intents").select("id, itinerary_id").in("itinerary_id", itinIds);
+  const intentItinerary = new Map((intents ?? []).map((r) => [r.id as string, r.itinerary_id as string]));
   const intentIds = (intents ?? []).map((r) => r.id as string);
   let bookingTickets: TicketVM[] = [];
   if (intentIds.length) {
     const { data: bookings } = await supabase
       .from("travel_bookings")
       .select(
-        `id, provider, booking_reference, ticket_status, actual_price, currency,
+        `id, booking_intent_id, provider, booking_reference, ticket_status, actual_price, currency,
          departure_at, arrival_at, seat_reservation, source,
          segments:travel_booking_segments(
            sequence, from_location_name, to_location_name, from_station_code, to_station_code,
@@ -129,7 +131,7 @@ async function ticketsForItineraries(itinIds: string[]): Promise<TicketVM[]> {
            ticket_type, route_restriction, coach, seat, barcode_ref, barcode_data)`,
       )
       .in("booking_intent_id", intentIds);
-    bookingTickets = ((bookings ?? []) as unknown as BookingRow[]).map(toTicket);
+    bookingTickets = ((bookings ?? []) as unknown as BookingRow[]).map((b) => ({ ...toTicket(b), itineraryId: intentItinerary.get(b.booking_intent_id) }));
   }
 
   const seen = new Set(stopTickets.map((t) => t.reference).filter(Boolean));


### PR DESCRIPTION
### Motivation
- Surface lightweight navigation between the trip tooling surfaces so users can jump from Today and Plan detail into Wallet, Navigate, Expenses and Mileage without adding new UI patterns. 
- Make Wallet tickets navigable back to the plan/day that produced them so users can trace booking origins. 
- Ensure empty states for Expenses and Mileage point users at the source workflows that create those records.

### Description
- Today page: derive a `Navigate` deep-link from the next spine anchor's coordinates and show compact `Wallet` and coordinate-aware `Navigate` buttons only when tickets exist or a next-leg target has coordinates (`src/app/(app)/today/page.tsx`).
- Plan detail: add a small “Related tools” row near the map/spine that conditionally links to `Wallet`, `Expenses`, `Mileage` and a plan-aware `Navigate` deep-link when relevant (`src/app/(app)/plan/[id]/page.tsx`).
- Wallet: threaded an optional `itineraryId` onto `TicketVM` and populated it in the wallet loaders so ticket cards can render a small `Open plan` backlink using existing `cc-btn` classes (`src/components/concierge/types.ts`, `src/lib/actions/wallet.ts`, `src/components/wallet/wallet-screen.tsx`).
- Empty states: added compact contextual links in the Expenses and Mileage empty states that reuse existing routes and visual classes for navigation glue only (`src/app/(app)/expenses/page.tsx`, `src/app/(app)/mileage/page.tsx`).

### Testing
- Ran `npm run typecheck` (`tsc --noEmit`) and it completed successfully. 
- Ran `npm test` (Vitest) and the test suite passed: 55 files, 457 tests all ✓. 
- Ran `npm run lint` but the environment prompted an interactive ESLint setup so linting was not completed non-interactively; `npm test -- --runInBand` failed because Vitest does not accept the Jest `--runInBand` flag.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59108464688328931d118a27087646)