### PR TITLE
Consolidate takeover baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: Validate
+
+on:
+  pull_request:
+  push:
+    branches:
+      - claude/khonsera-build-brief-An4oz
+
+concurrency:
+  group: validate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  app:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      NEXT_PUBLIC_SUPABASE_URL: https://example.supabase.co
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ci-placeholder
+      NEXT_PUBLIC_APP_URL: http://localhost:3000
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Unit tests
+        run: npm test
+
+      - name: Production build
+        run: npm run build

--- a/README.md
+++ b/README.md
@@ -1,137 +1,155 @@
 # Khonsera
 
-Quietly luxe travel planning. Plan, confirm and execute trips with rail vs
-drive comparison, manual booking for every transport mode, Google Places
-search built in, calendar blocks, expenses and on-the-day navigation.
+Khonsera is a travel-day operating system. It brings the plan, appointments, tasks, bookings, tickets, leave-by times, routes, live disruption information and expenses into one continuous day.
 
-Named after **Khonsu** — the Egyptian moon god, lord of time and guardian of
-travellers — and **sera**, Italian for evening. The brand voice is warm,
-editorial, restrained.
+The product promise is simple:
+
+> Know what is next, when to leave, how to get there and what you need when you arrive.
+
+## Product shape
+
+The live product is organised around five core surfaces:
+
+- **Today** — the current travel day, projected from every plan covering today.
+- **Plan** — create, import and resolve a day or multi-day trip.
+- **Wallet** — tickets and travel documents, ordered by when they are needed and available offline.
+- **Navigate** — door-to-door navigation for the next movement.
+- **Tasks** — actions attached to the day rather than a separate general-purpose task manager.
+
+People/clients, expenses, mileage and settings support that travel-day loop. They are not separate product centres.
+
+See [`docs/product-roadmap.md`](docs/product-roadmap.md) for the current scope and sequencing.
+
+## What is implemented
+
+Khonsera is beyond its original scaffold phase. The repository currently includes:
+
+- authentication, workspaces and row-level security;
+- personal and work modes;
+- day and multi-day plans with ordered stops and transitions;
+- a time-resolution engine and leave-by derivation;
+- recurring plans and reminders;
+- Google Calendar import and Gmail booking ingestion;
+- Trainline email/PDF parsing and ticket materialisation;
+- rail and flight booking structures, accommodation and manual transport;
+- map rendering, stored polylines and navigation deep links;
+- live rail departure/disruption hooks, TfL status and weather;
+- offline ticket storage and barcode presentation;
+- expenses, mileage, contacts, customers and saved locations;
+- staff-only demo fixtures for end-to-end review.
+
+Not every external integration is production-complete. Missing providers must remain explicit and honest rather than silently falling back to fake data for real users.
 
 ## Stack
 
-- Next.js 15 (App Router) + React + TypeScript
-- Tailwind CSS
-- Supabase (Postgres + Auth + Storage), RLS from day one
-- Vercel for hosting
+- Next.js 15 App Router, React 19 and TypeScript
+- Tailwind CSS plus the current `cc-*` component vocabulary
+- Supabase Postgres, Auth and Storage with RLS
+- Vercel deployment
+- Vitest unit and Supabase integration tests
+- MapLibre/PMTiles and provider-backed route data
 
-## Architecture spine
+## Domain spine
 
-```
+The active model is centred on an itinerary/event and its ordered day:
+
+```text
 User
