### PR TITLE
Unify app page headers with new AppScreen wrapper

### DIFF
--- a/src/app/(app)/contacts/page.tsx
+++ b/src/app/(app)/contacts/page.tsx
@@ -1,4 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
+import { AppScreen } from "@/components/ui/page-shell";
 import { requireUserContext } from "@/lib/auth";
 import { ContactsScreen } from "@/components/contacts/contacts-screen";
 import type { ContactVM } from "@/components/concierge";
@@ -27,17 +28,8 @@ export default async function ContactsPage() {
   });
 
   return (
-    <div className="cc-screen">
-      <header>
-        <span className="cc-eyebrow">
-          People
-        </span>
-        <h1 className="cc-screen-title" style={{ marginTop: 6 }}>
-          People
-        </h1>
-      </header>
-
+    <AppScreen eyebrow="People" title="People">
       <ContactsScreen initial={contacts} />
-    </div>
+    </AppScreen>
   );
 }

--- a/src/app/(app)/expenses/page.tsx
+++ b/src/app/(app)/expenses/page.tsx
@@ -1,4 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
+import { AppScreen } from "@/components/ui/page-shell";
 import { requireUserContext } from "@/lib/auth";
 import { getWorkspaceConfig } from "@/lib/flags/workspace-flags";
 import { formatDateInTz } from "@/lib/types/time";
@@ -37,11 +38,7 @@ export default async function ExpensesPage() {
   const byMonth = groupByMonth(expenses, wsCfg.timezone);
 
   return (
-    <div className="cc-screen">
-      <header>
-        <span className="cc-eyebrow">Ledger</span>
-        <h1 className="cc-screen-title" style={{ marginTop: 6 }}>Expenses</h1>
-      </header>
+    <AppScreen eyebrow="Ledger" title="Expenses">
 
       {expenses.length === 0 ? (
         <div className="cc-empty">
@@ -78,7 +75,7 @@ export default async function ExpensesPage() {
           ))}
         </>
       )}
-    </div>
+    </AppScreen>
   );
 }
 

--- a/src/app/(app)/mileage/page.tsx
+++ b/src/app/(app)/mileage/page.tsx
@@ -1,4 +1,5 @@
 import { listTrips, mileageReport } from "@/lib/actions/mileage";
+import { AppScreen } from "@/components/ui/page-shell";
 import { MileageLedger } from "@/components/mileage/mileage-ledger";
 import { DriveRecorder } from "@/components/mileage/drive-recorder";
 
@@ -8,16 +9,16 @@ export default async function MileagePage() {
   const [trips, report] = await Promise.all([listTrips(), mileageReport()]);
 
   return (
-    <div className="cc-screen" style={{ minHeight: "100%" }}>
-      <header style={{ marginBottom: "var(--space-4)" }}>
-        <span className="cc-eyebrow">Your private record</span>
-        <h1 className="cc-screen-title" style={{ marginTop: 6 }}>Mileage</h1>
-      </header>
-
+    <AppScreen
+      eyebrow="Your private record"
+      title="Mileage"
+      style={{ minHeight: "100%" }}
+      contentClassName="cc-mileage-content"
+    >
       <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-4)" }}>
         <DriveRecorder />
         <MileageLedger trips={trips} report={report} />
       </div>
-    </div>
+    </AppScreen>
   );
 }

--- a/src/app/(app)/navigate/page.tsx
+++ b/src/app/(app)/navigate/page.tsx
@@ -1,4 +1,5 @@
 import { requireUserContext } from "@/lib/auth";
+import { AppScreen } from "@/components/ui/page-shell";
 import { NavigateScreen } from "@/components/nav/navigate-screen";
 import type { NavPoint } from "@/lib/nav/types";
 
@@ -22,15 +23,8 @@ export default async function NavigatePage({
   }
 
   return (
-    <div className="cc-screen">
-      <header>
-        <span className="cc-eyebrow">Navigate</span>
-        <h1 className="cc-screen-title" style={{ marginTop: 6 }}>
-          Point to point
-        </h1>
-      </header>
-
+    <AppScreen eyebrow="Navigate" title="Point to point">
       <NavigateScreen initialDestination={initialDestination} />
-    </div>
+    </AppScreen>
   );
 }

--- a/src/app/(app)/plan/page.tsx
+++ b/src/app/(app)/plan/page.tsx
@@ -1,4 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
+import { AppScreen } from "@/components/ui/page-shell";
 import { requireUserContext } from "@/lib/auth";
 import { JourneyListCard, type JourneyVM } from "@/components/concierge";
 import { PlanCreate } from "@/components/plan/plan-create";
