### PR TITLE
Apply the approved Today direction to the Khonsera app

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,10 +1,8 @@
 import { redirect } from "next/navigation";
 import { requireUserContext } from "@/lib/auth";
 import { isApproved } from "@/lib/access";
-import { AppSidebar } from "@/components/app-sidebar";
 import { MobileAppbar } from "@/components/shell/mobile-appbar";
 import { MobileTabbar } from "@/components/mobile-tabbar";
-import { createClient } from "@/lib/supabase/server";
 
 export default async function AppLayout({
   children,
@@ -20,12 +18,6 @@ export default async function AppLayout({
   if (!isApproved(ctx)) {
     redirect("/");
   }
-  const supabase = await createClient();
-  const { data: workspace } = await supabase
-    .from("workspaces")
-    .select("name")
-    .eq("id", ctx.workspaceId)
-    .maybeSingle();
 
   const nameSource = ctx.fullName ?? ctx.email.split("@")[0];
   const firstName = nameSource.split(" ")[0] || "there";
@@ -38,38 +30,17 @@ export default async function AppLayout({
       .toUpperCase() || ctx.email[0]!.toUpperCase();
 
   return (
-    <div className="khonsera-app">
-      {/* Mobile / tablet — sticky command bar and safe-area-aware navigation. */}
-      <div className="cc-app-mobile lg:hidden">
-        <MobileAppbar
-          email={ctx.email}
-          firstName={firstName}
-          initials={initials}
-          isStaff={ctx.isStaff}
-          mode={ctx.activeMode}
-        />
-        <main className="cc-mobile-main">{children}</main>
-        <div className="cc-tabbar-wrap">
-          <MobileTabbar mode={ctx.activeMode} />
-        </div>
-      </div>
-
-      {/* Desktop — navigation rail and a full-width responsive work surface. */}
-      <div className="cc-app-desktop hidden lg:block">
-        <div className="cc-shell">
-          <AppSidebar
-            email={ctx.email}
-            firstName={firstName}
-            initials={initials}
-            workspaceName={workspace?.name ?? "Personal"}
-            mode={ctx.activeMode}
-          />
-          <div className="cc-shell-main">
-            <div className="cc-shell-canvas">
-              <main className="cc-shell-col">{children}</main>
-            </div>
-          </div>
-        </div>
+    <div className="khonsera-app khonsera-app--unified">
+      <MobileAppbar
+        email={ctx.email}
+        firstName={firstName}
+        initials={initials}
+        isStaff={ctx.isStaff}
+        mode={ctx.activeMode}
+      />
+      <main className="cc-app-main">{children}</main>
+      <div className="cc-tabbar-wrap">
+        <MobileTabbar mode={ctx.activeMode} />
       </div>
     </div>
   );

--- a/src/app/(app)/today/page.tsx
+++ b/src/app/(app)/today/page.tsx
@@ -136,6 +136,36 @@ function isToday(iso: string | null, today: string): boolean {
   );
 }
 
+function WeatherGlyph({ isDay }: { isDay: boolean }) {
+  return isDay ? (
+    <svg
+      className="cc-weather-glyph"
+      viewBox="0 0 48 48"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      aria-hidden
+    >
+      <circle cx="24" cy="24" r="7" />
+      <path d="M24 4v6M24 38v6M4 24h6M38 24h6M9.9 9.9l4.2 4.2M33.9 33.9l4.2 4.2M38.1 9.9l-4.2 4.2M14.1 33.9l-4.2 4.2" />
+    </svg>
+  ) : (
+    <svg
+      className="cc-weather-glyph"
+      viewBox="0 0 48 48"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d="M37 31.5A16 16 0 0 1 16.5 11 16 16 0 1 0 37 31.5Z" />
+    </svg>
+  );
+}
+
 export default async function TodayPage({
   searchParams,
 }: {
@@ -183,6 +213,7 @@ export default async function TodayPage({
   const travelByToStop = new Map<string, InboundLeg>();
   let baseCoord: { lat: number; lng: number } | null = null;
   let baseLabel: string | null = null;
+  let destinationLabel: string | null = null;
   let tickets: TicketVM[] = [];
   let mapStops: StopForMap[] = [];
   let mapTransitions: TransitionForMap[] = [];
@@ -229,6 +260,8 @@ export default async function TodayPage({
       if (st.type === "start" && !baseCoord) baseCoord = coordOf(st);
       if (st.type === "start" && !baseLabel)
         baseLabel = placeOf(st) ?? st.title ?? null;
+      if (st.type === "end")
+        destinationLabel = placeOf(st) ?? st.title ?? destinationLabel;
       // Base bookends remain part of routing, but they are context — never Today stops.
       if (
         st.type !== "start" &&
@@ -526,13 +559,26 @@ export default async function TodayPage({
       title={anchors.length ? dayPurpose : "Right now"}
       titleAs="h1"
       description={
-        anchors.length && baseLabel ? (
-          <>
-            From <strong>{baseLabel}</strong>
-          </>
+        anchors.length && (destinationLabel ?? baseLabel) ? (
+          <span className="cc-today-destination">
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.7"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden
+            >
+              <path d="M20 10c0 5-8 11-8 11S4 15 4 10a8 8 0 1 1 16 0Z" />
+              <circle cx="12" cy="10" r="2.5" />
+            </svg>
+            To <strong>{destinationLabel ?? baseLabel}</strong>
+          </span>
         ) : undefined
       }
       headerClassName="cc-today-head"
+      className="cc-today-direction"
       data-disrupted={disruptions.length ? "true" : undefined}
       actions={
         weather ? (
@@ -540,6 +586,7 @@ export default async function TodayPage({
             className="cc-weather"
             data-day={weather.isDay ? "true" : "false"}
           >
+            <WeatherGlyph isDay={weather.isDay} />
             <span className="cc-weather-temp">{weather.tempC}&deg;</span>
             <span className="cc-weather-meta">
               <span className="cc-weather-headline">{weather.headline}</span>
@@ -551,44 +598,48 @@ export default async function TodayPage({
     >
       <OfflineTicketSync tickets={tickets} />
       <div className="cc-day-dashboard">
-        <div className="cc-day-forecast" aria-label="Day conditions">
-          {weather && weather.hours.length > 0 ? (
-            <div
-              className="cc-weather-hours"
-              aria-label="Today's forecast by the hour"
-            >
-              {weather.hours.map((h) => (
-                <div
-                  key={h.label}
-                  className="cc-weather-hour"
-                  title={h.headline}
-                >
-                  <span className="cc-weather-hour-time">{h.label}</span>
-                  <span className="cc-weather-hour-temp">{h.tempC}&deg;</span>
-                  <span className="cc-weather-hour-cond">{h.headline}</span>
-                </div>
-              ))}
-            </div>
-          ) : null}
-          <TodayDisruption items={disruptions} />
-          {inLondon ? <TflLineStatus /> : null}
-        </div>
-
         {anchors.length ? (
           <>
+            <section className="cc-today-command" aria-label="Your next move">
+              <div className="cc-today-command-content">
+                <LiveDay anchors={spineAnchors} sub={sub} base={baseCoord} />
+              </div>
+              {todayJourney ? (
+                <div className="cc-today-command-map">
+                  <PlanMap journey={todayJourney} />
+                </div>
+              ) : null}
+            </section>
+
+            <div className="cc-day-forecast" aria-label="Day conditions">
+              {weather && weather.hours.length > 0 ? (
+                <div
+                  className="cc-weather-hours"
+                  aria-label="Today's forecast by the hour"
+                >
+                  {weather.hours.map((h) => (
+                    <div
+                      key={h.label}
+                      className="cc-weather-hour"
+                      title={h.headline}
+                    >
+                      <span className="cc-weather-hour-time">{h.label}</span>
+                      <span className="cc-weather-hour-temp">
+                        {h.tempC}&deg;
+                      </span>
+                      <span className="cc-weather-hour-cond">{h.headline}</span>
+                    </div>
+                  ))}
+                </div>
+              ) : null}
+              <TodayDisruption items={disruptions} />
+              {inLondon ? <TflLineStatus /> : null}
+            </div>
+
             <section
               className="cc-day-primary"
               aria-label={`Live itinerary for ${dayPurpose}`}
             >
-              {dayNote ? (
-                <div className="cc-day-point cc-day-point--today">
-                  <span className="cc-day-point-eyebrow">
-                    The point of the day
-                  </span>
-                  <p className="cc-standfirst">{dayNote}</p>
-                </div>
-              ) : null}
-              <LiveDay anchors={spineAnchors} sub={sub} base={baseCoord} />
               <TodaySpine
                 anchors={spineAnchors}
                 nextId={nextSpine?.id ?? null}
@@ -599,6 +650,12 @@ export default async function TodayPage({
               className="cc-day-context"
               aria-label="Day tools and documents"
             >
+              {dayNote ? (
+                <div className="cc-context-actions cc-context-actions--note">
+                  <span className="cc-context-label">Today</span>
+                  <span className="cc-context-detail">{dayNote}</span>
+                </div>
+              ) : null}
               {tickets.length > 0 ? (
                 <div className="cc-context-actions">
                   <span className="cc-context-label">Tickets today</span>
@@ -610,7 +667,6 @@ export default async function TodayPage({
                   </Link>
                 </div>
               ) : null}
-              {todayJourney ? <PlanMap journey={todayJourney} /> : null}
               {showNextDocument && nextTicket ? (
                 <TodayDocument ticket={nextTicket} />
               ) : null}

--- a/src/app/khonsera-today-direction.css
+++ b/src/app/khonsera-today-direction.css
@@ -1,0 +1,1048 @@
+/* Khonsera application direction · July 2026
+ *
+ * The approved Today mock is the application specification. This layer makes
+ * the existing product behave as that app: one unified chrome, one decisive
+ * next-move surface, one integrated map, and one continuous itinerary object.
+ */
+
+:root {
+  --kh-app-max: 1180px;
+  --kh-app-gutter: clamp(16px, 3.25vw, 30px);
+  --kh-emerald: var(--gold);
+  --kh-emerald-strong: var(--gold-2);
+  --kh-emerald-soft: var(--sage-soft);
+  --kh-canvas: #f8f9f8;
+  --kh-map-wash: color-mix(in srgb, var(--sage-soft) 55%, var(--card));
+  --kh-panel-shadow: 0 1px 2px rgba(24, 26, 31, 0.04),
+    0 12px 30px -18px rgba(24, 26, 31, 0.19);
+  --kh-float-shadow: 0 2px 5px rgba(24, 26, 31, 0.04),
+    0 12px 24px -15px rgba(24, 26, 31, 0.2);
+}
+
+html[data-theme="light"],
+html[data-theme="light"] body {
+  background: var(--kh-canvas);
+}
+
+.khonsera-app--unified {
+  min-height: 100dvh;
+  background: radial-gradient(circle at 52% -8%, var(--card), transparent 34rem),
+    var(--kh-canvas);
+}
+
+.khonsera-app--unified .cc-app-main {
+  width: min(100%, calc(var(--kh-app-max) + (var(--kh-app-gutter) * 2)));
+  min-height: 100dvh;
+  margin-inline: auto;
+  padding: 22px var(--kh-app-gutter)
+    calc(var(--tabbar-height) + 92px + env(safe-area-inset-bottom));
+}
+
+/* Unified application chrome ------------------------------------------------ */
+
+.khonsera-app--unified .cc-appbar {
+  width: min(100%, calc(var(--kh-app-max) + (var(--kh-app-gutter) * 2)));
+  min-height: 72px;
+  margin-inline: auto;
+  padding: calc(16px + env(safe-area-inset-top)) var(--kh-app-gutter) 10px;
+  border: 0;
+  background: transparent;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+}
+
+.khonsera-app--unified .cc-lockup {
+  gap: 17px;
+}
+
+.khonsera-app--unified .cc-brand-dot {
+  width: 10px;
+  height: 10px;
+  background: var(--kh-emerald-strong);
+  box-shadow: none;
+}
+
+.khonsera-app--unified .cc-appbar .cc-lockup .wm {
+  display: block;
+  padding-left: 0;
+  color: var(--ink);
+  font-family: var(--display);
+  font-size: 16px;
+  font-weight: var(--fw-regular);
+  letter-spacing: 0.38em;
+}
+
+.khonsera-app--unified .cc-appbar-right {
+  gap: 14px;
+}
+
+.khonsera-app--unified .cc-appbar .cc-iconbtn {
+  width: 58px;
+  height: 58px;
+  min-width: 58px;
+  min-height: 58px;
+  border: 1px solid var(--rule);
+  border-radius: var(--radius-pill);
+  background: var(--card);
+  box-shadow: var(--kh-float-shadow);
+}
+
+.khonsera-app--unified .cc-appbar .cc-iconbtn:hover {
+  background: var(--card);
+  color: var(--ink);
+  box-shadow:
+    0 2px 6px rgba(24, 26, 31, 0.05),
+    0 18px 30px -17px rgba(24, 26, 31, 0.24);
+}
+
+.khonsera-app--unified .cc-appbar-icon,
+.khonsera-app--unified .cc-appbar-icon svg {
+  width: 24px;
+  height: 24px;
+}
+
+.khonsera-app--unified .cc-tabbar-wrap {
+  border-top-color: var(--rule);
+  background: color-mix(in srgb, var(--card) 94%, transparent);
+  box-shadow: 0 -10px 34px -28px rgba(24, 26, 31, 0.28);
+}
+
+.khonsera-app--unified .cc-tabbar {
+  width: min(100%, 862px);
+  max-width: 862px;
+}
+
+.khonsera-app--unified .cc-tab {
+  border-radius: 0;
+  color: var(--ink-faint);
+}
+
+.khonsera-app--unified .cc-tab[data-active="true"],
+.khonsera-app--unified .cc-tab[data-active="true"] .cc-tab-ico {
+  color: var(--kh-emerald-strong);
+}
+
+.khonsera-app--unified .cc-tab[data-active="true"] .cc-tab-dot {
+  display: none;
+}
+
+/* Today header -------------------------------------------------------------- */
+
+.cc-today-direction {
+  gap: 24px;
+}
+
+.cc-today-direction .cc-today-head {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(250px, 280px);
+  align-items: end;
+  gap: 32px;
+}
+
+.cc-today-direction .cc-today-head .cc-screen-copy {
+  min-width: 0;
+}
+
+.cc-today-direction .cc-today-head .cc-eyebrow {
+  color: var(--ink-dim);
+  font-size: 14px;
+  font-weight: var(--fw-medium);
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+}
+
+.cc-today-direction .cc-today-head .cc-screen-title {
+  margin-top: 8px;
+  color: var(--ink);
+  font-family: var(--display);
+  font-size: clamp(50px, 7vw, 74px);
+  font-weight: var(--fw-medium);
+  line-height: 0.96;
+  letter-spacing: -0.055em;
+}
+
+.cc-today-direction .cc-screen-description {
+  margin-top: 22px;
+  color: var(--ink-2);
+  font-size: 17px;
+}
+
+.cc-today-destination {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.cc-today-destination svg {
+  width: 20px;
+  height: 20px;
+  flex: none;
+}
+
+.cc-today-destination strong {
+  color: inherit;
+  font-weight: inherit;
+}
+
+.cc-today-direction .cc-screen-actions {
+  width: 100%;
+}
+
+.cc-today-direction .cc-weather {
+  width: 100%;
+  min-width: 0;
+  min-height: 142px;
+  display: grid;
+  grid-template-columns: 58px auto minmax(0, 1fr);
+  align-items: center;
+  gap: 14px;
+  padding: 24px 26px;
+  border: 1px solid var(--rule);
+  border-radius: 22px;
+  background: var(--card);
+  box-shadow: var(--kh-panel-shadow);
+}
+
+.cc-today-direction .cc-weather-glyph {
+  width: 54px;
+  height: 54px;
+  color: var(--amber);
+}
+
+.cc-today-direction .cc-weather[data-day="false"] .cc-weather-glyph {
+  color: var(--slate);
+}
+
+.cc-today-direction .cc-weather-temp {
+  color: var(--ink);
+  font-family: var(--display);
+  font-size: 45px;
+  font-weight: var(--fw-medium);
+  line-height: 1;
+  letter-spacing: -0.045em;
+}
+
+.cc-today-direction .cc-weather-meta {
+  gap: 5px;
+}
+
+.cc-today-direction .cc-weather-headline {
+  color: var(--ink-2);
+  font-size: 15px;
+  font-weight: var(--fw-medium);
+}
+
+.cc-today-direction .cc-weather-place {
+  color: var(--ink-dim);
+  font-family: var(--sans);
+  font-size: 12px;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+/* Today composition --------------------------------------------------------- */
+
+.cc-today-direction .cc-day-dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+}
+
+.cc-today-command {
+  min-height: 418px;
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--rule);
+  border-radius: 22px;
+  background: var(--kh-map-wash);
+  box-shadow: var(--kh-panel-shadow);
+}
+
+.cc-today-command-content {
+  min-height: 418px;
+  position: relative;
+  z-index: 2;
+  display: flex;
+  align-items: stretch;
+  padding: 0;
+  pointer-events: none;
+  background: linear-gradient(
+    90deg,
+    var(--card) 0%,
+    var(--card) 48%,
+    color-mix(in srgb, var(--card) 86%, transparent) 58%,
+    transparent 74%
+  );
+}
+
+.cc-today-command-map {
+  position: absolute;
+  z-index: 1;
+  inset: 0 0 0 42%;
+  min-width: 0;
+}
+
+.cc-today-command-map .cc-route-map {
+  height: 100%;
+  min-height: 100%;
+  margin: 0;
+  overflow: hidden;
+  border: 0;
+  border-radius: 0;
+  background: var(--kh-map-wash);
+  box-shadow: none;
+}
+
+.cc-today-command-map .cc-route-map > div {
+  height: 100% !important;
+  min-height: 100% !important;
+  border-radius: 0 !important;
+}
+
+.cc-today-command .cc-active-tile {
+  width: 64%;
+  min-height: 418px;
+  position: relative;
+  z-index: 3;
+  gap: 14px;
+  padding: 31px 30px 26px;
+  overflow: visible;
+  border: 0 !important;
+  border-radius: 0;
+  background: transparent !important;
+  box-shadow: none;
+  text-shadow: none;
+  pointer-events: auto;
+}
+
+.cc-today-command:not(:has(.cc-today-command-map)) .cc-active-tile {
+  width: 100%;
+}
+
+.cc-today-command .cc-active-tile::after,
+.cc-today-command .cc-active-tile .pg::after {
+  content: none !important;
+}
+
+.cc-today-command .cc-at-status {
+  gap: 10px;
+  color: var(--kh-emerald-strong);
+  font-size: 12px;
+  font-weight: var(--fw-semibold);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.cc-today-command .cc-at-dot {
+  width: 9px;
+  height: 9px;
+}
+
+.cc-today-command .cc-setoff-sheet {
+  display: grid;
+  gap: 12px;
+  text-shadow: none;
+}
+
+.cc-today-command .cc-setoff-eyb {
+  justify-content: flex-start;
+  gap: 8px;
+}
+
+.cc-today-command .cc-setoff-kicker {
+  color: var(--ink-2);
+  font-size: 17px;
+}
+
+.cc-today-command .cc-setoff-for {
+  overflow: hidden;
+  color: var(--ink-dim);
+  font-size: 13px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cc-setoff-core {
+  display: flex;
+  align-items: center;
+  gap: 42px;
+}
+
+.cc-today-command .cc-setoff-figure {
+  color: var(--ink);
+  font-family: var(--display);
+  font-size: clamp(62px, 8vw, 92px);
+  font-weight: var(--fw-regular);
+  line-height: 0.95;
+  letter-spacing: -0.06em;
+  text-shadow: none;
+}
+
+.cc-today-command .cc-setoff-colon {
+  color: var(--ink);
+}
+
+.cc-leave-ring {
+  width: 104px;
+  height: 104px;
+  position: relative;
+  display: grid;
+  flex: none;
+  place-items: center;
+}
+
+.cc-leave-ring svg {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  inset: 0;
+  transform: rotate(-90deg);
+}
+
+.cc-leave-ring circle {
+  fill: none;
+  stroke-width: 5;
+}
+
+.cc-leave-ring-track {
+  stroke: var(--rule-2);
+}
+
+.cc-leave-ring-progress {
+  stroke: var(--kh-emerald-strong);
+  stroke-linecap: round;
+  stroke-dasharray: 244;
+}
+
+.cc-leave-ring > span {
+  position: relative;
+  z-index: 1;
+  color: var(--ink-dim);
+  font-size: 12px;
+  line-height: 1.2;
+  text-align: center;
+}
+
+.cc-leave-ring strong {
+  display: block;
+  color: var(--ink);
+  font-size: 14px;
+  font-weight: var(--fw-medium);
+}
+
+.cc-next-facts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.cc-next-facts > span {
+  min-height: 42px;
+  display: inline-flex;
+  align-items: center;
+  padding: 0 13px;
+  border: 1px solid var(--rule);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--card) 82%, transparent);
+  color: var(--ink-2);
+  font-size: 13px;
+  font-weight: var(--fw-medium);
+  backdrop-filter: blur(10px);
+}
+
+.cc-next-facts > span::before {
+  width: 6px;
+  height: 6px;
+  content: "";
+  margin-right: 9px;
+  border: 1px solid currentColor;
+  border-radius: var(--radius-pill);
+  color: var(--kh-emerald-strong);
+}
+
+.cc-today-command .cc-setoff-move {
+  max-width: 54ch;
+  color: var(--ink-2);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.cc-next-actions {
+  display: grid;
+  grid-template-columns: 1.55fr repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: auto;
+}
+
+.cc-next-action {
+  min-width: 0;
+  min-height: 52px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 0 14px;
+  border: 1px solid var(--rule);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--card) 92%, transparent);
+  color: var(--ink-2);
+  box-shadow: 0 4px 12px -8px rgba(24, 26, 31, 0.32);
+  font-size: 13px;
+  font-weight: var(--fw-semibold);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.cc-next-action svg {
+  width: 18px;
+  height: 18px;
+  flex: none;
+}
+
+.cc-next-action:hover {
+  background: var(--card);
+  transform: translateY(-1px);
+}
+
+.cc-next-action:disabled {
+  cursor: wait;
+  opacity: 0.55;
+}
+
+.cc-next-action--primary {
+  justify-content: space-between;
+  border-color: transparent;
+  background: var(--kh-emerald-strong);
+  color: #ffffff;
+  box-shadow: 0 10px 20px -12px color-mix(in srgb, var(--kh-emerald) 70%, transparent);
+}
+
+.cc-next-action--primary:hover {
+  background: var(--char);
+}
+
+/* Weather strip ------------------------------------------------------------ */
+
+.cc-today-direction .cc-day-forecast {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.cc-today-direction .cc-weather-hours {
+  min-height: 98px;
+  display: grid;
+  grid-template-columns: repeat(6, minmax(116px, 1fr));
+  grid-auto-flow: row;
+  gap: 0;
+  padding: 16px 12px;
+  overflow-x: auto;
+  border: 1px solid var(--rule);
+  border-radius: 22px;
+  background: var(--card);
+  box-shadow: var(--kh-panel-shadow);
+}
+
+.cc-today-direction .cc-weather-hour {
+  min-width: 116px;
+  display: grid;
+  grid-template-columns: 1fr;
+  align-content: center;
+  gap: 6px;
+  padding: 0 20px;
+  border-left: 1px solid var(--rule);
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.cc-today-direction .cc-weather-hour:first-child {
+  border-left: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.cc-today-direction .cc-weather-hour-time {
+  color: var(--ink-dim);
+  font-family: var(--sans);
+  font-size: 12px;
+  letter-spacing: 0.03em;
+}
+
+.cc-today-direction .cc-weather-hour:first-child .cc-weather-hour-time {
+  color: var(--kh-emerald-strong);
+  font-weight: var(--fw-semibold);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.cc-today-direction .cc-weather-hour-temp {
+  color: var(--ink);
+  font-family: var(--display);
+  font-size: 23px;
+  font-weight: var(--fw-medium);
+}
+
+.cc-today-direction .cc-weather-hour-cond {
+  color: var(--ink-dim);
+  font-size: 10px;
+}
+
+/* One continuous itinerary ------------------------------------------------- */
+
+.cc-today-direction .cc-day-primary {
+  gap: 0;
+}
+
+.cc-today-direction .cc-spine-heading {
+  margin: 10px 0 15px;
+  color: var(--ink-dim);
+  font-size: 13px;
+}
+
+.cc-today-direction .cc-spine-heading .cc-eyebrow {
+  color: var(--ink);
+  font-size: 16px;
+  font-weight: var(--fw-semibold);
+}
+
+.cc-today-direction .cc-spine {
+  width: 100%;
+  position: relative;
+  gap: 0;
+  padding: 0 0 0 74px;
+  overflow: hidden;
+  border: 1px solid var(--rule);
+  border-radius: 22px;
+  background: var(--card);
+  box-shadow: var(--kh-panel-shadow);
+}
+
+.cc-today-direction .cc-spine-rail {
+  width: 1px;
+  top: 18px;
+  bottom: 18px;
+  left: 26px;
+  background: var(--rule-2);
+}
+
+.cc-today-direction .cc-spine > .cc-node:has(.cc-now-row) {
+  display: none;
+}
+
+.cc-today-direction .cc-spine .cc-node {
+  min-height: 106px;
+  display: block;
+  padding: 20px 24px 20px 10px;
+  border-top: 1px solid var(--rule);
+  background: transparent;
+}
+
+.cc-today-direction .cc-spine > .cc-node:first-of-type,
+.cc-today-direction .cc-spine-rail + .cc-node {
+  border-top: 0;
+}
+
+.cc-today-direction .cc-spine .cc-node-dot {
+  width: 48px;
+  height: 48px;
+  top: 22px;
+  left: -48px;
+  margin: 0;
+  border: 1px solid var(--rule);
+  border-radius: var(--radius-pill);
+  background: var(--card);
+  box-shadow: var(--kh-float-shadow);
+  color: var(--ink);
+  transform: translateX(-50%);
+}
+
+.cc-today-direction .cc-spine .cc-node[data-state="next"] .cc-node-dot {
+  border-color: var(--kh-emerald-strong);
+  background: var(--kh-emerald-strong);
+  color: #ffffff;
+}
+
+.cc-today-direction .cc-spine .cc-node-dot > span {
+  width: 12px;
+  height: 12px;
+  border-width: 2px;
+  box-shadow: none;
+}
+
+.cc-today-direction .cc-spine .cc-node[data-state="next"] .cc-node-dot > span {
+  border-color: #ffffff;
+  background: transparent;
+}
+
+.cc-today-direction
+  .cc-spine
+  :is(
+    .cc-walk,
+    .cc-appt,
+    .cc-anchor-card,
+    .cc-station-card,
+    .cc-transfer,
+    .cc-pass
+  ) {
+  width: 100%;
+  max-width: 100%;
+  padding: 0 !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  text-shadow: none !important;
+}
+
+.cc-today-direction
+  .cc-spine
+  :is(
+    .cc-walk,
+    .cc-appt,
+    .cc-anchor-card,
+    .cc-station-card,
+    .cc-transfer,
+    .cc-pass
+  )::after {
+  content: none !important;
+}
+
+.cc-today-direction .cc-walk {
+  min-height: 86px;
+  justify-content: center;
+}
+
+.cc-today-direction .cc-walk-head {
+  justify-content: flex-start;
+  gap: 12px;
+}
+
+.cc-today-direction .cc-walk-mode {
+  color: var(--ink);
+  font-size: 16px;
+  font-weight: var(--fw-semibold);
+}
+
+.cc-today-direction .cc-walk-mins {
+  color: var(--ink-2);
+  font-family: var(--sans);
+  font-size: 15px;
+  text-shadow: none;
+}
+
+.cc-today-direction .cc-walk-window {
+  max-width: 360px;
+  color: var(--ink-dim);
+  font-family: var(--sans);
+  font-size: 13px;
+}
+
+.cc-today-direction .cc-walk-dest {
+  color: var(--ink-dim);
+  font-size: 13px;
+}
+
+.cc-today-direction .cc-walk-spare {
+  margin-left: 8px;
+  background: var(--kh-emerald-soft);
+  color: var(--kh-emerald-strong);
+}
+
+.cc-today-direction .cc-walk-foot {
+  display: none;
+}
+
+.cc-today-direction .cc-appt-title,
+.cc-today-direction .cc-station-title {
+  font-size: 18px;
+}
+
+.cc-today-direction .cc-pass--docked .cc-pass-band {
+  padding: 0 0 12px !important;
+  background: transparent !important;
+  color: var(--kh-emerald-strong) !important;
+}
+
+.cc-today-direction .cc-pass--docked .cc-pass-band * {
+  color: inherit !important;
+}
+
+.cc-today-direction .cc-pass--docked .cc-pass-route {
+  padding: 8px 10px 18px !important;
+}
+
+.cc-today-direction .cc-pass--docked .cc-pass-code {
+  color: var(--ink) !important;
+  font-family: var(--display);
+  font-size: 34px !important;
+  font-weight: var(--fw-regular) !important;
+}
+
+.cc-today-direction .cc-pass--docked .cc-pass-place {
+  color: var(--ink-dim) !important;
+  font-size: 12px !important;
+}
+
+.cc-today-direction .cc-pass--docked .cc-pass-stub {
+  grid-template-columns: repeat(3, minmax(0, 1fr)) !important;
+  padding: 14px 10px 4px !important;
+  border-top: 1px solid var(--rule);
+}
+
+.cc-today-direction .cc-pass--docked .cc-pass-status,
+.cc-today-direction .cc-pass--docked .cc-pass-consequence,
+.cc-today-direction .cc-pass--docked .cc-pass-ready {
+  padding-right: 10px !important;
+  padding-left: 10px !important;
+}
+
+.cc-today-direction .cc-transfer {
+  min-height: 72px;
+  display: flex;
+  align-items: center;
+  color: var(--rail-2);
+}
+
+.cc-today-direction .cc-transfer-head {
+  width: 100%;
+}
+
+.cc-today-direction .cc-spine-toggle {
+  min-height: 44px;
+  margin: 10px 24px 10px 10px;
+  border: 1px solid var(--rule);
+  background: var(--card);
+  box-shadow: none;
+}
+
+/* Contextual exits --------------------------------------------------------- */
+
+.cc-today-direction .cc-day-context {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.cc-today-direction .cc-context-actions {
+  min-height: 70px;
+  padding: 15px 20px;
+  border: 1px solid var(--rule);
+  border-radius: 14px;
+  background: var(--card);
+  box-shadow: var(--kh-panel-shadow);
+}
+
+.cc-today-direction .cc-context-actions--note {
+  align-items: flex-start;
+  flex-direction: column;
+}
+
+.cc-today-direction .cc-context-actions--planner {
+  grid-column: 1 / -1;
+}
+
+/* Responsive translation -------------------------------------------------- */
+
+@media (max-width: 900px) {
+  .cc-today-command .cc-active-tile {
+    width: 68%;
+  }
+
+  .cc-next-actions {
+    grid-template-columns: 1.45fr repeat(3, minmax(88px, 1fr));
+  }
+
+  .cc-next-action {
+    padding-inline: 11px;
+  }
+
+  .cc-next-action:not(.cc-next-action--primary) svg {
+    display: none;
+  }
+}
+
+@media (max-width: 767px) {
+  .khonsera-app--unified .cc-app-main {
+    padding-top: 10px;
+  }
+
+  .khonsera-app--unified .cc-appbar {
+    position: sticky;
+    padding-bottom: 8px;
+    background: color-mix(in srgb, var(--kh-canvas) 92%, transparent);
+    backdrop-filter: blur(18px);
+    -webkit-backdrop-filter: blur(18px);
+  }
+
+  .khonsera-app--unified .cc-appbar .cc-iconbtn {
+    width: 46px;
+    height: 46px;
+    min-width: 46px;
+    min-height: 46px;
+  }
+
+  .cc-today-direction .cc-today-head {
+    grid-template-columns: 1fr;
+    gap: 22px;
+  }
+
+  .cc-today-direction .cc-today-head .cc-screen-title {
+    font-size: clamp(46px, 14vw, 62px);
+  }
+
+  .cc-today-direction .cc-weather {
+    min-height: 112px;
+    grid-template-columns: 48px auto minmax(0, 1fr);
+    padding: 20px;
+  }
+
+  .cc-today-direction .cc-weather-glyph {
+    width: 46px;
+    height: 46px;
+  }
+
+  .cc-today-direction .cc-weather-temp {
+    font-size: 38px;
+  }
+
+  .cc-today-command {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .cc-today-command-content {
+    min-height: auto;
+    background: var(--card);
+  }
+
+  .cc-today-command-map {
+    height: 220px;
+    position: relative;
+    inset: auto;
+    order: 2;
+  }
+
+  .cc-today-command .cc-active-tile {
+    width: 100%;
+    min-height: 0;
+    padding: 24px 20px 20px;
+  }
+
+  .cc-setoff-core {
+    gap: 22px;
+  }
+
+  .cc-today-command .cc-setoff-figure {
+    font-size: clamp(58px, 20vw, 82px);
+  }
+
+  .cc-leave-ring {
+    width: 92px;
+    height: 92px;
+  }
+
+  .cc-next-actions {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .cc-next-action:not(.cc-next-action--primary) svg {
+    display: block;
+  }
+
+  .cc-today-direction .cc-weather-hours {
+    grid-template-columns: none;
+    grid-auto-columns: minmax(100px, 1fr);
+    grid-auto-flow: column;
+  }
+
+  .cc-today-direction .cc-weather-hour {
+    min-width: 100px;
+    padding-inline: 15px;
+  }
+
+  .cc-today-direction .cc-spine {
+    padding-left: 62px;
+  }
+
+  .cc-today-direction .cc-spine-rail {
+    left: 23px;
+  }
+
+  .cc-today-direction .cc-spine .cc-node {
+    padding-right: 16px;
+  }
+
+  .cc-today-direction .cc-spine .cc-node-dot {
+    width: 42px;
+    height: 42px;
+    left: -39px;
+  }
+
+  .cc-today-direction .cc-day-context {
+    grid-template-columns: 1fr;
+  }
+
+  .cc-today-direction .cc-context-actions--planner {
+    grid-column: auto;
+  }
+}
+
+@media (max-width: 430px) {
+  .khonsera-app--unified .cc-appbar .cc-lockup .wm {
+    font-size: 13px;
+    letter-spacing: 0.27em;
+  }
+
+  .khonsera-app--unified .cc-appbar-right {
+    gap: 8px;
+  }
+
+  .cc-today-direction .cc-screen-description {
+    margin-top: 16px;
+    font-size: 15px;
+  }
+
+  .cc-setoff-core {
+    align-items: flex-end;
+    gap: 12px;
+  }
+
+  .cc-today-command .cc-setoff-figure {
+    font-size: clamp(52px, 19vw, 70px);
+  }
+
+  .cc-leave-ring {
+    width: 82px;
+    height: 82px;
+  }
+
+  .cc-next-facts {
+    gap: 7px;
+  }
+
+  .cc-next-facts > span {
+    min-height: 36px;
+    padding-inline: 10px;
+    font-size: 11px;
+  }
+
+  .cc-next-action {
+    min-height: 48px;
+    font-size: 12px;
+  }
+
+  .cc-today-direction .cc-pass--docked .cc-pass-code {
+    font-size: 28px !important;
+  }
+
+  .cc-today-direction .cc-pass--docked .cc-pass-stub {
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cc-next-action {
+    transition: none;
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,6 +16,7 @@ import "./khonsera-edition-iii-sharing.css"; // Edition III sharing/comms/safety
 import "./khonsera-edition-iii-round13.css"; // Edition III Round 13 coherence + features skin
 import "./khonsera-edition-iii-nav.css"; // Edition III N1 — premium guidance surface (.cc-nav*) — LAST
 import "./khonsera-instrument.css"; // Instrument Edition v8 — reviewed production direction, final authority
+import "./khonsera-today-direction.css"; // Jul 2026 app direction — unified shell + route-first Today surface
 import { PwaRegister } from "@/components/pwa-register";
 
 // Canonical Instrument Edition type stack:

--- a/src/components/mobile-tabbar.tsx
+++ b/src/components/mobile-tabbar.tsx
@@ -3,7 +3,12 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import type { AppMode } from "@/lib/mode";
-import { isActiveNav, navigationGlyphs, primaryNavigation, type NavigationIcon } from "@/lib/navigation";
+import {
+  isActiveNav,
+  navigationGlyphs,
+  primaryNavigation,
+  type NavigationIcon,
+} from "@/lib/navigation";
 
 // Primary nav — Design's bottom bar (`.cc-tabbar` / `.cc-tab`). Today, Plan,
 // Tasks, Wallet, and Navigate stay one tap away so the day's ticket and next-leg
@@ -11,7 +16,7 @@ import { isActiveNav, navigationGlyphs, primaryNavigation, type NavigationIcon }
 export function MobileTabbar({ mode }: { mode: AppMode }) {
   const pathname = usePathname();
   return (
-    <nav className="cc-tabbar lg:hidden" aria-label="Primary">
+    <nav className="cc-tabbar" aria-label="Primary">
       {primaryNavigation(mode).map((t) => {
         const active = isActiveNav(pathname, t.href);
         return (
@@ -35,8 +40,17 @@ export function MobileTabbar({ mode }: { mode: AppMode }) {
 
 function Glyph({ name }: { name: NavigationIcon }) {
   return (
-    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-      strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+    <svg
+      width="22"
+      height="22"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.7"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
       <path d={navigationGlyphs[name]} />
     </svg>
   );

--- a/src/components/shell/mobile-appbar.tsx
+++ b/src/components/shell/mobile-appbar.tsx
@@ -48,13 +48,9 @@ export function MobileAppbar({
   const overflowGroups = mobileOverflowNavigation(mode);
   return (
     <>
-      <header className="cc-appbar lg:hidden" data-scrolled="false">
+      <header className="cc-appbar" data-scrolled="false">
         <div className="cc-appbar-left">
-          <Link
-            href="/today"
-            className="cc-lockup"
-            aria-label="Khonsera"
-          >
+          <Link href="/today" className="cc-lockup" aria-label="Khonsera">
             <span className="cc-brand-dot" aria-hidden />
             <span className="wm">KHONSERA</span>
           </Link>
@@ -82,10 +78,7 @@ export function MobileAppbar({
       </header>
 
       {open ? (
-        <div
-          className="cc-overflow-layer lg:hidden"
-          onClick={() => setOpen(false)}
-        >
+        <div className="cc-overflow-layer" onClick={() => setOpen(false)}>
           <div className="cc-overflow-scrim" />
           <div
             id="mobile-overflow"

--- a/src/components/today/live-day.tsx
+++ b/src/components/today/live-day.tsx
@@ -4,7 +4,11 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import type { SpineAnchor, TransitionProgressState } from "./spine-model";
 import { londonClock } from "./spine-model";
-import { computeDayState, type EngineAnchor, type Feasibility } from "@/lib/today/engine";
+import {
+  computeDayState,
+  type EngineAnchor,
+  type Feasibility,
+} from "@/lib/today/engine";
 import { fetchNavRoute } from "@/lib/actions/nav";
 import { setLiveTransitionProgress } from "@/lib/actions/live-transition";
 import { useLivePosition } from "./use-live-position";
@@ -21,7 +25,9 @@ function samePoint(
   return Math.abs(a.lat - b.lat) < 0.00015 && Math.abs(a.lng - b.lng) < 0.00015;
 }
 
-function urgencyOf(feas: Feasibility | null): "comfortable" | "urgent" | "breach" {
+function urgencyOf(
+  feas: Feasibility | null,
+): "comfortable" | "urgent" | "breach" {
   if (!feas) return "comfortable";
   if (feas.band === "cliff") return "breach";
   if (feas.band === "leave_now" || feas.band === "heads_up") return "urgent";
@@ -30,12 +36,51 @@ function urgencyOf(feas: Feasibility | null): "comfortable" | "urgent" | "breach
 
 function instruction(feas: Feasibility | null): string {
   if (!feas) return "Working out your leave time";
-  if (feas.band === "cliff") return "Leave now — this connection may no longer work";
+  if (feas.band === "cliff")
+    return "Leave now — this connection may no longer work";
   if (feas.band === "leave_now") return "Leave now";
   if (feas.slackMin <= 60) return `Leave in ${Math.max(0, feas.slackMin)} min`;
   const hours = Math.floor(feas.slackMin / 60);
   const mins = feas.slackMin % 60;
   return `Leave in ${hours}h${mins ? ` ${mins}m` : ""}`;
+}
+
+function compactDuration(minutes: number): string {
+  const safeMinutes = Math.max(0, minutes);
+  if (safeMinutes < 60) return `${safeMinutes}m`;
+  const hours = Math.floor(safeMinutes / 60);
+  const remainder = safeMinutes % 60;
+  return `${hours}h${remainder ? ` ${remainder}m` : ""}`;
+}
+
+function NextActionIcon({
+  name,
+}: {
+  name: "arrow" | "share" | "reroute" | "ticket";
+}) {
+  const path = {
+    arrow: "M5 12h14m-5-5 5 5-5 5",
+    share:
+      "M18 8a3 3 0 1 0-2.83-4A3 3 0 0 0 18 8ZM6 15a3 3 0 1 0 2.83 4A3 3 0 0 0 6 15Zm12 5a3 3 0 1 0-2.83-4A3 3 0 0 0 18 20ZM8.6 13.7l6.8-3.4M8.6 16.3l6.8 3.4",
+    reroute:
+      "M16 3h5v5M4 20l6.5-6.5a4 4 0 0 1 5.7 0L21 18M21 3l-6.5 6.5M4 4l5 5",
+    ticket:
+      "M3 7a2 2 0 0 0 2-2h14a2 2 0 0 0 2 2v2a3 3 0 0 0 0 6v2a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-2a3 3 0 0 0 0-6V7Zm9-2v14",
+  }[name];
+
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.7"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d={path} />
+    </svg>
+  );
 }
 
 function progressFor(
@@ -59,6 +104,7 @@ export function LiveDay({
   const router = useRouter();
   const [now, setNow] = useState(() => Date.now());
   const [route, setRoute] = useState<NavRoute | null>(null);
+  const [routeRefresh, setRouteRefresh] = useState(0);
   const [optimisticProgress, setOptimisticProgress] = useState<{
     anchorId: string;
     state: TransitionProgressState;
@@ -76,7 +122,8 @@ export function LiveDay({
   const operationalAnchors = useMemo(() => {
     if (!anchors.length || !base) return anchors;
     const first = anchors[0];
-    if (first.role === "stop" && samePoint(first.coord, base)) return anchors.slice(1);
+    if (first.role === "stop" && samePoint(first.coord, base))
+      return anchors.slice(1);
     return anchors;
   }, [anchors, base]);
 
@@ -89,15 +136,21 @@ export function LiveDay({
         plannedTravelMinutes: anchor.plannedTravelMinutes,
         isStation: !!anchor.station,
         bufferMinutes: anchor.bufferMinutes,
-        notBeforeMs: anchor.notBeforeIso ? Date.parse(anchor.notBeforeIso) : null,
+        notBeforeMs: anchor.notBeforeIso
+          ? Date.parse(anchor.notBeforeIso)
+          : null,
         isBlockingSpan: anchor.type === "shift",
       })),
     [operationalAnchors],
   );
 
   const preliminary = computeDayState({ anchors: engineAnchors, nowMs: now });
-  const next = preliminary.nextIndex != null ? operationalAnchors[preliminary.nextIndex] : null;
-  const isScheduledOutcome = next?.role === "arrival" || next?.role === "changeover";
+  const next =
+    preliminary.nextIndex != null
+      ? operationalAnchors[preliminary.nextIndex]
+      : null;
+  const isScheduledOutcome =
+    next?.role === "arrival" || next?.role === "changeover";
   const progress = progressFor(next, optimisticProgress);
   const isOnWay = !isScheduledOutcome && progress === "live";
   const isArrived = !isScheduledOutcome && progress === "done";
@@ -117,23 +170,57 @@ export function LiveDay({
     setRoute(null);
     if (!origin || !next?.coord || isArrived || isScheduledOutcome) return;
     let active = true;
-    void fetchNavRoute({ origin, destination: { ...next.coord, name: next.title }, mode }).then((result) => {
+    void fetchNavRoute({
+      origin,
+      destination: { ...next.coord, name: next.title },
+      mode,
+    }).then((result) => {
       if (active && result.ok) setRoute(result.value);
     });
     return () => {
       active = false;
     };
-  }, [origin?.lat, origin?.lng, next?.id, next?.coord?.lat, next?.coord?.lng, next?.title, mode, isArrived, isScheduledOutcome]);
+  }, [
+    origin?.lat,
+    origin?.lng,
+    next?.id,
+    next?.coord?.lat,
+    next?.coord?.lng,
+    next?.title,
+    mode,
+    isArrived,
+    isScheduledOutcome,
+    routeRefresh,
+  ]);
 
   useEffect(() => {
-    if (isScheduledOutcome || !next?.coord || !next.inboundTransitionId || !fix || !isOnWay) return;
-    const distance = haversineMeters(fix.lat, fix.lng, next.coord.lat, next.coord.lng);
+    if (
+      isScheduledOutcome ||
+      !next?.coord ||
+      !next.inboundTransitionId ||
+      !fix ||
+      !isOnWay
+    )
+      return;
+    const distance = haversineMeters(
+      fix.lat,
+      fix.lng,
+      next.coord.lat,
+      next.coord.lng,
+    );
     const arrivalRadius = Math.max(45, fix.accuracy * 1.5);
-    if (distance > arrivalRadius || arrivalCommit.current === next.inboundTransitionId) return;
+    if (
+      distance > arrivalRadius ||
+      arrivalCommit.current === next.inboundTransitionId
+    )
+      return;
 
     arrivalCommit.current = next.inboundTransitionId;
     setOptimisticProgress({ anchorId: next.id, state: "done" });
-    void setLiveTransitionProgress({ transitionId: next.inboundTransitionId, state: "done" }).then((result) => {
+    void setLiveTransitionProgress({
+      transitionId: next.inboundTransitionId,
+      state: "done",
+    }).then((result) => {
       if (!result.ok) {
         arrivalCommit.current = null;
         setOptimisticProgress({ anchorId: next.id, state: "live" });
@@ -142,7 +229,16 @@ export function LiveDay({
       }
       router.refresh();
     });
-  }, [fix, isOnWay, isScheduledOutcome, next?.id, next?.coord?.lat, next?.coord?.lng, next?.inboundTransitionId, router]);
+  }, [
+    fix,
+    isOnWay,
+    isScheduledOutcome,
+    next?.id,
+    next?.coord?.lat,
+    next?.coord?.lng,
+    next?.inboundTransitionId,
+    router,
+  ]);
 
   useEffect(() => {
     arrivalCommit.current = null;
@@ -153,13 +249,16 @@ export function LiveDay({
   const state = computeDayState({
     anchors: engineAnchors,
     nowMs: now,
-    liveTravelSeconds: !isScheduledOutcome ? route?.duration_s ?? null : null,
+    liveTravelSeconds: !isScheduledOutcome ? (route?.duration_s ?? null) : null,
   });
 
   if (!next) {
     return (
       <section className="cc-active-tile" data-urgency="comfortable">
-        <span className="cc-at-status"><span className="cc-at-dot" />All done</span>
+        <span className="cc-at-status">
+          <span className="cc-at-dot" />
+          All done
+        </span>
         <h2 className="cc-at-headline">That’s your travel day</h2>
         {sub ? <p className="cc-at-sub">{sub}</p> : null}
       </section>
@@ -169,14 +268,29 @@ export function LiveDay({
   const feas = state.feasibility;
   const target = next.station?.name ?? next.title;
   const etaMs = route ? now + route.duration_s * 1000 : null;
-  const setOffClock = !isOnWay && !isArrived && !isScheduledOutcome && feas && feas.band !== "cliff" ? HHMM(feas.leaveByMs) : null;
-  const arrivedFigure = next.station && next.role === "departure" && next.arriveByIso
-    ? londonClock(next.arriveByIso)
-    : londonClock(next.actualArrivedAt) ?? HHMM(now);
+  const setOffClock =
+    !isOnWay &&
+    !isArrived &&
+    !isScheduledOutcome &&
+    feas &&
+    feas.band !== "cliff"
+      ? HHMM(feas.leaveByMs)
+      : null;
+  const arrivedFigure =
+    next.station && next.role === "departure" && next.arriveByIso
+      ? londonClock(next.arriveByIso)
+      : (londonClock(next.actualArrivedAt) ?? HHMM(now));
 
-  const scheduledStartMs = next.arriveByIso ? Date.parse(next.arriveByIso) : null;
-  const changeHasArrived = next.role === "changeover" && scheduledStartMs != null && now >= scheduledStartMs;
-  const scheduledFigure = changeHasArrived ? londonClock(next.endIso) : londonClock(next.arriveByIso);
+  const scheduledStartMs = next.arriveByIso
+    ? Date.parse(next.arriveByIso)
+    : null;
+  const changeHasArrived =
+    next.role === "changeover" &&
+    scheduledStartMs != null &&
+    now >= scheduledStartMs;
+  const scheduledFigure = changeHasArrived
+    ? londonClock(next.endIso)
+    : londonClock(next.arriveByIso);
   const figure = isScheduledOutcome
     ? scheduledFigure
     : isArrived
@@ -186,26 +300,33 @@ export function LiveDay({
         : setOffClock;
   const parts = figure?.split(":") ?? null;
   const arriveByMs = next.arriveByIso ? Date.parse(next.arriveByIso) : null;
-  const routeArrivalMs = arriveByMs != null && feas ? arriveByMs - feas.bufferMinutes * 60_000 : arriveByMs;
+  const routeArrivalMs =
+    arriveByMs != null && feas
+      ? arriveByMs - feas.bufferMinutes * 60_000
+      : arriveByMs;
   const arrivalLabel = routeArrivalMs != null ? HHMM(routeArrivalMs) : null;
   const constrainedLabel =
-    !isOnWay && !isArrived && !isScheduledOutcome && feas?.constrainedByPrevious && next.notBeforeIso
+    !isOnWay &&
+    !isArrived &&
+    !isScheduledOutcome &&
+    feas?.constrainedByPrevious &&
+    next.notBeforeIso
       ? `Your shift ends at ${londonClock(next.notBeforeIso)}`
       : null;
 
-  async function startJourney() {
-    if (!next?.inboundTransitionId || isScheduledOutcome) return;
-    const transitionId = next.inboundTransitionId;
-    const anchorId = next.id;
-    setProgressError(null);
-    setOptimisticProgress({ anchorId, state: "live" });
-    const result = await setLiveTransitionProgress({ transitionId, state: "live" });
-    if (!result.ok) {
-      setOptimisticProgress(null);
-      setProgressError(result.error);
+  async function shareTrip() {
+    const url = window.location.href;
+    if (navigator.share) {
+      await navigator
+        .share({
+          title: "My Khonsera travel day",
+          text: `Follow my next move to ${target}.`,
+          url,
+        })
+        .catch(() => undefined);
       return;
     }
-    router.refresh();
+    await navigator.clipboard?.writeText(url);
   }
 
   const kicker = isScheduledOutcome
@@ -236,55 +357,155 @@ export function LiveDay({
     : next.role === "changeover"
       ? `${londonClock(next.arriveByIso)} arrival · ${Math.max(0, Math.round(((next.endIso ? Date.parse(next.endIso) : 0) - (next.arriveByIso ? Date.parse(next.arriveByIso) : 0)) / 60_000))} min to change`
       : `Scheduled arrival at ${target}`;
+  const isPreparing =
+    !isOnWay && !isArrived && !isScheduledOutcome && feas != null;
+  const countdownLabel =
+    feas && isPreparing && feas.band !== "cliff" && feas.band !== "leave_now"
+      ? compactDuration(feas.slackMin)
+      : null;
+  const countdownOffset = isPreparing
+    ? 244 - Math.min(1, Math.max(0, feas?.slackMin ?? 0) / 120) * 244
+    : 244;
+  const movementCopy = isScheduledOutcome
+    ? scheduledCopy
+    : isArrived
+      ? next.station && next.role === "departure"
+        ? `${target} · you’re ready for the ${londonClock(next.arriveByIso)} service`
+        : `You’ve reached ${target}`
+      : isOnWay
+        ? `${route ? Math.max(1, Math.round(route.duration_s / 60)) : (feas?.travelMinutes ?? "—")} min remaining`
+        : instruction(feas);
 
   return (
-    <section className="cc-active-tile cc-setoff" data-urgency={isArrived || isScheduledOutcome ? "comfortable" : urgencyOf(feas)}>
-      <span className="cc-at-status"><span className="cc-at-dot" />{status}</span>
+    <section
+      className="cc-active-tile cc-setoff"
+      data-urgency={
+        isArrived || isScheduledOutcome ? "comfortable" : urgencyOf(feas)
+      }
+    >
+      <span className="cc-at-status">
+        <span className="cc-at-dot" />
+        {status}
+      </span>
 
       <div className="pg cc-setoff-sheet">
         <div className="cc-setoff-eyb">
           <span className="cc-setoff-kicker">{kicker}</span>
-          <span className="cc-setoff-for">{isArrived ? `at ${target}` : `for ${target}`}</span>
+          <span className="cc-setoff-for">
+            {isArrived ? `at ${target}` : `for ${target}`}
+          </span>
         </div>
-        {parts ? (
-          <div className="mono engr-deep cc-setoff-figure" aria-label={`${kicker} ${figure}`}>
-            <span>{parts[0]}</span><span className="cc-setoff-colon">:</span><span>{parts[1]}</span>
+        <div className="cc-setoff-core">
+          {parts ? (
+            <div
+              className="mono cc-setoff-figure"
+              aria-label={`${kicker} ${figure}`}
+            >
+              <span>{parts[0]}</span>
+              <span className="cc-setoff-colon">:</span>
+              <span>{parts[1]}</span>
+            </div>
+          ) : (
+            <div className="cc-setoff-figure cc-setoff-figure--word">Now</div>
+          )}
+          {countdownLabel ? (
+            <div
+              className="cc-leave-ring"
+              aria-label={`Leave in ${countdownLabel}`}
+            >
+              <svg viewBox="0 0 100 100" aria-hidden>
+                <circle
+                  className="cc-leave-ring-track"
+                  cx="50"
+                  cy="50"
+                  r="39"
+                />
+                <circle
+                  className="cc-leave-ring-progress"
+                  cx="50"
+                  cy="50"
+                  r="39"
+                  style={{ strokeDashoffset: countdownOffset }}
+                />
+              </svg>
+              <span>
+                Leave in<strong>{countdownLabel}</strong>
+              </span>
+            </div>
+          ) : null}
+        </div>
+        {isPreparing ? (
+          <div className="cc-next-facts">
+            <span>
+              {feas.travelMinutes} min {mode === "drive" ? "by car" : mode}
+            </span>
+            {arrivalLabel ? <span>Arrive by {arrivalLabel}</span> : null}
+            {feas.bufferMinutes > 0 ? (
+              <span>{feas.bufferMinutes} min early</span>
+            ) : null}
           </div>
-        ) : (
-          <div className="mono engr-deep cc-setoff-figure cc-setoff-figure--word">Now</div>
-        )}
-        <p className="cc-setoff-move">
-          {isScheduledOutcome
-            ? scheduledCopy
-            : isArrived
-              ? next.station && next.role === "departure"
-                ? `${target} · you’re ready for the ${londonClock(next.arriveByIso)} service`
-                : `You’ve reached ${target}`
-              : isOnWay
-                ? `${route ? Math.max(1, Math.round(route.duration_s / 60)) : feas?.travelMinutes ?? "—"} min remaining`
-                : `${instruction(feas)} · ${feas ? `${feas.travelMinutes} min ${mode === "drive" ? "by car" : mode}` : "route pending"}`}
-          {!isOnWay && !isArrived && !isScheduledOutcome && arrivalLabel ? ` · arrive by ${arrivalLabel}` : ""}
-          {!isOnWay && !isArrived && !isScheduledOutcome && feas?.bufferMinutes ? ` · ${feas.bufferMinutes} min early` : ""}
-        </p>
-        {constrainedLabel ? <p className="cc-setoff-move">{constrainedLabel}; the preferred {feas?.preferredBufferMinutes ?? 0}-minute margin will reduce to {feas?.bufferMinutes ?? 0} minutes.</p> : null}
+        ) : null}
+        <p className="cc-setoff-move">{movementCopy}</p>
+        {constrainedLabel ? (
+          <p className="cc-setoff-move">
+            {constrainedLabel}; the preferred{" "}
+            {feas?.preferredBufferMinutes ?? 0}-minute margin will reduce to{" "}
+            {feas?.bufferMinutes ?? 0} minutes.
+          </p>
+        ) : null}
       </div>
 
       {next.pass?.ticket.legs[0]?.barcodes?.length ? (
-        <p style={{ margin: 0, fontSize: "var(--fs-label)", color: "var(--ink-dim)" }}>
+        <p
+          style={{
+            margin: 0,
+            fontSize: "var(--fs-label)",
+            color: "var(--ink-dim)",
+          }}
+        >
           Your ticket is ready on the journey below.
         </p>
       ) : null}
 
-      {!isOnWay && !isArrived && !isScheduledOutcome && next.inboundTransitionId ? (
+      <div className="cc-next-actions">
         <button
           type="button"
-          className="cc-btn cc-btn-gold"
-          disabled={!route}
-          onClick={() => void startJourney()}
+          className="cc-next-action cc-next-action--primary"
+          onClick={() => router.push("/navigate")}
         >
-          {route ? "I’m on my way" : "Finding route…"}
+          <span>View best route</span>
+          <NextActionIcon name="arrow" />
         </button>
-      ) : null}
+        <button
+          type="button"
+          className="cc-next-action"
+          onClick={() => void shareTrip()}
+        >
+          <NextActionIcon name="share" />
+          <span>Share trip</span>
+        </button>
+        <button
+          type="button"
+          className="cc-next-action"
+          disabled={!origin || !next.coord}
+          onClick={() => {
+            setRoute(null);
+            setRouteRefresh((value) => value + 1);
+          }}
+        >
+          <NextActionIcon name="reroute" />
+          <span>Re-route</span>
+        </button>
+        <button
+          type="button"
+          className="cc-next-action"
+          onClick={() => router.push("/wallet")}
+        >
+          <NextActionIcon name="ticket" />
+          <span>Tickets</span>
+        </button>
+      </div>
+
       {progressError ? <p className="cc-sheet-error">{progressError}</p> : null}
     </section>
   );

--- a/src/components/today/today-direction-layout.test.ts
+++ b/src/components/today/today-direction-layout.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const todayPage = readFileSync(
+  new URL("../../app/(app)/today/page.tsx", import.meta.url),
+  "utf8",
+);
+const liveDay = readFileSync(
+  new URL("./live-day.tsx", import.meta.url),
+  "utf8",
+);
+const appLayout = readFileSync(
+  new URL("../../app/(app)/layout.tsx", import.meta.url),
+  "utf8",
+);
+const directionCss = readFileSync(
+  new URL("../../app/khonsera-today-direction.css", import.meta.url),
+  "utf8",
+);
+
+describe("the approved Today application direction", () => {
+  it("keeps the next move and route map inside one dominant command surface", () => {
+    const command = todayPage.indexOf('className="cc-today-command"');
+    const map = todayPage.indexOf('className="cc-today-command-map"');
+    const forecast = todayPage.indexOf('className="cc-day-forecast"');
+    const itinerary = todayPage.indexOf('className="cc-day-primary"');
+
+    expect(command).toBeGreaterThan(-1);
+    expect(map).toBeGreaterThan(command);
+    expect(forecast).toBeGreaterThan(map);
+    expect(itinerary).toBeGreaterThan(forecast);
+  });
+
+  it("retains the four approved next-move actions", () => {
+    expect(liveDay).toContain("View best route");
+    expect(liveDay).toContain("Share trip");
+    expect(liveDay).toContain("Re-route");
+    expect(liveDay).toContain("Tickets");
+  });
+
+  it("uses unified chrome instead of the retired permanent desktop rail", () => {
+    expect(appLayout).toContain("khonsera-app--unified");
+    expect(appLayout).not.toContain("AppSidebar");
+    expect(appLayout).not.toContain("cc-app-desktop");
+  });
+
+  it("styles the itinerary as one continuous object", () => {
+    expect(directionCss).toContain(".cc-today-direction .cc-spine {");
+    expect(directionCss).toContain("border-radius: 22px");
+    expect(directionCss).toContain(".cc-today-command-map");
+  });
+});


### PR DESCRIPTION
## Outcome

Applies the supplied July 2026 Today mock to the actual Khonsera application rather than leaving it as a separate design-system prototype.

## What changed

- Replaces the split mobile/desktop shell and permanent desktop rail with one responsive Khonsera chrome: wordmark, create/overflow utilities and the five-destination bottom navigation.
- Rebuilds `/today` around the approved hierarchy: day purpose and destination, one dominant live next-move/map surface, compact conditions, one continuous itinerary, then contextual ticket/planning exits.
- Keeps the existing Supabase-backed Today projection and live route engine intact.
- Adds working best-route, share, re-route and ticket actions to the next-move surface.
- Flattens populated movement, transfer and rail-pass entries into one composed itinerary object while preserving live platform/status and ticket behaviour.
- Adds responsive rules for wide, compact and phone layouts plus a direction regression test.

## Why

The previous work encoded the mock as a standalone HTML direction inside the uploaded design-system package. That did not upgrade the product. This PR applies the direction to the repository and active Vercel application layer.

## Data impact

No Supabase schema, data, auth, migration or RLS changes.

## Validation

- Prettier parsed and formatted every changed TSX/CSS file.
- esbuild parsed all changed TSX entry points successfully.
- `today-direction-layout.test.ts`: 4/4 tests passed locally.
- Full Next.js/Vitest/Vercel preview checks pending the connected CI deployment.