- └── Workspace (personal | organisation)
-      ├── Customers / CustomerSites / Contacts
-      ├── Locations + TravelProfile
-      ├── VisitPlan                 ← the top-level object
-      │    ├── PlanningRun
-      │    │    └── TravelOption
-      │    │         └── JourneyLeg (+ alternatives)
-      │    ├── CalendarEventLinks
-      │    ├── BookingIntent → TravelBooking
-      │    ├── ExpenseRecords (+ MileageExpense)
-      │    ├── VisitChecklistItems
-      │    └── SavedTrip → TripProgress
-      └── NotificationRules
+└── Workspace
+    ├── Travel profile, saved locations, people and clients
+    ├── Itinerary (a day or multi-day event)
+    │   ├── Intention / purpose
+    │   ├── Stops
+    │   ├── Transitions
+    │   ├── Booked transport and stays
+    │   ├── Tickets and documents
+    │   ├── Tasks, reminders and recurring rules
+    │   └── Expenses and mileage
+    └── Connected calendar, Gmail and provider integrations
 ```
 
-`VisitPlan → PlanningRun → TravelOption → JourneyLeg → SavedTrip` is the spine.
+`Itinerary → Stop → Transition` is the operational spine. Today is a projection of that plan, not a separate editable copy.
 
-## Integration strategy
+## Integration principles
 
-Every external dependency (calendar, routing, rail timetable, rail booking,
-notifications) is behind an interface in `src/lib/integrations/`. Each module
-returns `IntegrationResult<T>` in one of three modes:
+External providers are isolated behind actions and integration modules. Follow these rules:
 
-- `live` — real provider call (none yet)
-- `demo` — realistic mock data; only returned when **staff** has demo mode on
-- `unavailable` — honest "not connected" state for real users
+1. Real users receive live provider data or a clear unavailable state.
+2. Demo data is staff-only and server enforced.
+3. Imported source material retains provenance where possible.
+4. Provider failures must not corrupt the underlying plan.
+5. A travel day must remain usable offline where the required document was already materialised.
 
-This means real users always go through real flows with honest gaps, while
-staff can flip demo mode to walk the end-to-end product. The toggle is
-server-enforced via `profiles.is_staff`.
-
-Feature flags live in `src/lib/features.ts`. Flip to `true` as each integration
-lands.
+Environment variables are documented in [`.env.example`](.env.example).
 
 ## Local setup
 
 ```bash
-# Install deps
 npm install
-
-# Copy env template and fill in Supabase keys
 cp .env.example .env.local
-
-# (Optional) start Supabase locally
-npx supabase start
-npx supabase db reset      # applies migrations + seed
-
-# Run dev server
 npm run dev
 ```
 
-Make any account `is_staff` from SQL:
-
-```sql
-update profiles set is_staff = true where email = 'you@example.com';
-```
-
-## Tests
-
-Two tiers:
+For a local Supabase stack:
 
 ```bash