@@ -104,13 +105,7 @@ export default async function PlanIndexPage() {
   ]);
 
   return (
-    <div className="cc-screen">
-      <header>
-        <span className="cc-eyebrow">Plan</span>
-        <h1 className="cc-screen-title" style={{ marginTop: 6 }}>
-          What are you planning?
-        </h1>
-      </header>
+    <AppScreen eyebrow="Plan" title="What are you planning?">
 
       <PlanCreate />
 
@@ -167,6 +162,6 @@ export default async function PlanIndexPage() {
           ) : null}
         </>
       )}
-    </div>
+    </AppScreen>
   );
 }

--- a/src/app/(app)/tasks/page.tsx
+++ b/src/app/(app)/tasks/page.tsx
@@ -1,4 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
+import { AppScreen } from "@/components/ui/page-shell";
 import { requireUserContext } from "@/lib/auth";
 import { TasksScreen } from "@/components/tasks/tasks-screen";
 import type { TaskVM } from "@/components/concierge";
@@ -24,17 +25,8 @@ export default async function TasksPage() {
   }));
 
   return (
-    <div className="cc-screen">
-      <header>
-        <span className="cc-eyebrow">
-          Tasks
-        </span>
-        <h1 className="cc-screen-title" style={{ marginTop: 6 }}>
-          Things to do
-        </h1>
-      </header>
-
+    <AppScreen eyebrow="Tasks" title="Things to do">
       <TasksScreen initial={tasks} />
-    </div>
+    </AppScreen>
   );
 }

