### PR TITLE
Add onboarding checklist to welcome and plan

### DIFF
--- a/src/app/(app)/plan/page.tsx
+++ b/src/app/(app)/plan/page.tsx
@@ -9,6 +9,8 @@ import { RecurringOffers } from "@/components/plan/recurring-offers";
 import { loadReminders } from "@/lib/actions/reminders";
 import { listRecurringEvents, materializeRecurring, listRecurringOffers } from "@/lib/actions/recurring";
 import type { PlacePickerLocation } from "@/components/place-picker";
+import { OnboardingChecklist } from "@/components/onboarding/onboarding-checklist";
+import { loadOnboardingChecklistState } from "@/lib/onboarding";
 
 // Plan — the INDEX of Events (proposal §3a). The two-level structure that fixes
 // the singleton bug: this lists every Event (a day or a multi-day trip) hinged
@@ -94,10 +96,11 @@ export default async function PlanIndexPage() {
   archive.reverse(); // most-recent past first
 
   const empty = itins.length === 0;
-  const [reminders, recurringRules, recurringOffers, { data: pickCustomers }, { data: pickSites }, { data: pickLocations }] = await Promise.all([
+  const [reminders, recurringRules, recurringOffers, checklist, { data: pickCustomers }, { data: pickSites }, { data: pickLocations }] = await Promise.all([
     loadReminders(),
     listRecurringEvents(),
     listRecurringOffers(),
+    loadOnboardingChecklistState(),
     supabase.from("customers").select("id, name").eq("workspace_id", ctx.workspaceId).order("name"),
     supabase.from("customer_sites").select("id, customer_id, name, address").eq("workspace_id", ctx.workspaceId),
     supabase.from("locations").select("id, name, type, address").eq("workspace_id", ctx.workspaceId).order("type").order("name"),
@@ -127,6 +130,7 @@ export default async function PlanIndexPage() {
 
       {empty ? (
         <div className="cc-plan-empty">
+          <OnboardingChecklist state={checklist} context="plan-empty" />
           <p className="cc-plan-empty-lead">Nothing planned yet.</p>
           <p className="cc-plan-empty-sub">
             Add a day by hand — your trains, stays and meetings — or import the bookings

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -123,7 +123,8 @@ export default async function SettingsPage({
           ) : null}
         </div>
 
-        <CalendarSection
+        <div id="calendar" className="scroll-mt-24">
+          <CalendarSection
           connection={
             calendarConn
               ? {
@@ -133,8 +134,10 @@ export default async function SettingsPage({
               : null
           }
         />
+        </div>
 
-        <GmailSection
+        <div id="gmail" className="scroll-mt-24">
+          <GmailSection
           connection={
             gmailConn
               ? {
@@ -145,6 +148,7 @@ export default async function SettingsPage({
               : null
           }
         />
+        </div>
 
         <div className="j-card p-5 md:col-span-2">
           <h2 className="h3 mb-4">International</h2>
@@ -153,7 +157,7 @@ export default async function SettingsPage({
           </div>
         </div>
 
-        <div className="j-card p-5 md:col-span-2">
+        <div id="travel-profile" className="j-card p-5 md:col-span-2 scroll-mt-24">
           <div className="mb-4 flex items-center justify-between">
             <h2 className="h3">Travel preferences</h2>
             <Link href="/locations" className="small underline">

--- a/src/app/welcome/page.tsx
+++ b/src/app/welcome/page.tsx
@@ -2,11 +2,13 @@ import { redirect } from "next/navigation";
 import { requireUserContext } from "@/lib/auth";
 import { isWelcomed } from "@/lib/welcome";
 import { WelcomeScreen } from "@/components/welcome/welcome-screen";
+import { loadOnboardingChecklistState } from "@/lib/onboarding";
 
 // First-run (§3). Chromeless — deliberately outside the (app) shell so the first
 // minute is just Khonsera, no navigation furniture. If already welcomed, skip.
 export default async function WelcomePage() {
   const ctx = await requireUserContext();
   if (await isWelcomed()) redirect("/today");
-  return <WelcomeScreen mode={ctx.activeMode} />;
+  const checklist = await loadOnboardingChecklistState();
+  return <WelcomeScreen mode={ctx.activeMode} checklist={checklist} />;
 }

--- a/src/components/onboarding/onboarding-checklist.tsx
+++ b/src/components/onboarding/onboarding-checklist.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import { PlanCreate } from "@/components/plan/plan-create";
+import type { OnboardingChecklistState } from "@/lib/onboarding";
+
+type Props = {
+  state: OnboardingChecklistState;
+  context?: "welcome" | "plan-empty";
+};
+
+const DISMISS_KEY = "khonsera_onboarding_checklist_dismissed";
+
+export function OnboardingChecklist({ state, context = "welcome" }: Props) {
+  const [dismissed, setDismissed] = useState(false);
+  const canDismiss = state.hasItinerary;
+
+  useEffect(() => {
+    if (!canDismiss) return;
+    setDismissed(window.localStorage.getItem(DISMISS_KEY) === "1");
+  }, [canDismiss]);
+
+  const items = useMemo(
+    () => [
+      {
+        key: "profile",
+        done: state.travelProfileBaseSet,
+        title: "Set your travel base",
+        detail: "Tell Khonsera where journeys usually start and return.",
+        action: <Link href="/settings#travel-profile" className="cc-btn cc-btn-ghost">Set base</Link>,
+      },
+      {
+        key: "calendar",
+        done: state.calendarConnected,
+        title: "Connect Google Calendar",
+        detail: "Bring in meetings and avoid conflicts when planning.",
+        action: <Link href="/settings#calendar" className="cc-btn cc-btn-ghost">Connect calendar</Link>,
+      },
+      {
+        key: "gmail",
+        done: state.gmailConnected,
+        title: "Connect Gmail",
+        detail: "Scan booking confirmations and tickets when you plan.",
+        action: <Link href="/settings#gmail" className="cc-btn cc-btn-ghost">Connect Gmail</Link>,
+      },
+      {
+        key: "itinerary",
+        done: state.hasItinerary,
+        title: "Create or import your first plan",
+        detail: "Start a day by hand, then add bookings from email or calendar.",
+        action: context === "plan-empty" ? (
+          <PlanCreate label="Create first plan" className="cc-btn cc-btn-gold" />
+        ) : (
+          <Link href="/plan" className="cc-btn cc-btn-gold">Open Plan</Link>
+        ),
+      },
+    ],
+    [context, state.calendarConnected, state.gmailConnected, state.hasItinerary, state.travelProfileBaseSet],
+  );
+
+  const completeCount = items.filter((item) => item.done).length;
+
+  if (dismissed && canDismiss) return null;
+
+  return (
+    <section className="j-card p-5" aria-labelledby="onboarding-checklist-title">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <span className="cc-eyebrow">Getting started</span>
+          <h2 id="onboarding-checklist-title" className="h3 mt-1">Your Khonsera setup</h2>
+          <p className="small mt-1">{completeCount} of {items.length} complete. Finish the essentials now, or come back later.</p>
+        </div>
+        {canDismiss ? (
+          <button
+            type="button"
+            className="cc-btn cc-btn-ghost"
+            onClick={() => {
+              window.localStorage.setItem(DISMISS_KEY, "1");
+              setDismissed(true);
+            }}
+          >
+            Dismiss
+          </button>
+        ) : null}
+      </div>
+      <div className="mt-4 grid gap-3">
+        {items.map((item) => (
+          <div key={item.key} className="flex items-center justify-between gap-3 rounded-xl border border-line bg-white/50 p-3">
+            <div className="flex items-start gap-3">
+              <span aria-hidden className={item.done ? "text-sage" : "text-terra"}>{item.done ? "✓" : "○"}</span>
+              <div>
+                <p className="font-medium text-ink">{item.title}</p>
+                <p className="small">{item.detail}</p>
+              </div>
+            </div>
+            {item.done ? <span className="tiny text-sage">Done</span> : item.action}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/plan/plan-calendar-import.tsx
+++ b/src/components/plan/plan-calendar-import.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import type { Route } from "next";
 import {
   loadCalendarProposals,
   importCalendarEvents,
@@ -57,6 +58,7 @@ export function PlanCalendarImport({ itineraryId }: { itineraryId: string }) {
         return;
       }
       setOpen(false);
+      router.push(`/plan/${itineraryId}` as Route);
       router.refresh();
     });
   }

--- a/src/components/plan/plan-import.tsx
+++ b/src/components/plan/plan-import.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import type { Route } from "next";
 import { GmailImportPanel } from "@/app/(app)/itineraries/[id]/gmail-import-panel";
 
 // Bring a booking in from email, on the new Plan flow (the user's "I can't bring
@@ -35,7 +36,10 @@ export function PlanImport({
       lastStopId={lastStopId}
       lastStopLabel={lastStopLabel}
       onClose={() => setOpen(false)}
-      onImported={() => router.refresh()}
+      onImported={() => {
+        router.push(`/plan/${itineraryId}` as Route);
+        router.refresh();
+      }}
       standaloneRuns
     />
   );

--- a/src/components/welcome/welcome-screen.tsx
+++ b/src/components/welcome/welcome-screen.tsx
@@ -3,6 +3,8 @@
 import { useState, useTransition } from "react";
 import type { Mode } from "@/components/concierge";
 import { chooseAndContinue } from "@/lib/actions/welcome";
+import { OnboardingChecklist } from "@/components/onboarding/onboarding-checklist";
+import type { OnboardingChecklistState } from "@/lib/onboarding";
 
 // First-run (§3) — Design Round 2 (`.cc-welcome`). Chromeless: emblem, a warm
 // Satoshi self-intro (one Spectral-gold word), then the honest fork.
@@ -13,7 +15,7 @@ const Chevron = () => (
   </svg>
 );
 
-export function WelcomeScreen({ mode }: { mode: Mode }) {
+export function WelcomeScreen({ mode, checklist }: { mode: Mode; checklist: OnboardingChecklistState }) {
   const [step, setStep] = useState<"intro" | "booked">("intro");
   const [pending, startTransition] = useTransition();
   const go = (target: string) => startTransition(() => chooseAndContinue(target));
@@ -23,6 +25,8 @@ export function WelcomeScreen({ mode }: { mode: Mode }) {
       <div style={{ width: "100%", maxWidth: 460, display: "flex", flexDirection: "column", gap: "var(--space-5)" }}>
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img className="cc-welcome-emblem" src="/brand/mk-ink.png" alt="" />
+
+        <OnboardingChecklist state={checklist} context="welcome" />
 
         {step === "intro" ? (
           <>
@@ -53,7 +57,7 @@ export function WelcomeScreen({ mode }: { mode: Mode }) {
               Is it <em>booked</em> — in part or full? However much you know, I&apos;ll take it from there.
             </h1>
             <div className="cc-welcome-fork">
-              <button type="button" className="cc-fork-option" data-primary="true" disabled={pending} onClick={() => go("/settings")}>
+              <button type="button" className="cc-fork-option" data-primary="true" disabled={pending} onClick={() => go("/settings#gmail")}>
                 <div>
                   <span className="t">It&apos;s booked — in my inbox</span>
                   <span className="s">Connect your email; I&apos;ll find the confirmations and build the cards.</span>

--- a/src/lib/onboarding.ts
+++ b/src/lib/onboarding.ts
@@ -1,0 +1,55 @@
+import { createClient } from "@/lib/supabase/server";
+import { requireUserContext } from "@/lib/auth";
+export type OnboardingChecklistState = {
+  travelProfileBaseSet: boolean;
+  calendarConnected: boolean;
+  gmailConnected: boolean;
+  hasItinerary: boolean;
+};
+
+export async function loadOnboardingChecklistState(): Promise<OnboardingChecklistState> {
+  const ctx = await requireUserContext();
+  const supabase = await createClient();
+
+  const [{ data: profile }, { data: calendarConn }, { data: gmailConn }, { count: itineraryCount }] = await Promise.all([
+    supabase
+      .from("travel_profiles")
+      .select("default_drive_origin_location_id, default_rail_origin_location_id, default_return_location_id, default_rail_origin_transport_hub_id, default_flight_origin_transport_hub_id")
+      .eq("user_id", ctx.userId)
+      .eq("workspace_id", ctx.workspaceId)
+      .maybeSingle(),
+    supabase
+      .from("calendar_connections")
+      .select("id")
+      .eq("user_id", ctx.userId)
+      .eq("workspace_id", ctx.workspaceId)
+      .eq("provider", "google")
+      .eq("status", "active")
+      .maybeSingle(),
+    supabase
+      .from("gmail_connections")
+      .select("id")
+      .eq("user_id", ctx.userId)
+      .eq("workspace_id", ctx.workspaceId)
+      .eq("status", "active")
+      .maybeSingle(),
+    supabase
+      .from("itineraries")
+      .select("id", { count: "exact", head: true })
+      .eq("user_id", ctx.userId)
+      .eq("workspace_id", ctx.workspaceId),
+  ]);
+
+  return {
+    travelProfileBaseSet: Boolean(
+      profile?.default_drive_origin_location_id ||
+        profile?.default_rail_origin_location_id ||
+        profile?.default_return_location_id ||
+        profile?.default_rail_origin_transport_hub_id ||
+        profile?.default_flight_origin_transport_hub_id,
+    ),
+    calendarConnected: Boolean(calendarConn),
+    gmailConnected: Boolean(gmailConn),
+    hasItinerary: Boolean((itineraryCount ?? 0) > 0),
+  };
+}


### PR DESCRIPTION
### Motivation
- Provide a simple onboarding checklist derived from existing profile/connections/itinerary data so new users can complete essential setup quickly.
- Surface the checklist on the first-run Welcome screen and the Plan empty state to drive calendar/Gmail connections and plan creation/import flows.
- Deep-link checklist actions to Settings anchors and ensure the UI guides users into `/today` or the created `/plan/[id]` after the first successful import/create, while allowing the checklist to be dismissed once an itinerary exists.

### Description
- Add a server-side loader `loadOnboardingChecklistState` that queries travel profile defaults, active Google Calendar and Gmail connections, and itinerary count (`src/lib/onboarding.ts`).
- Add a client onboarding component `OnboardingChecklist` that renders checklist items with deep links to `#/calendar`, `#/gmail`, and `#/travel-profile`, shows plan creation/import actions, and stores a dismiss flag in `localStorage` (only dismissible when `hasItinerary` is true) (`src/components/onboarding/onboarding-checklist.tsx`).
- Wire the checklist into the Welcome flow and Plan empty state by loading the checklist state server-side and passing it to the WelcomeScreen and Plan index (`src/app/welcome/page.tsx`, `src/components/welcome/welcome-screen.tsx`, `src/app/(app)/plan/page.tsx`).
- Add Settings anchors for the Calendar, Gmail, and Travel Profile sections and deep-link the Welcome “booked” path to the Gmail anchor (`src/app/(app)/settings/page.tsx`, `src/components/welcome/welcome-screen.tsx`).
- Ensure successful imports/plan creation route users to the created plan detail and refresh the UI by updating import handlers to push `/plan/[id]` on completion (`src/components/plan/plan-import.tsx`, `src/components/plan/plan-calendar-import.tsx`).

### Testing
- Ran `npm run typecheck` (TypeScript typecheck) which completed successfully.
- Ran `git diff --check` (whitespace/checks) which reported no issues.
- Attempted `npm run lint` but the environment prompted for an interactive ESLint setup, so the lint step was not completed in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a591086fbd083288fe60ace31ce6511)