-# Unit tests — pure functions only, no DB. Fast.
-npm test
+npx supabase start
+npx supabase db reset
+npm run db:types
+```
 
-# Integration tests — require a running Supabase. Skipped automatically
-# when SUPABASE_TEST_URL isn't set.
-SUPABASE_TEST_URL=http://localhost:54321 \
-SUPABASE_TEST_ANON_KEY=$(npx supabase status -o env | grep ANON_KEY | cut -d= -f2-) \
-SUPABASE_TEST_SERVICE_ROLE_KEY=$(npx supabase status -o env | grep SERVICE_ROLE_KEY | cut -d= -f2-) \
+## Validation
+
+```bash
+npm run typecheck
+npm test
+npm run build
+```
+
+Integration tests require a running Supabase instance and the `SUPABASE_TEST_*` environment variables:
+
+```bash
 npm run test:integration
 ```
 
-Integration tests cover RLS isolation (cross-workspace deny), state-machine
-correctness (illegal transitions rejected, direct status writes blocked,
-audit rows written), and live the `tests/integration/` directory. Helpers
-under `src/lib/testing/` provision real test users via the auth-trigger.
+Pull requests run the non-database checks in GitHub Actions. Vercel remains the deployment/build status source.
 
-## Build phases
+## Working agreements
 
-- **Phase 0** (this PR): bones — Next.js + Supabase + auth + RLS schema + nav + skeleton screens
-- **Phase 1**: schema (folded into Phase 0 — every entity exists with RLS)
-- **Phase 2**: app shell (done — all 10 screens routed with skeletons)
-- **Phase 3**: customers + locations + settings CRUD
-- **Phase 4**: visit planning end-to-end with stubbed routing/rail data
-- **Phase 5+**: swap stubs for real integrations one at a time
+- Branch from the repository default branch and use a focused pull request.
+- Protect the travel-day promise from feature sprawl.
+- Prefer shared `cc-*` primitives over one-off page markup.
+- Keep Today decisive: one prominent next action, then supporting context.
+- Preserve RLS and workspace scoping for every new table or query.
+- Add pure tests for planning, time and projection logic.
+- Do not commit secrets or service-role credentials.
+- Treat older design documents as historical unless they are marked current in the roadmap or design index.
 
-## Project layout
+## Repository layout
 
-```
+```text
 src/
   app/
-    (auth pages: login, signup, callback)
-    (app)/                  authed routes (sidebar nav)
-      dashboard/
-      visits/ new/ [id]/ [id]/travel-day/ [id]/booking/
-      itinerary/
-      customers/
-      locations/
-      expenses/
-      settings/
+    (app)/
+      today/             current-day projection
+      plan/              itinerary index and detail
+      wallet/            tickets and documents
+      navigate/          next-movement navigation
+      tasks/             day-linked actions
+      contacts/          personal people
+      customers/         work clients and sites
+      expenses/ mileage/ supporting records
+      settings/          profile and integrations
   components/
-    ui/                     shared primitives (Button, PageShell, ComingSoon)
+    plan/ today/ wallet/ shared product components
+    ui/                  shared primitives
   lib/
-    supabase/               server, browser, middleware
-    integrations/           calendar, routing, rail, booking, notifications
-    planning/               pure feasibility engine
-    auth.ts                 requireUser, requireUserContext
-    demo-mode.ts            staff-only demo toggle
-    features.ts             feature flag constants
-    types/                  domain types
+    actions/             server actions and data orchestration
+    planning/            pure planning/projection logic
+    integrations/        provider adapters
+    supabase/            browser/server clients
+    types/               domain and generated database types
 supabase/
-  migrations/0001_init.sql  full schema + RLS + auto-provisioning trigger
+  migrations/            schema, functions and RLS
   seed.sql
-  config.toml
 ```

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -1,0 +1,94 @@
+# Khonsera product roadmap
+
+Status: current takeover baseline, July 2026.
+
+## North-star outcome
+
+A user should be able to open Khonsera on a travel day and understand, without assembling information from other apps:
+
+- what they are doing next;
+- when they need to leave;
+- how they are getting there;
+- whether the journey has changed;
+- which ticket, document or task they need;
+- what comes after the current movement.
+
+The product is successful when the user can operate the whole day from Today, while Plan remains the place where the day is prepared and corrected.
+
+## Core loop
+
+1. **Capture the day** from calendar, email or manual entry.
+2. **Resolve the chain** of places, commitments, bookings and travel between them.
+3. **Prepare the user** with leave-by times, gaps, missing documents and night-before review.
+4. **Run the day** from one decisive Today surface.
+5. **Close the loop** with expenses, mileage, completed tasks and reusable recurring patterns.
+
+## Now: reliability and convergence
+
+The immediate objective is not to add another large feature family. It is to make the existing end-to-end journey coherent and dependable.
+
+### Product
+
+- Give Today one authoritative next action for every meaningful state.
+- Remove duplicated and competing calls to action across Today.
+- Make empty states action-led and consistent.
+- Clarify onboarding around three starts: manual plan, calendar import and booking-email import.
+- Audit navigation so supporting tools do not compete with the core travel-day loop.
+
+### Engineering
+
+- Keep typecheck, unit tests and production build as pull-request gates.
+- Add tests around Today state selection, leave-by derivation and imported-plan edge cases.
+- Continue consolidating repeated sheet, page-shell and empty-state markup.
+- Document live, partial and unavailable provider integrations accurately.
+- Resolve or retire stale pull requests after their useful work has been reconstructed.
+
+### Design
+
+- Establish one current visual direction and mark older design eras as historical.
+- Review the current cotton/letterpress documents against the newer bright, ultra-modern, restrained mid-century travel direction before changing global tokens.
+- Do not perform a broad visual rewrite without representative mobile Today, Plan, Wallet and Navigate screens approved together.
+
+## Next: complete the travel day
+
+- Improve first-leg and between-stop leave-by confidence.
+- Show the consequence of delays against later commitments, not just the raw delay.
+- Make tickets appear at the exact point of use and remain available without signal.
+- Strengthen multi-plan composition when work and personal events overlap.
+- Complete calendar round-tripping rules and duplicate handling.
+- Improve booking-email matching, provenance and correction flows.
+- Add dependable partner/traveller status sharing for meaningful changes.
+
+## Later: supporting depth
+
+These capabilities are valuable only after the core day is reliable:
+
+- expense export and reporting;
+- richer mileage workflows;
+- organisation administration and shared workspaces;
+- rail, flight, stay and parking booking partnerships;
+- packing lists and reusable trip templates;
+- group travel and shared itineraries;
+- destination and downtime recommendations.
+
+## Deferred or experimental
+
+The following should not drive the main navigation or roadmap until validated:
+
+- a general-purpose CRM;
+- a general-purpose task manager;
+- broad lifestyle or pastime discovery;
+- building a full booking marketplace before the day-of experience is trustworthy;
+- features that do not improve planning, readiness, movement or recovery on a travel day.
+
+## Decision test
+
+Before adding or expanding a feature, answer:
+
+1. Does this help the user plan the day, become ready, move, recover from a change or close out the trip?
+2. Is Khonsera the natural place for it, or are we recreating another specialist app?
+3. Can the benefit be surfaced through Today or Plan without another top-level destination?
+4. What happens when the provider is unavailable or the user has no signal?
+5. Which existing surface or concept can be simplified as a result?
+
+A feature that cannot answer those questions should remain deferred.