--- a/src/app/(app)/today/page.tsx
+++ b/src/app/(app)/today/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { AppScreen } from "@/components/ui/page-shell";
 import type { Route } from "next";
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
@@ -438,26 +439,15 @@ export default async function TodayPage({
   const lastTodayStop = allStops.length ? allStops[allStops.length - 1] : null;
 
   return (
-    <div className="cc-screen" data-disrupted={disruptions.length ? "true" : undefined}>
-      {/* Keep today's tickets on-device for the barrier (no-signal Aztec). */}
-      <OfflineTicketSync tickets={tickets} />
-      <header className="cc-today-head">
-        <div>
-          <span className="cc-eyebrow">Today</span>
-          {/* When the day header renders below (it carries the page <h1> = the
-              day's purpose), this stays a quiet contextual strip — not a second
-              h1. With no day, it remains the screen's heading. */}
-          {anchors.length ? (
-            <p className="cc-screen-title" style={{ marginTop: 6 }}>
-              Right now
-            </p>
-          ) : (
-            <h1 className="cc-screen-title" style={{ marginTop: 6 }}>
-              Right now
-            </h1>
-          )}
-        </div>
-        {weather ? (
+    <AppScreen
+      eyebrow="Today"
+      title="Right now"
+      titleAs={anchors.length ? "p" : "h1"}
+      headerClassName="cc-today-head"
+      headerStyle={{ alignItems: "flex-start" }}
+      data-disrupted={disruptions.length ? "true" : undefined}
+      actions={
+        weather ? (
           <div className="cc-weather" data-day={weather.isDay ? "true" : "false"}>
             <span className="cc-weather-temp">{weather.tempC}&deg;</span>
             <span className="cc-weather-meta">
@@ -465,8 +455,11 @@ export default async function TodayPage({
               <span className="cc-weather-place">{weather.place}</span>
             </span>
           </div>
-        ) : null}
-      </header>
+        ) : null
+      }
+    >
+      {/* Keep today's tickets on-device for the barrier (no-signal Aztec). */}
+      <OfflineTicketSync tickets={tickets} />
 
       {weather && weather.hours.length > 0 ? (
         <div className="cc-weather-hours" aria-label="Today's forecast by the hour">
@@ -599,6 +592,6 @@ export default async function TodayPage({
       )}
 
       {tomorrowReview ? <DayReviewCard review={tomorrowReview} eyebrow="Tomorrow" /> : null}
-    </div>
+    </AppScreen>
   );
 }

--- a/src/app/(app)/wallet/page.tsx
+++ b/src/app/(app)/wallet/page.tsx
@@ -1,4 +1,5 @@
 import { requireUserContext } from "@/lib/auth";
+import { AppScreen } from "@/components/ui/page-shell";
 import { WalletScreen } from "@/components/wallet/wallet-screen";
 import { OfflineTicketSync } from "@/components/offline/offline-ticket-sync";
 import { loadWalletTickets } from "@/lib/actions/wallet";
@@ -24,17 +25,10 @@ export default async function WalletPage({
   const tickets: TicketVM[] = demo ? DEMO_TICKETS : await loadWalletTickets();
 
   return (
-    <div className="cc-screen">
-      <header>
-        <span className="cc-eyebrow">Wallet</span>
-        <h1 className="cc-screen-title" style={{ marginTop: 6 }}>
-          Your tickets
-        </h1>
-      </header>
-
+    <AppScreen eyebrow="Wallet" title="Your tickets">
       <WalletScreen tickets={tickets} />
       {/* Mirror the wallet to the device so /offline can show the Aztec with no signal. */}
       {demo ? null : <OfflineTicketSync tickets={tickets} />}
-    </div>
+    </AppScreen>
   );
 }

--- a/src/components/ui/page-shell.tsx
+++ b/src/components/ui/page-shell.tsx
@@ -1,4 +1,82 @@
+import type { ComponentPropsWithoutRef, CSSProperties, ElementType, ReactNode } from "react";
+
 import { cn } from "@/lib/utils";
+
+type AppScreenProps<T extends ElementType = "h1"> = ComponentPropsWithoutRef<"div"> & {
+  eyebrow?: ReactNode;
+  title: ReactNode;
+  titleAs?: T;
+  description?: ReactNode;
+  actions?: ReactNode;
+  children?: ReactNode;
+  contentClassName?: string;
+  headerClassName?: string;
+  headerStyle?: CSSProperties;
+};
+
+export function AppScreen<T extends ElementType = "h1">({
+  eyebrow,
+  title,
+  titleAs,
+  description,
+  actions,
+  children,
+  className,
+  contentClassName,
+  headerClassName,
+  headerStyle,
+  ...props
+}: AppScreenProps<T>) {
+  const Title = titleAs ?? "h1";
+
+  return (
+    <div className={cn("cc-screen", className)} {...props}>
+      <header
+        className={headerClassName}
+        style={{
+          display: "flex",
+          alignItems: "flex-end",
+          justifyContent: "space-between",
+          gap: "var(--space-4)",
+          flexWrap: "wrap",
+          ...headerStyle,
+        }}
+      >
+        <div style={{ minWidth: 0 }}>
+          {eyebrow ? <span className="cc-eyebrow">{eyebrow}</span> : null}
+          <Title className="cc-screen-title" style={{ marginTop: eyebrow ? 6 : 0 }}>
+            {title}
+          </Title>
+          {description ? (
+            <p
+              className="serif-i"
+              style={{
+                fontSize: 16,
+                color: "var(--ink-dim)",
+                margin: "8px 0 0",
+                maxWidth: "60ch",
+                lineHeight: 1.55,
+              }}
+            >
+              {description}
+            </p>
+          ) : null}
+        </div>
+        {actions ? (
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+            {actions}
+          </div>
+        ) : null}
+      </header>
+      <div
+        className={contentClassName}
+        style={{ display: "flex", flexDirection: "column", gap: "var(--space-6)" }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
 
 export function PageShell({
   title,
@@ -11,8 +89,8 @@ export function PageShell({
   title: string;
   description?: string;
   eyebrow?: string;
-  actions?: React.ReactNode;
-  children?: React.ReactNode;
+  actions?: ReactNode;
+  children?: ReactNode;
   className?: string;
 }) {
   return (


### PR DESCRIPTION
### Motivation
- Reduce repeated header markup across app screens by introducing a lightweight shared wrapper that implements the `cc-screen` contract and consistent spacing. 
- Provide a single component that supports eyebrow, title, description, actions, and flexible title element to preserve special cases like Today’s live-state heading.
- Remove repeated inline `style={{ marginTop: 6 }}` usages and centralise header spacing so mobile and desktop remain consistent.

### Description
- Add `AppScreen` to `src/components/ui/page-shell.tsx` with props `eyebrow`, `title`, `titleAs`, `description`, `actions`, `headerClassName`, `headerStyle`, and `contentClassName`, rendering a `cc-screen` root, header, and consistent content spacing. 
- Migrate repeated header blocks in `src/app/(app)/plan/page.tsx`, `src/app/(app)/tasks/page.tsx`, `src/app/(app)/wallet/page.tsx`, `src/app/(app)/expenses/page.tsx`, `src/app/(app)/mileage/page.tsx`, `src/app/(app)/contacts/page.tsx`, and `src/app/(app)/navigate/page.tsx` to use `AppScreen`. 
- Update `src/app/(app)/today/page.tsx` to use `AppScreen` while preserving Today-specific behaviors by using `titleAs`, `headerClassName`, `headerStyle`, and `actions` for the weather area and keeping `OfflineTicketSync`/disruption attributes. 
- Adjust `PageShell` typings to reuse `ReactNode` types and keep the original `PageShell` component intact.

### Testing
- Ran `npm run typecheck` (`tsc --noEmit`) and it completed successfully. 
- Ran `git diff --check` to ensure no whitespace/merge issues and it reported clean. 
- Attempted `npm run lint` but `next lint` prompted for an interactive ESLint setup in this environment so linting did not complete non-interactively.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5910860e6883289004c538136110cd)