--- a/docs/takeover-notes.md
+++ b/docs/takeover-notes.md
@@ -1,0 +1,29 @@
+# Takeover notes
+
+## Baseline
+
+Khonsera is a functioning product codebase, not a Phase 0 scaffold. The previous README and build-phase description were materially behind the implementation.
+
+## Decisions from the first pass
+
+- The product centre is the end-to-end travel day.
+- `LiveDay` is the authoritative day-of next-move surface: it already calculates leave-by timing, live route state and the primary Navigate action.
+- Today should support `LiveDay` with disruption, ticket and timeline context rather than adding a second competing next-action card.
+- Plan remains the preparation and correction surface.
+- Wallet, Navigate and day-linked Tasks are part of the core loop.
+- People/clients, expenses, mileage and workspace administration are supporting capabilities.
+- Shared `cc-*` primitives should replace page-specific empty-state and action markup.
+- The cotton/letterpress design documents remain historical input, not an automatic instruction for new global styling. A representative-screen review is required before changing global tokens.
+
+## Stale pull requests reconstructed
+
+- PR #21 identified the right problem on Today but proposed an additional action card on an older page structure. Its useful principle is retained; its implementation is not copied.
+- PR #24 introduced a useful actionable empty-state pattern. That pattern has been rebuilt on the current head while preserving newer onboarding and Wallet behaviour.
+
+## Next engineering sequence
+
+1. Remove the duplicate Wallet, Navigate and Open Plan button rows surrounding `LiveDay` on Today.
+2. Make disruption and missing-document states clearly modify or precede the existing `LiveDay` action rather than competing with it.
+3. Review Today, Plan, Wallet and Navigate together on a representative mobile viewport.
+4. Add focused tests around leave-by, disruption priority and imported-plan edge cases.
+5. Resolve or close PRs #21 and #24 after the replacement work is validated.

--- a/src/app/(app)/expenses/page.tsx
+++ b/src/app/(app)/expenses/page.tsx
@@ -1,7 +1,6 @@
-import Link from "next/link";
-import type { Route } from "next";
 import { createClient } from "@/lib/supabase/server";
 import { AppScreen } from "@/components/ui/page-shell";
+import { EmptyStateActions } from "@/components/ui/empty-state-actions";
 import { requireUserContext } from "@/lib/auth";
 import { getWorkspaceConfig } from "@/lib/flags/workspace-flags";
 import { formatDateInTz } from "@/lib/types/time";
@@ -41,19 +40,15 @@ export default async function ExpensesPage() {
 
   return (
     <AppScreen eyebrow="Ledger" title="Expenses">
-
       {expenses.length === 0 ? (
-        <div className="cc-empty">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src="/brand/mk-ink.png" alt="" />
-          <p className="cc-empty-title">Nothing to settle</p>
-          <p className="cc-empty-sub">Tickets, mileage, parking and receipts captured against a journey land here.</p>
-          <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap", justifyContent: "center" }}>
-            <Link href={"/plan" as Route} className="cc-btn cc-btn-gold">Open plan</Link>
-            <Link href={"/wallet" as Route} className="cc-btn cc-btn-ghost">Wallet tickets</Link>
-            <Link href={"/mileage" as Route} className="cc-btn cc-btn-ghost">Mileage</Link>
-          </div>
-        </div>
+        <EmptyStateActions
+          title="Nothing to settle"
+          description="Mileage, tickets, parking and receipts captured against a journey will collect here."
+          actions={[
+            { label: "Log mileage", href: "/mileage" },
+            { label: "Open plan", href: "/plan", variant: "secondary" },
+          ]}
+        />
       ) : (
         <>
           <div className="cc-total-bar">

--- a/src/app/(app)/plan/page.tsx
+++ b/src/app/(app)/plan/page.tsx
@@ -3,6 +3,7 @@ import { AppScreen } from "@/components/ui/page-shell";
 import { requireUserContext } from "@/lib/auth";
 import { JourneyListCard, type JourneyVM } from "@/components/concierge";
 import { PlanCreate } from "@/components/plan/plan-create";
+import { EmptyStateActions } from "@/components/ui/empty-state-actions";
 import { RemindersStrip } from "@/components/plan/reminders-strip";
 import { DeleteEventButton } from "@/components/plan/delete-event-button";
 import { RecurringManager } from "@/components/plan/recurring-manager";
@@ -37,8 +38,6 @@ export default async function PlanIndexPage() {
   const ctx = await requireUserContext();
   const supabase = await createClient();
 
-  // Lazy-generate any due recurring days before listing (idempotent; steady state
-  // is just a read). Then the new days show in the list below.
   await materializeRecurring();
 
   const { data: rows } = await supabase
@@ -49,8 +48,6 @@ export default async function PlanIndexPage() {
   const itins = (rows ?? []) as ItinRow[];
   const ids = itins.map((i) => i.id);
 
-  // Two roll-up queries (not N+1): stop counts, and which stops have an
-  // onward transition (so we can show "n to resolve").
   const counts = new Map<string, number>();
   const withLeg = new Map<string, Set<string>>();
   if (ids.length) {
@@ -74,10 +71,9 @@ export default async function PlanIndexPage() {
     dateEnd: i.date_end,
     status: i.status,
     anchorCount: counts.get(i.id) ?? 0,
-    openGapCount: 0, // refined in a later chunk; kept calm for now
+    openGapCount: 0,
   });
 
-  // Grouping by span vs today (mirrors the Wallet's day grouping).
   const today = ymd(new Date());
   const weekEnd = ymd(new Date(Date.now() + 7 * 86_400_000));
   const groups: Group[] = [
@@ -94,7 +90,7 @@ export default async function PlanIndexPage() {
     else groups[2].items.push(vm);
   }
   const liveGroups = groups.filter((g) => g.items.length);
-  archive.reverse(); // most-recent past first
+  archive.reverse();
 
   const empty = itins.length === 0;
   const [reminders, recurringRules, recurringOffers, checklist, { data: pickCustomers }, { data: pickSites }, { data: pickLocations }] = await Promise.all([
@@ -109,7 +105,6 @@ export default async function PlanIndexPage() {
 
   return (
     <AppScreen eyebrow="Plan" title="What are you planning?">
-
       <PlanCreate />
 
       <RecurringOffers offers={recurringOffers} />
@@ -126,14 +121,17 @@ export default async function PlanIndexPage() {
       {empty ? (
         <div className="cc-plan-empty">
           <OnboardingChecklist state={checklist} context="plan-empty" />
-          <p className="cc-plan-empty-lead">Nothing planned yet.</p>
-          <p className="cc-plan-empty-sub">
-            Add a day by hand — your trains, stays and meetings — or import the bookings
-            from your inbox, and Khonsera threads the rest.
-          </p>
-          <div style={{ marginTop: "var(--space-3)" }}>
+          <EmptyStateActions
+            title="Nothing planned yet"
+            description="Start with a day, a calendar event or a booking email. Khonsera will thread the journey around it."
+            image={false}
+            actions={[
+              { label: "Import calendar", href: "/api/auth/google/connect", variant: "secondary" },
+              { label: "Scan booking emails", href: "/api/auth/gmail/connect", variant: "secondary" },
+            ]}
+          >
             <PlanCreate label="Plan a day" />
-          </div>
+          </EmptyStateActions>
         </div>
       ) : (
         <>

--- a/src/components/contacts/contacts-screen.tsx
+++ b/src/components/contacts/contacts-screen.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { ContactChip } from "@/components/concierge";
 import type { ContactVM } from "@/components/concierge";
+import { EmptyStateActions } from "@/components/ui/empty-state-actions";
 import { createContactQuick } from "@/lib/actions/contact-search";
 
 // People — Design Round 2 secondary template: .cc-add + a .cc-contact-chip grid,
@@ -11,6 +12,7 @@ import { createContactQuick } from "@/lib/actions/contact-search";
 export function ContactsScreen({ initial }: { initial: ContactVM[] }) {
   const router = useRouter();
   const [name, setName] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
   const [pending, startTransition] = useTransition();
 
   function add() {
@@ -32,6 +34,7 @@ export function ContactsScreen({ initial }: { initial: ContactVM[] }) {
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round"><path d="M12 5v14M5 12h14" /></svg>
         </span>
         <input
+          ref={inputRef}
           value={name}
           onChange={(e) => setName(e.target.value)}
           onKeyDown={(e) => e.key === "Enter" && add()}
@@ -42,12 +45,15 @@ export function ContactsScreen({ initial }: { initial: ContactVM[] }) {
       </label>
 
       {initial.length === 0 ? (
-        <div className="cc-empty">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src="/brand/mk-ink.png" alt="" />
-          <p className="cc-empty-title">No one here yet</p>
-          <p className="cc-empty-sub">Add the people you meet and travel to see — Khonsera keeps them close to the days they belong to.</p>
-        </div>
+        <EmptyStateActions
+          title="No people or clients yet"
+          description="Add them once, then attach them to visits and meeting days in Plan."
+          actions={[{ label: "Add client", href: "/customers/new", variant: "secondary" }]}
+        >
+          <button type="button" className="cc-btn cc-btn-gold" onClick={() => inputRef.current?.focus()}>
+            Add person
+          </button>
+        </EmptyStateActions>
       ) : (
         <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-2)" }}>
           {initial.map((c) => <ContactChip key={c.id} contact={c} />)}

--- a/src/components/tasks/tasks-screen.tsx
+++ b/src/components/tasks/tasks-screen.tsx
@@ -4,6 +4,7 @@ import { useState, useTransition } from "react";
 import { TaskRow } from "@/components/concierge";
 import type { TaskVM } from "@/components/concierge";
 import { createTask, setTaskDone } from "@/lib/actions/tasks";
+import { EmptyStateActions } from "@/components/ui/empty-state-actions";
 
 // Tasks — Design Round 2 secondary template (.cc-section / .cc-empty / .cc-add +
 // the .cc-task-row contract component) in a real CRUD loop.
@@ -50,12 +51,11 @@ export function TasksScreen({ initial }: { initial: TaskVM[] }) {
       </label>
 
       {open.length === 0 && done.length === 0 ? (
-        <div className="cc-empty">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src="/brand/mk-ink.png" alt="" />
-          <p className="cc-empty-title">Nothing on your list</p>
-          <p className="cc-empty-sub">Add a task and it lands on the right day.</p>
-        </div>
+        <EmptyStateActions
+          title="Nothing on your list"
+          description="Add a task and it lands on the right day."
+          image={false}
+        />
       ) : (
         <>
           <section className="cc-section">

--- a/src/components/ui/empty-state-actions.tsx
+++ b/src/components/ui/empty-state-actions.tsx
@@ -1,0 +1,62 @@
+import type { ReactNode } from "react";
+import type { Route } from "next";
+import { cn } from "@/lib/utils";
+
+export type EmptyStateAction = {
+  label: string;
+  href: Route | `/api/${string}` | URL;
+  variant?: "primary" | "secondary";
+};
+
+export function EmptyStateActions({
+  title,
+  description,
+  actions = [],
+  children,
+  className,
+  image = true,
+}: {
+  title: string;
+  description: string;
+  actions?: EmptyStateAction[];
+  children?: ReactNode;
+  className?: string;
+  image?: boolean;
+}) {
+  return (
+    <div className={cn("cc-empty", className)}>
+      {image ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src="/brand/mk-ink.png" alt="" />
+      ) : null}
+      <p className="cc-empty-title">{title}</p>
+      <p className="cc-empty-sub">{description}</p>
+      {children || actions.length > 0 ? (
+        <div
+          className="cc-empty-actions"
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            justifyContent: "center",
+            gap: "var(--space-2)",
+            marginTop: "var(--space-3)",
+          }}
+        >
+          {children}
+          {actions.map((action) => {
+            const href = action.href instanceof URL ? action.href.toString() : action.href;
+            return (
+              <a
+                key={`${action.label}-${href}`}
+                href={href}
+                className={action.variant === "secondary" ? "cc-btn cc-btn-ghost" : "cc-btn cc-btn-gold"}
+              >
+                {action.label}
+              </a>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/wallet/wallet-screen.tsx
+++ b/src/components/wallet/wallet-screen.tsx
@@ -7,6 +7,7 @@ import { useRouter } from "next/navigation";
 import { Pass, PassPeek, ScanView } from "@/components/concierge";
 import type { TicketVM, BarcodeVM } from "@/components/concierge";
 import { ticketUseMoment } from "@/components/concierge";
+import { EmptyStateActions } from "@/components/ui/empty-state-actions";
 import { deleteBookedRun } from "@/lib/actions/plan-edit";
 
 // The Wallet (planner master brief §7) — document-centric: every booking across
@@ -44,15 +45,12 @@ export function WalletScreen({ tickets }: { tickets: TicketVM[] }) {
   if (visible.length === 0) {
     return (
       <div className="cc-wallet cc-wallet--lux">
-        <div className="cc-wallet-empty">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src="/brand/mk-ink.png" alt="" />
-          <p className="cc-wallet-empty-lead">Your tickets will live here.</p>
-          <p className="cc-wallet-empty-sub">
-            Every booking, grouped by day, the next one you need on top — and ready
-            to scan even without signal.
-          </p>
-        </div>
+        <EmptyStateActions
+          className="cc-wallet-empty"
+          title="Your tickets will live here"
+          description="Connect Gmail and travel bookings become tickets, grouped by the day you need them and ready when signal drops."
+          actions={[{ label: "Connect Gmail", href: "/api/auth/gmail/connect" }]}
+        />
       </div>
     );
   }


### PR DESCRIPTION
## What changed

- replaces the obsolete scaffold README with the current product, architecture and validation baseline
- adds a focused product roadmap and takeover decision record
- adds pull-request validation for typecheck, unit tests and production build
- introduces one reusable `EmptyStateActions` primitive
- applies the shared empty-state pattern to Plan, Wallet, Expenses, Tasks and Contacts
- preserves newer onboarding and Wallet booking-removal behaviour while reconstructing the useful parts of stale PR #24

## Why

The repository had outgrown its documentation and several empty screens used separate copy, artwork and action patterns. The earlier takeover branch also accumulated connector marker commits. This rebuilds the intended work from the current default head as one reviewable commit.

## Product impact

Empty screens now direct users towards the next relevant action instead of ending in passive explanation. The roadmap centres future work on the travel-day loop and records `LiveDay` as Today's existing authoritative next-move surface, avoiding a duplicate action card from stale PR #21.

## Validation

A new GitHub Actions workflow runs:

- `npm run typecheck`
- `npm test`
- `npm run build`

This PR was assembled through the GitHub connector, so those checks are the executable validation source for the branch.