### PR TITLE
Implement Screen One Today design

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,24 +18,30 @@ if a utility is wanted), never a one-off hardcode. Tokens never fork. (Legacy in
 migrated to tokens incrementally per-component, not in a big sweep — see the manifest's migration
 status.)
 
-### Current visual authority — Instrument Edition v8 (2026-07-28)
+### Current visual authority — Instrument Edition v8 + Today Screen One (2026-07-28)
 
 The approved source is **Khonsera Design System 9**, implemented in
 `src/app/khonsera-instrument-tokens.css` and the final application layer
 `src/app/khonsera-instrument.css`. These load after the historical edition CSS and therefore define
-the effective UI. Keep the existing data/action contracts; evolve presentation through this layer.
+the effective UI. **The uploaded Screen One reference is the newer, route-specific authority for
+`/today`**, implemented last in `src/app/khonsera-screen-one.css`. Keep the existing data/action
+contracts; evolve presentation through these final layers.
 
 - Neutral stone ground, flat white cards, cool high-contrast ink, hairline structure and quiet
   single-direction elevation.
-- Signal green is the interaction accent. Rail orange is line identity only.
+- Signal green remains the general interaction accent. On `/today`, Screen One intentionally uses
+  rail orange for the brand dot, live markers and single primary actions; the selectors are scoped
+  to the Today composition and must not recolour other product surfaces.
 - Satoshi carries display/UI/body; JetBrains Mono carries time, codes, eyebrows and technical
   status. No serif or literary italic.
 - Identity is the uppercase Satoshi wordmark plus one signal-green dot. The moon/pictorial emblem,
   paper grain, letterpress and deboss effects are retired from app chrome.
 - Mobile is one calm chronological column with 44px minimum targets and persistent app/tab bars.
-  Desktop uses the 248px rail, a bounded primary day column, and a sticky context/tool column.
-- `/today` orders conditions → live day/spine → map/documents/tools on mobile and becomes a
-  primary-plus-context command desk at 1360px. `/plan/[id]` uses the same primary/context split.
+  `/today` remains one bounded 760px column at every width; other desktop application surfaces use
+  the Instrument shell rules.
+- `/today` orders compact context → next move → six-hour conditions → itinerary → wallet/planning
+  exits. The former route map is retired from Today: `View best route` opens route detail and the
+  interactive journey map remains on `/plan/[id]`.
 - Historical spine selectors are not safe on the instrument surfaces:
   `TodaySpine` must not regain `.cc-spine-v7`, whose legacy 42px grid column collapses populated
   cards. Instrument node placement is guarded by `.khonsera-app .cc-spine .cc-node`; Plan groups a
@@ -52,12 +58,20 @@ the effective UI. Keep the existing data/action contracts; evolve presentation t
   arrival milestones; do not repeat adjacent station anchors that describe the same points. Keep
   genuine changeovers as compact transfer rows. Docked rail passes use the compact semantic
   `cc-pass-*` structure, preserving route, times and status while hiding secondary fields.
+  Today passes additionally use the `today`/`.cc-pass--today` operational face.
 - Inline **Add here** affordances belong after real commitment anchors, not between the departure,
   changeover and arrival records of a transport run. Today has one page header only: date eyebrow,
   day purpose, and origin; do not reintroduce a second title block inside the primary column.
 - Mobile `/plan/[id]` keeps the route map and bookings visible, but groups budget, sharing,
   constraints and intake behind **Day tools**. On desktop that body is always visible. `/today`
-  offers a focused add/open-planner handoff rather than duplicating the full intake toolkit.
+  offers one contextual `Plan something` action rather than duplicating the full intake toolkit.
+- The Screen One “Keep N-min margin” switch persists
+  `travel_profiles.default_arrival_buffer_minutes` through the existing `updateTravelProfile`
+  action. It changes Today station leave-by calculations; it is not a decorative toggle.
+- `src/app/__design/today/page.tsx` is the sample-data responsive harness for Screen One. It renders
+  the real `LiveDay`, active `TodaySpine` alias and `LivePass`, disables only the end-bookend lookup,
+  and returns 404 when `VERCEL_ENV=production`. Use its preview deployment for the required 390px /
+  1440px overflow check without exposing a user itinerary.
 - The uploaded source has a duplicated light selector that accidentally repeats night accent values;
   the imported `khonsera-instrument-tokens.css` removes that duplicate and keeps the earlier
   canonical light signal-green tokens.

--- a/docs/component-contract.md
+++ b/docs/component-contract.md
@@ -9,13 +9,15 @@ Each entry: **Data** (what it shows) · **States** (what Design must draw). Mobi
 ---
 
 ### ActiveTile — the day-of focal point (Today's hero)
+
 **Data:** a status word + dot (urgency), the headline of what matters now, the next `AnchorCard`
 target (+ time), the next `LegCard` summary, and (pre-departure) a leave-by figure.
 **States:** `dormant` (calm/near-empty), `readiness` (leave-by countdown), `in-transit` (live leg),
 `arrived` (current anchor + what's next). Urgency overlay: `comfortable` · `urgent` · `breach`
-(breach dot pulses). Layout is fixed across states — only the dot + words change. *(See `today.md`.)*
+(breach dot pulses). Layout is fixed across states — only the dot + words change. _(See `today.md`.)_
 
 ### AnchorCard — a fixed point on the spine
+
 **Data:** type (`appointment | reservation | accommodation_check_in | accommodation_check_out |
 transport_arrival | flight | custom`), title, place, and the **three-variable model**:
 **arrive-by · duration · leave-by** — set any two, the third is **derived**.
@@ -24,6 +26,7 @@ transport_arrival | flight | custom`), title, place, and the **three-variable mo
 (computed, effortless, not directly editable). Fuzzy values **harden** as legs are chosen.
 
 ### LegCard — the travel between two anchors
+
 **Data:** mode / mode-mix with optional **first-mile/last-mile** sub-legs (walk→train→taxi); the
 **door-to-door total time** (the headline + the only rank key); cost; departure/arrival; structural
 pattern (`Direct | Drop-and-go | Hub-to-hub`); booking status.
@@ -31,32 +34,38 @@ pattern (`Direct | Drop-and-go | Hub-to-hub`); booking status.
 `chosen/booked` · `at-risk` (tight connection / downstream conflict).
 
 ### GapCard — unallocated time between anchors
+
 **Data:** type (`transport_gap | accommodation_gap | unplanned_time | care_gap`), the two endpoints,
 a binary-reveal prompt, and (for free time) a **bounded** "you have until 16:10 here".
 **States:** `open` (needs input) · `watching` · `resolved` · `dismissed`.
 
 ### IntentionCard — a soft goal, beside the spine (proposal, never auto-inserted)
+
 **Data:** description ("see the museum"), optional target, buffer, back-calculated leave-by.
 **States:** `soft` vs `promoted_to_hard`; `active` vs `toggled_off` (dimmed); reads **provisional/
 dismissable**, clearly different from committed anchors.
 
 ### ComparisonMatrix — the transport decision layer (opens on tapping a leg)
+
 **Data:** the **top 4 fastest viable** options ranked by **door-to-door total** (+ "show all"); each
 shows door-to-door time (rank key), mode-mix/sub-legs, cost, departure+arrival. **Speed ranks;
 exclusions filter** (an exclusion removes options, never down-ranks). **Train booking-pair:** outbound
-+ return as one unit, chevron between halves, a live **consequence band** ("this return → leave the
-museum by 16:10").
-**States:** `open` (a focused **sheet/overlay** on mobile, not a wide table) · one `selected`
-(hardens fuzzy values) · `empty` (no viable options).
+
+- return as one unit, chevron between halves, a live **consequence band** ("this return → leave the
+  museum by 16:10").
+  **States:** `open` (a focused **sheet/overlay** on mobile, not a wide table) · one `selected`
+  (hardens fuzzy values) · `empty` (no viable options).
 
 ### JourneyListCard — one Event in the Plan index `.cc-journey-card`
+
 **Data:** title, mode, **span** (single date, or range + "N days"), stop count, open-gap count,
 status. **States:** list · archive (dimmed) · empty. Now `.cc-*`-styled (the one list component that
 hadn't had an Edition II pass) and links into the **Event detail** (`/plan/[id]`), not legacy.
-**Distinct from `TicketCard`:** JourneyListCard summarises a *whole Event*; a TicketCard is *one
-booked document* within it. **DESIGN-PENDING** — queued for a round with the rest of §Plan surfaces.
+**Distinct from `TicketCard`:** JourneyListCard summarises a _whole Event_; a TicketCard is _one
+booked document_ within it. **DESIGN-PENDING** — queued for a round with the rest of §Plan surfaces.
 
 ### Plan surfaces — Code floor, DESIGN-PENDING (proposal "events-by-day")
+
 New compositions styled by `.cc-*` + tokens as a functional floor, **awaiting a Design round**:
 `.cc-plan-group`/`.cc-plan-list` (index day-groups, Wallet-mirrored) · `.cc-plan-new` + the new-Event
 `.cc-sheet` (start date + optional name) · `.cc-plan-empty` · `.cc-event-head`/`.cc-event-back` (the
@@ -71,6 +80,7 @@ A chosen leg/anchor resolves into one or more booked documents. These four are t
 members the Wallet (§7) and Today (§8) reuse — **no further new components for either surface.**
 
 ### TicketCard — a booked travel document
+
 **Data:** `kind` (`rail | air | stay | ground`); operator(s); reference; price; `source` (synced ·
 manual · forwarded · inbox · affiliate · wallet · ocr — governs trust + pre-fill + live refresh);
 per journey **place+time pair(s)** with platform/gate/terminal; **changes** (each connection's
@@ -83,18 +93,21 @@ stepped by a chevron with a live **consequence band** ("this return → leave th
 **full** (open). `data-kind` per mode. Plus the leg `StatusStrip` states below.
 
 ### StatusStrip — the live status line
+
 **Data:** `status` (`on_time · delayed · platform_change · gate_change · boarding · cancelled ·
 stale`), optional detail ("+18 min" · "Platform 4 → 1"), `offline` (stale marker — last-known shown
 at the barrier without signal). **States:** the seven statuses (each visually distinct; only
 `cancelled`/`delayed` earn warmth, never alarm-red throughout) · `offline`/stale.
 
 ### BarcodePresenter — the scannable code
+
 **Data:** `format` (`aztec` rail · `pdf417`/`qr` air · `qr` transit), payload value, optional
-passenger label. **The code *is* the ticket** — Design owns the **frame** (quiet zone preserved,
+passenger label. **The code _is_ the ticket** — Design owns the **frame** (quiet zone preserved,
 high contrast, **nothing overlaid on the code**), Code injects the symbology pixels at wire-up.
 **States:** `data-size` = inline (in a TicketCard) · scan (fullscreen). Per-format framing.
 
 ### ScanView — fullscreen presentation at the barrier
+
 **Data:** a one-line journey summary (for the guard), the barcode(s), a swipeable **stack for
 multiple passengers**. **THE function-over-finish exception (§6.3):** code large + centred,
 **brightness maxed**, minimal chrome — Design must **not** elevate it into something that won't
@@ -105,6 +118,7 @@ scan. **States:** single · multi-passenger (pager) · per-format.
 > at the barrier has failed.
 
 ### Pass — the first-class wallet rendering (Round 5b) — `concierge/pass.tsx`
+
 **Not a new contract member — a richer presentation of a booked document** (same `TicketVM`; reuses
 `StatusStrip` + `BarcodePresenter`). The materially-real issued ticket: operator band + kind seam,
 the big time-pair, a drawn connector, perforation + barcode stub. `Pass` (full, next-needed) +
@@ -112,25 +126,34 @@ the big time-pair, a drawn connector, perforation + barcode stub. `Pass` (full, 
 booked (`.cc-pass--docked`: tighter, barcode → a quiet "Ticket ready" line; a return is a second
 docked pass downstream, not a stack — the timeline carries order). The Wallet uses `Pass`; the
 compact `TicketCard` remains for non-stacked list contexts (e.g. Today's single promoted document).
+On the production Today spine, `today` adds the Screen One operational face
+(`.cc-pass--today`): departure + live status/platform lead, route identity stays prominent, and the
+stub reduces to departs/platform/arrives. It is still the same `TicketVM` and live status source.
 
 ### ModeSwitch — Work/Personal
+
 **Data:** `work | personal`. A **toggle, not a tab**; persisted; reachable from the shell.
 
 ### ContactChip — a person
+
 **Data:** name, channel (`phone | email | whatsapp`). **States:** bound (real contact) · unbound.
 
 ### TaskRow — a to-do
+
 **Data:** title, optional due, done. **States:** open · done (struck-through). Date-bearing tasks
 surface on that day.
 
 ### ExpenseRow — a spend line
+
 **Data:** amount + currency, category, date.
 
 ### NudgeCard — a proactive intervention (the raised voice)
+
 **Data:** an **intervention** message ("leave 10 minutes earlier"), optional action. Never a raw data
 widget. **States:** dismissible. **Earns prominence by being rare** — gold/accent reserved for it.
 
 ### ReadinessPrompt — pre-departure prep / back-calculation
+
 **Data:** leave-by, derived wake/prepare time, the routine steps. One orchestrated prompt, not
 scattered sums.
 
@@ -138,11 +161,12 @@ scattered sums.
 
 ## Deviation & care layer (Edition III P9–P13) — live on `/plan/[id]` + `/today`
 
-*The components that appear when the day deviates from plan or needs looking after. Round 7 brand-passed
+_The components that appear when the day deviates from plan or needs looking after. Round 7 brand-passed
 the live-spine set (✓ skinned); the recovery + nudge set is the **Round 8** request (🟡 to skin). Full
-brief, contract classes, states and preview steps live in `docs/design-handoff-edition-iii.md`.*
+brief, contract classes, states and preview steps live in `docs/design-handoff-edition-iii.md`._
 
 ### Live-spine set (P9–P10) — ✓ Round 7 skinned
+
 **Decision-clock** (`.cc-decision-clock` · `.label/.figure/.for`) — the day's single "set off by HH:MM".
 **Live-alert** (per-leg, rail + TfL) — live status + the engine **consequence** ("you'll miss the 09:40,
 act by 09:27"); minor=gold, severe=rust. **Fragility** (`.cc-fragility`) — "tight plan, one delay and it
@@ -150,6 +174,7 @@ breaks". **Day-ripple** (`.cc-day-ripple`) — the whole-day knock-on. **Today d
 (`.cc-today-disruption`, `cc-screen[data-disrupted]`) — the day's character shifting to disruption.
 
 ### RecoveryCard — the way out (P11) · 🟡 Round 8
+
 `plan/recovery-card.tsx`, `.cc-recovery` (+ `-head/-eyebrow/-note/-list/-opt/-label/-conseq/-return/-via`).
 **Data:** beneath a cancelled/severely-delayed booked train — each viable alternative + its consequence
 ("makes your 2pm, 12 min spare" / "reaches it 18 min late"); the booked-return impact (`-return`, rust);
@@ -157,6 +182,7 @@ an OTP detour note (`-via`, "via Coventry · 1 change"). **States:** per-option 
 (true reassures/sage, false stays quiet — never red); `data-return=at-risk`; the `· sample` honesty cue.
 
 ### PlanNudges / NudgeCard — contextual care (P12–P13) · 🟡 Round 8
+
 `plan/plan-nudges.tsx` wrapping the `NudgeCard` (above). Six rules render through **two states**:
 **open** (`NudgeCard`, gold-tint) — one calm proposal + action + "Not now" (weather→leave-earlier,
 running-late→fast-track, layover→lounge, parking→pre-book, gate-change→reroute); **accepted**
@@ -164,9 +190,10 @@ running-late→fast-track, layover→lounge, parking→pre-book, gate-change→r
 foresight (ahead-of-time, unhurried) vs reaction (moment-of, a touch more weight); once acted, it settles.
 
 ### Connections surface (ED-Flight / ED-Stay) — search / compare / book / manage · 🟡 Rounds 11–12
-*The "buy + service without leaving Khonsera" surface on `/plan/[id]`. Three SEPARATE flows (the old
-Flights|Stays toggle was retired) sharing the `.cc-conn*` shell from Round 9. Full briefs + contract
-classes in `docs/design-handoff-edition-iii.md` (Rounds 11, 12, + manage-booking).*
+
+_The "buy + service without leaving Khonsera" surface on `/plan/[id]`. Three SEPARATE flows (the old
+Flights|Stays toggle was retired) sharing the `.cc-conn_`shell from Round 9. Full briefs + contract
+classes in`docs/design-handoff-edition-iii.md` (Rounds 11, 12, + manage-booking).\*
 
 - **FlightFinder** 🟡 R11 — `plan/flight-finder.tsx`. Trip-type (`.cc-conn-triptype`) → search
   (`.cc-conn-field--airport` autocomplete incl. city/all-airports, return/pax/cabin) → compare
@@ -187,6 +214,7 @@ classes in `docs/design-handoff-edition-iii.md` (Rounds 11, 12, + manage-booking
 ---
 
 ### Ledger & teams (P15 mileage · P16 budget · P17 approvals) · 🟡 Ledger pack
+
 - **Mileage** (`/mileage`) — `DriveRecorder` (`.cc-mileage-rec`) + `MileageLedger` (`.cc-mileage*`):
   claimable-£ summary + CSV, trips with a Business|Personal toggle (`-trip[data-class]`), purpose-needed
   flag, manual add.
@@ -200,6 +228,7 @@ classes in `docs/design-handoff-edition-iii.md` (Rounds 11, 12, + manage-booking
 ---
 
 ## Cross-cutting rules
+
 - **Tokens only** (`design-tokens.md`); no raw hex/px in components.
 - **Calm by default;** gold/accent is punctuation — the single live "now" pulse or the one action.
 - **No emojis.** Copy is voiced as **Khonsera** (never a human name).

--- a/docs/design-tokens.md
+++ b/docs/design-tokens.md
@@ -79,6 +79,9 @@ Weights: `--fw-regular` 400 · `--fw-medium` 500 · `--fw-semibold` 600. Trackin
 · `--space-3` 12 · `--space-3-5` 14 · `--space-4` 16 · `--space-4-5` 18 · `--space-5` 20 · `--space-6` 24 · `--space-8`
 32 · `--space-12` 48. (Tailwind's numeric `gap-2`/`p-3`… already resolve to these px values.)
 
+`--today-column-max` 760 bounds the approved single-column Today composition on wide screens while
+allowing it to fill the mobile viewport.
+
 ## Radius scale
 
 Instrument tokens: `--radius-xs` 7 · `--radius-sm` 10 · `--radius-md` 14 ·

--- a/docs/process/screen-specs/today.md
+++ b/docs/process/screen-specs/today.md
@@ -1,13 +1,13 @@
 # SCREEN SPEC — TODAY / LIVE
 
-*For Design. Destination: `screen-specs/today.md` inside `for-design.zip`.*
-*Output target: 4 states × 3 sizes = 12 artboards.*
+_For Design. Destination: `screen-specs/today.md` inside `for-design.zip`._
+_Output target: 4 states × 3 sizes = 12 artboards._
 
 ## Purpose
 
 The live, in-the-moment view. **Not a dashboard you configure** — it morphs automatically
 through states driven by time and live data (weather, delays, gate/platform changes,
-calendar). It answers one question: *what do I need to know or do right now?*
+calendar). It answers one question: _what do I need to know or do right now?_
 
 ## Mental model
 
@@ -62,7 +62,7 @@ At an anchor (the appointment, the hotel).
 Today is **one surface that transitions automatically**, not four screens the user navigates
 between. Design the **transitions**, not only the static frames: what fades, what slides,
 how the `ActiveTile` transforms from countdown → live leg → arrived. In keeping with Khonsu
-(the moon, time, dusk), the morph should feel like the surface is *turning* through the day;
+(the moon, time, dusk), the morph should feel like the surface is _turning_ through the day;
 a quiet time-of-day / horizon through-line is welcome.
 
 ## Live data → interventions, not widgets
@@ -84,6 +84,21 @@ Single focal column. `ActiveTile` is the hero — large, top. Supporting cards s
 priority order. At larger sizes, **resist** spreading into a multi-column dashboard: Today
 stays a single calm spine even with room, and the extra space becomes breathing room, not
 more widgets. This protects the “morphing surface, not dashboard” principle.
+
+### Approved Screen One composition (July 2026)
+
+The supplied Screen One reference is the current visual authority for the readiness/in-transit
+composition. The production screen keeps one bounded column in this order:
+
+1. Date, day purpose, base location, and compact local conditions.
+2. Warm `ActiveTile` with the single primary route action and three compact secondary actions.
+3. Six-hour conditions strip.
+4. `TodaySpine` with a persisted arrival-margin switch, open movement/change rows, and carded
+   commitments or operational passes.
+5. Tickets/Wallet exits and the contextual `Plan something` action.
+
+The prior map-led Today command is retired. Route detail still opens from `View best route`; the
+full interactive journey map remains on the canonical `/plan/[id]` surface.
 
 ## Restraint notes (brand-critical)
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -15,7 +15,7 @@
  * Bump VERSION to roll the caches (old ones are deleted on activate).
  */
 
-const VERSION = "khonsera-v1";
+const VERSION = "khonsera-v2";
 const STATIC_CACHE = `${VERSION}-static`;
 const PAGE_CACHE = `${VERSION}-pages`;
 
@@ -38,7 +38,9 @@ self.addEventListener("activate", (event) => {
   event.waitUntil(
     (async () => {
       const keys = await caches.keys();
-      await Promise.all(keys.filter((k) => !k.startsWith(VERSION)).map((k) => caches.delete(k)));
+      await Promise.all(
+        keys.filter((k) => !k.startsWith(VERSION)).map((k) => caches.delete(k)),
+      );
       await self.clients.claim();
     })(),
   );

--- a/src/app/(app)/today/page.tsx
+++ b/src/app/(app)/today/page.tsx
@@ -34,13 +34,8 @@ import {
 import { foldStopsToLegTickets } from "@/lib/tickets/from-stops";
 import { TodayDemo } from "@/components/today/today-demo";
 import { isDemoModeActive } from "@/lib/demo-mode";
-import { PlanMap } from "@/components/plan/plan-map";
-import {
-  buildJourneyFromStops,
-  type StopForMap,
-  type TransitionForMap,
-} from "@/components/journey-map/from-stops";
 import { PlanAdd } from "@/components/plan/plan-add";
+import { TodayBufferControl } from "@/components/today/today-buffer-control";
 import type {
   PlacePickerLocation,
   PlacePickerCustomer,
@@ -166,6 +161,97 @@ function WeatherGlyph({ isDay }: { isDay: boolean }) {
   );
 }
 
+function WeatherHourGlyph({ code, label }: { code: number; label: string }) {
+  const hour = Number(label.slice(0, 2));
+  const isNight = Number.isFinite(hour) && (hour < 6 || hour >= 20);
+
+  if (code >= 51) {
+    return (
+      <svg
+        className="cc-weather-hour-glyph"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.7"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden
+      >
+        <path d="M7 17h10a4 4 0 0 0 .7-7.9A6 6 0 0 0 6.4 8.3 4.5 4.5 0 0 0 7 17Z" />
+        <path d="m8 20-1 2m5-2-1 2m5-2-1 2" />
+      </svg>
+    );
+  }
+
+  if (code >= 3) {
+    return (
+      <svg
+        className="cc-weather-hour-glyph"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.7"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden
+      >
+        <path d="M7 18h10a4 4 0 0 0 .7-7.9A6 6 0 0 0 6.4 9.3 4.5 4.5 0 0 0 7 18Z" />
+      </svg>
+    );
+  }
+
+  return isNight ? (
+    <svg
+      className="cc-weather-hour-glyph"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.7"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d="M19 15.5A8 8 0 0 1 8.5 5 8 8 0 1 0 19 15.5Z" />
+    </svg>
+  ) : (
+    <svg
+      className="cc-weather-hour-glyph"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.7"
+      strokeLinecap="round"
+      aria-hidden
+    >
+      <circle cx="12" cy="12" r="3.5" />
+      <path d="M12 2v2m0 16v2M2 12h2m16 0h2M5 5l1.5 1.5m11 11L19 19m0-14-1.5 1.5m-11 11L5 19" />
+    </svg>
+  );
+}
+
+function TodayContextIcon({ name }: { name: "ticket" | "wallet" | "chevron" }) {
+  const path =
+    name === "ticket"
+      ? "M3 7a2 2 0 0 0 2-2h14a2 2 0 0 0 2 2v2a3 3 0 0 0 0 6v2a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-2a3 3 0 0 0 0-6V7Zm9-2v14"
+      : name === "wallet"
+        ? "M4 6h14a2 2 0 0 1 2 2v10H5a2 2 0 0 1-2-2V6Zm0 0 11-3v3m5 5h-5a2 2 0 0 0 0 4h5"
+        : "m9 18 6-6-6-6";
+
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.7"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d={path} />
+    </svg>
+  );
+}
+
 export default async function TodayPage({
   searchParams,
 }: {
@@ -186,23 +272,33 @@ export default async function TodayPage({
 
   const now = new Date();
   const today = ymd(now);
-  const { data: events } = await supabase
-    .from("itineraries")
-    .select("id, title, mode, date_start, date_end, status")
-    .lte("date_start", today)
-    .gte("date_end", today)
-    .in("status", ["draft", "planning", "planned", "in_progress"])
-    .order("date_start", { ascending: true });
-  const covering = events ?? [];
-
   const tomorrow = ymd(new Date(now.getTime() + 86_400_000));
-  const { data: tmrwRows } = await supabase
-    .from("itineraries")
-    .select("id")
-    .eq("date_start", tomorrow)
-    .in("status", ["draft", "planning", "planned", "in_progress"])
-    .order("date_start", { ascending: true })
-    .limit(1);
+  const [{ data: events }, { data: tmrwRows }, { data: travelProfile }] =
+    await Promise.all([
+      supabase
+        .from("itineraries")
+        .select("id, title, mode, date_start, date_end, status")
+        .lte("date_start", today)
+        .gte("date_end", today)
+        .in("status", ["draft", "planning", "planned", "in_progress"])
+        .order("date_start", { ascending: true }),
+      supabase
+        .from("itineraries")
+        .select("id")
+        .eq("date_start", tomorrow)
+        .in("status", ["draft", "planning", "planned", "in_progress"])
+        .order("date_start", { ascending: true })
+        .limit(1),
+      supabase
+        .from("travel_profiles")
+        .select("default_arrival_buffer_minutes")
+        .eq("user_id", ctx.userId)
+        .eq("workspace_id", ctx.workspaceId)
+        .maybeSingle(),
+    ]);
+  const covering = events ?? [];
+  const stationBufferMinutes =
+    travelProfile?.default_arrival_buffer_minutes ?? 15;
   const tomorrowReview =
     tmrwRows && tmrwRows.length
       ? await buildDayReview(tmrwRows[0].id as string)
@@ -213,10 +309,7 @@ export default async function TodayPage({
   const travelByToStop = new Map<string, InboundLeg>();
   let baseCoord: { lat: number; lng: number } | null = null;
   let baseLabel: string | null = null;
-  let destinationLabel: string | null = null;
   let tickets: TicketVM[] = [];
-  let mapStops: StopForMap[] = [];
-  let mapTransitions: TransitionForMap[] = [];
   const legCardByOriginId = new Map<
     string,
     {
@@ -260,8 +353,6 @@ export default async function TodayPage({
       if (st.type === "start" && !baseCoord) baseCoord = coordOf(st);
       if (st.type === "start" && !baseLabel)
         baseLabel = placeOf(st) ?? st.title ?? null;
-      if (st.type === "end")
-        destinationLabel = placeOf(st) ?? st.title ?? destinationLabel;
       // Base bookends remain part of routing, but they are context — never Today stops.
       if (
         st.type !== "start" &&
@@ -285,37 +376,6 @@ export default async function TodayPage({
         actualArrivedAt: tr.actual_arrived_at,
         notBeforeIso: from?.type === "shift" ? from.end_time : null,
       });
-    }
-
-    if (covering.length === 1) {
-      const geo = (g: Geo) =>
-        g
-          ? {
-              name: g.name ?? null,
-              latitude: g.latitude ?? null,
-              longitude: g.longitude ?? null,
-            }
-          : null;
-      mapStops = evStops.map((st) => ({
-        id: st.id,
-        title: st.title,
-        location: geo(st.location),
-        customer_site: geo(st.customer_site),
-        transport_hub: st.transport_hub
-          ? {
-              code: st.transport_hub.code ?? null,
-              name: st.transport_hub.name ?? null,
-              latitude: st.transport_hub.latitude ?? null,
-              longitude: st.transport_hub.longitude ?? null,
-            }
-          : null,
-      }));
-      mapTransitions = evTransitions.map((tr) => ({
-        from_stop_id: tr.from_stop_id,
-        mode: tr.mode ?? "walk",
-        overview_polyline: tr.overview_polyline ?? null,
-        computed_duration_minutes: tr.computed_duration_minutes ?? null,
-      }));
     }
 
     tickets = tickets.concat(jt);
@@ -439,7 +499,8 @@ export default async function TodayPage({
       coord: stationCoord ?? coordOf(s),
       plannedTravelMinutes: leg?.minutes ?? null,
       travelMode: leg?.mode ?? null,
-      bufferMinutes: s.type === "shift" ? 0 : undefined,
+      bufferMinutes:
+        s.type === "shift" ? 0 : station ? stationBufferMinutes : undefined,
       notBeforeIso: leg?.notBeforeIso ?? null,
       inboundTransitionId: leg?.id ?? null,
       transitionState: leg?.state ?? null,
@@ -483,6 +544,13 @@ export default async function TodayPage({
         ? `From ${baseLabel}`
         : undefined;
   const weather = await getLocalWeather();
+  const weatherLow =
+    weather && weather.hours.length > 0
+      ? weather.hours.reduce(
+          (lowest, hour) => Math.min(lowest, hour.tempC),
+          weather.tempC,
+        )
+      : weather?.tempC;
   const dateEyebrow = new Intl.DateTimeFormat("en-GB", {
     timeZone: "Europe/London",
     weekday: "short",
@@ -516,13 +584,6 @@ export default async function TodayPage({
       null;
   }
 
-  const todayJourney =
-    covering.length === 1
-      ? buildJourneyFromStops(mapStops, mapTransitions, {
-          id: covering[0].id,
-          eyebrow: `${dateEyebrow} · DOOR TO DOOR`,
-        })
-      : null;
   const toolsEvent = covering.length === 1 ? covering[0] : null;
   let toolPickers: {
     customers: PlacePickerCustomer[];
@@ -559,7 +620,7 @@ export default async function TodayPage({
       title={anchors.length ? dayPurpose : "Right now"}
       titleAs="h1"
       description={
-        anchors.length && (destinationLabel ?? baseLabel) ? (
+        anchors.length && baseLabel ? (
           <span className="cc-today-destination">
             <svg
               viewBox="0 0 24 24"
@@ -573,7 +634,7 @@ export default async function TodayPage({
               <path d="M20 10c0 5-8 11-8 11S4 15 4 10a8 8 0 1 1 16 0Z" />
               <circle cx="12" cy="10" r="2.5" />
             </svg>
-            To <strong>{destinationLabel ?? baseLabel}</strong>
+            From <strong>{baseLabel}</strong>
           </span>
         ) : undefined
       }
@@ -590,7 +651,9 @@ export default async function TodayPage({
             <span className="cc-weather-temp">{weather.tempC}&deg;</span>
             <span className="cc-weather-meta">
               <span className="cc-weather-headline">{weather.headline}</span>
-              <span className="cc-weather-place">{weather.place}</span>
+              <span className="cc-weather-place">
+                {weatherLow}&deg; / {weather.place}
+              </span>
             </span>
           </div>
         ) : null
@@ -604,11 +667,6 @@ export default async function TodayPage({
               <div className="cc-today-command-content">
                 <LiveDay anchors={spineAnchors} sub={sub} base={baseCoord} />
               </div>
-              {todayJourney ? (
-                <div className="cc-today-command-map">
-                  <PlanMap journey={todayJourney} />
-                </div>
-              ) : null}
             </section>
 
             <div className="cc-day-forecast" aria-label="Day conditions">
@@ -617,16 +675,19 @@ export default async function TodayPage({
                   className="cc-weather-hours"
                   aria-label="Today's forecast by the hour"
                 >
-                  {weather.hours.map((h) => (
+                  {weather.hours.slice(0, 6).map((h, index) => (
                     <div
                       key={h.label}
                       className="cc-weather-hour"
                       title={h.headline}
                     >
-                      <span className="cc-weather-hour-time">{h.label}</span>
+                      <span className="cc-weather-hour-time">
+                        {index === 0 ? "Now" : h.label}
+                      </span>
                       <span className="cc-weather-hour-temp">
                         {h.tempC}&deg;
                       </span>
+                      <WeatherHourGlyph code={h.code} label={h.label} />
                       <span className="cc-weather-hour-cond">{h.headline}</span>
                     </div>
                   ))}
@@ -643,6 +704,9 @@ export default async function TodayPage({
               <TodaySpine
                 anchors={spineAnchors}
                 nextId={nextSpine?.id ?? null}
+                toolbar={
+                  <TodayBufferControl initialMinutes={stationBufferMinutes} />
+                }
               />
             </section>
 
@@ -657,46 +721,56 @@ export default async function TodayPage({
                 </div>
               ) : null}
               {tickets.length > 0 ? (
-                <div className="cc-context-actions">
-                  <span className="cc-context-label">Tickets today</span>
-                  <Link
-                    href={"/wallet" as Route}
-                    className="cc-btn cc-btn-ghost"
-                  >
-                    Open wallet
-                  </Link>
-                </div>
+                <Link
+                  href={"/wallet" as Route}
+                  className="cc-today-context-row cc-today-context-row--ticket"
+                >
+                  <span className="cc-today-context-icon">
+                    <TodayContextIcon name="ticket" />
+                  </span>
+                  <span className="cc-today-context-copy">
+                    <strong>Tickets today</strong>
+                    <span>
+                      You have {tickets.length} active ticket
+                      {tickets.length === 1 ? "" : "s"}
+                    </span>
+                  </span>
+                  <span className="cc-today-context-chevron">
+                    <TodayContextIcon name="chevron" />
+                  </span>
+                </Link>
               ) : null}
+              <Link
+                href={"/wallet" as Route}
+                className="cc-today-context-row cc-today-context-row--wallet"
+              >
+                <span className="cc-today-context-icon">
+                  <TodayContextIcon name="wallet" />
+                </span>
+                <span className="cc-today-context-copy">
+                  <strong>Wallet</strong>
+                </span>
+                <span className="cc-today-context-chevron">
+                  <TodayContextIcon name="chevron" />
+                </span>
+              </Link>
               {showNextDocument && nextTicket ? (
                 <TodayDocument ticket={nextTicket} />
               ) : null}
               {toolsEvent && toolPickers ? (
-                <div className="cc-context-actions cc-context-actions--planner">
-                  <div className="cc-context-copy">
-                    <span className="cc-context-label">Plan this day</span>
-                    <span className="cc-context-detail">
-                      Add a stop here or open the full planner.
-                    </span>
-                  </div>
-                  <div className="cc-context-buttons">
-                    <Link
-                      href={`/plan/${toolsEvent.id}` as Route}
-                      className="cc-btn cc-btn-ghost"
-                    >
-                      Open planner
-                    </Link>
-                    <PlanAdd
-                      variant="primary"
-                      journeyId={toolsEvent.id}
-                      journeyDate={toolsEvent.date_start as string}
-                      customers={toolPickers.customers}
-                      customerSites={toolPickers.customerSites}
-                      locations={toolPickers.locations}
-                    />
-                  </div>
+                <div className="cc-today-plan-action">
+                  <PlanAdd
+                    variant="primary"
+                    label="Plan something"
+                    journeyId={toolsEvent.id}
+                    journeyDate={toolsEvent.date_start as string}
+                    customers={toolPickers.customers}
+                    customerSites={toolPickers.customerSites}
+                    locations={toolPickers.locations}
+                  />
                 </div>
               ) : (
-                <PlanCreate />
+                <PlanCreate className="cc-today-plan-button" />
               )}
             </aside>
           </>

--- a/src/app/__design/today/page.tsx
+++ b/src/app/__design/today/page.tsx
@@ -1,0 +1,278 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { ChevronRight, CloudSun, Ticket, WalletCards } from "lucide-react";
+import { MobileAppbar } from "@/components/shell/mobile-appbar";
+import { LiveDay } from "@/components/today/live-day";
+import { TodaySpine } from "@/components/today/today-spine";
+import { TodayBufferControl } from "@/components/today/today-buffer-control";
+import { AppScreen } from "@/components/ui/page-shell";
+import type { SpineAnchor } from "@/components/today/spine-model";
+import type { TicketVM } from "@/components/concierge";
+import type { NavigationIcon } from "@/lib/navigation";
+import { navigationGlyphs } from "@/lib/navigation";
+
+function at(now: number, minutes: number): string {
+  return new Date(now + minutes * 60_000).toISOString();
+}
+
+function Glyph({ name }: { name: NavigationIcon }) {
+  return (
+    <svg
+      width="22"
+      height="22"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.7"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d={navigationGlyphs[name]} />
+    </svg>
+  );
+}
+
+function PreviewTabbar() {
+  const tabs: Array<{
+    label: string;
+    icon: NavigationIcon;
+    active?: boolean;
+  }> = [
+    { label: "Today", icon: "today", active: true },
+    { label: "Plan", icon: "plan" },
+    { label: "Tasks", icon: "tasks" },
+    { label: "Wallet", icon: "wallet" },
+    { label: "Navigate", icon: "navigate" },
+  ];
+
+  return (
+    <nav className="cc-tabbar" aria-label="Primary preview">
+      {tabs.map((tab) => (
+        <span
+          key={tab.label}
+          className="cc-tab"
+          data-active={tab.active ? "true" : "false"}
+        >
+          <span className="cc-tab-ico" aria-hidden>
+            <Glyph name={tab.icon} />
+          </span>
+          <span className="cc-tab-label">{tab.label}</span>
+          <span className="cc-tab-dot" />
+        </span>
+      ))}
+    </nav>
+  );
+}
+
+export default function TodayDesignPreview() {
+  if (process.env.VERCEL_ENV === "production") notFound();
+
+  const now = Date.now();
+  const ticket: TicketVM = {
+    id: "screen-one-preview-ticket",
+    kind: "rail",
+    operator: "Thameslink",
+    source: "manual",
+    legs: [
+      {
+        id: "screen-one-preview-leg",
+        origin: {
+          place: "Harpenden",
+          code: "HPD",
+          time: at(now, 75),
+          platform: "1",
+        },
+        destination: {
+          place: "London St Pancras",
+          code: "STP",
+          time: at(now, 108),
+        },
+        durationMinutes: 33,
+        status: { status: "on_time" },
+      },
+    ],
+  };
+  const anchors: SpineAnchor[] = [
+    {
+      id: "screen-one-preview-station",
+      type: "custom",
+      title: "Harpenden Station",
+      place: "Harpenden",
+      arriveByIso: at(now, 60),
+      endIso: at(now, 75),
+      coord: { lat: 51.8146, lng: -0.3515 },
+      plannedTravelMinutes: 12,
+      bufferMinutes: 15,
+      navMode: "walk",
+      station: {
+        name: "Harpenden",
+        code: "HPD",
+        kind: "rail_station",
+      },
+      role: "departure",
+      pass: {
+        ticket,
+        crs: "HPD",
+        time: null,
+        dest: "STP",
+      },
+    },
+    {
+      id: "screen-one-preview-change",
+      type: "custom",
+      title: "London St Pancras",
+      place: "London",
+      arriveByIso: at(now, 108),
+      endIso: at(now, 118),
+      coord: { lat: 51.5308, lng: -0.1238 },
+      plannedTravelMinutes: null,
+      navMode: "walk",
+      station: {
+        name: "London St Pancras",
+        code: "STP",
+        kind: "rail_station",
+      },
+      role: "changeover",
+    },
+    {
+      id: "screen-one-preview-dinner",
+      type: "reservation",
+      title: "Dinner at Sessions Arts Club",
+      place: "Clerkenwell",
+      arriveByIso: at(now, 150),
+      endIso: at(now, 255),
+      coord: { lat: 51.5229, lng: -0.111 },
+      plannedTravelMinutes: 18,
+      navMode: "walk",
+      station: null,
+      role: "stop",
+    },
+  ];
+
+  return (
+    <div className="khonsera-app khonsera-app--unified">
+      <MobileAppbar
+        email="preview@khonsera.com"
+        firstName="Preview"
+        initials="KP"
+        isStaff={false}
+        mode="work"
+      />
+      <main className="cc-app-main">
+        <AppScreen
+          eyebrow="MON, 28 JUL"
+          title="Work"
+          description={
+            <span className="cc-today-destination">
+              From <strong>20 Wilce Avenue</strong>
+            </span>
+          }
+          titleAs="h1"
+          headerClassName="cc-today-head"
+          className="cc-today-direction"
+          actions={
+            <div className="cc-weather" data-day="true">
+              <CloudSun className="cc-weather-glyph" aria-hidden />
+              <span className="cc-weather-temp">18&deg;</span>
+              <span className="cc-weather-meta">
+                <span className="cc-weather-headline">Partly cloudy</span>
+                <span className="cc-weather-place">13&deg; / Harpenden</span>
+              </span>
+            </div>
+          }
+        >
+          <div className="cc-day-dashboard">
+            <section className="cc-today-command" aria-label="Your next move">
+              <div className="cc-today-command-content">
+                <LiveDay
+                  anchors={anchors}
+                  sub="Work · Harpenden to London"
+                  base={null}
+                />
+              </div>
+            </section>
+
+            <div className="cc-day-forecast" aria-label="Day conditions">
+              <div
+                className="cc-weather-hours"
+                aria-label="Today's forecast by the hour"
+              >
+                {[
+                  ["Now", "18°"],
+                  ["18:00", "17°"],
+                  ["19:00", "16°"],
+                  ["20:00", "15°"],
+                  ["21:00", "14°"],
+                  ["22:00", "13°"],
+                ].map(([label, temperature]) => (
+                  <div className="cc-weather-hour" key={label}>
+                    <span className="cc-weather-hour-time">{label}</span>
+                    <span className="cc-weather-hour-temp">{temperature}</span>
+                    <CloudSun className="cc-weather-hour-glyph" aria-hidden />
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <section
+              className="cc-day-primary"
+              aria-label="Live preview itinerary"
+            >
+              <TodaySpine
+                anchors={anchors}
+                nextId={anchors[0]?.id}
+                nowOverride={now}
+                resolveEndContext={false}
+                toolbar={<TodayBufferControl initialMinutes={15} />}
+              />
+            </section>
+
+            <aside
+              className="cc-day-context"
+              aria-label="Day tools and documents"
+            >
+              <Link
+                href="/wallet"
+                className="cc-today-context-row cc-today-context-row--ticket"
+              >
+                <span className="cc-today-context-icon">
+                  <Ticket aria-hidden />
+                </span>
+                <span className="cc-today-context-copy">
+                  <strong>Tickets today</strong>
+                  <span>You have 1 active ticket</span>
+                </span>
+                <span className="cc-today-context-chevron">
+                  <ChevronRight aria-hidden />
+                </span>
+              </Link>
+              <Link
+                href="/wallet"
+                className="cc-today-context-row cc-today-context-row--wallet"
+              >
+                <span className="cc-today-context-icon">
+                  <WalletCards aria-hidden />
+                </span>
+                <span className="cc-today-context-copy">
+                  <strong>Wallet</strong>
+                </span>
+                <span className="cc-today-context-chevron">
+                  <ChevronRight aria-hidden />
+                </span>
+              </Link>
+              <div className="cc-today-plan-action">
+                <button type="button" className="cc-btn cc-btn-gold">
+                  <span aria-hidden>+</span> Plan something
+                </button>
+              </div>
+            </aside>
+          </div>
+        </AppScreen>
+      </main>
+      <div className="cc-tabbar-wrap">
+        <PreviewTabbar />
+      </div>
+    </div>
+  );
+}

--- a/src/app/khonsera-instrument-tokens.css
+++ b/src/app/khonsera-instrument-tokens.css
@@ -368,6 +368,7 @@ html:not([data-theme="dark"]) {
   --space-6: 24px;
   --space-8: 32px;
   --space-12: 48px;
+  --today-column-max: 760px;
 
   /* ── Radius — the instrument's rounded rectangles.
      badge 7 · chip/button 10 · card/tile 14 · sheet/hero 20 · modal 24. ──── */

--- a/src/app/khonsera-screen-one.css
+++ b/src/app/khonsera-screen-one.css
@@ -1,0 +1,1121 @@
+/* Khonsera Today · Screen One direction · July 2026
+ *
+ * The supplied mobile screen is the visual authority for Today. This final,
+ * additive layer keeps the real data/actions and translates that hierarchy
+ * directly onto the production components.
+ */
+
+:root {
+  --kh-today-accent: var(--rail);
+  --kh-today-accent-strong: var(--rail-2);
+  --kh-today-accent-soft: var(--rail-soft);
+  --kh-today-icon-size: calc(var(--space-12) - var(--space-2));
+  --kh-today-timeline-offset: calc(var(--space-8) + var(--space-2));
+}
+
+.khonsera-app--unified:has(.cc-today-direction) {
+  background: linear-gradient(
+    to bottom,
+    color-mix(in srgb, var(--card) 62%, var(--paper)),
+    var(--paper)
+  );
+}
+
+.khonsera-app--unified:has(.cc-today-direction) .cc-app-main {
+  padding-top: var(--space-2);
+}
+
+.khonsera-app--unified:has(.cc-today-direction) .cc-appbar {
+  min-height: auto;
+  padding-top: calc(var(--space-3) + env(safe-area-inset-top));
+  padding-bottom: var(--space-2);
+}
+
+.khonsera-app--unified:has(.cc-today-direction) .cc-appbar .cc-lockup {
+  gap: var(--space-2);
+}
+
+.khonsera-app--unified:has(.cc-today-direction) .cc-brand-dot {
+  width: var(--space-2);
+  height: var(--space-2);
+  background: var(--kh-today-accent);
+  box-shadow: 0 0 0 var(--space-1)
+    color-mix(in srgb, var(--kh-today-accent) 12%, transparent);
+}
+
+.khonsera-app--unified:has(.cc-today-direction) .cc-appbar .cc-lockup .wm {
+  font-size: var(--fs-body);
+  font-weight: var(--fw-semibold);
+  letter-spacing: var(--ls-eyebrow);
+}
+
+.khonsera-app--unified:has(.cc-today-direction) .cc-appbar-right {
+  gap: var(--space-2);
+}
+
+.khonsera-app--unified:has(.cc-today-direction) .cc-appbar .cc-iconbtn {
+  width: var(--kh-today-icon-size) !important;
+  height: var(--kh-today-icon-size) !important;
+  min-width: var(--kh-today-icon-size) !important;
+  min-height: var(--kh-today-icon-size) !important;
+  border: 0;
+  background: var(--card);
+  box-shadow: var(--lift-sm);
+}
+
+.khonsera-app--unified:has(.cc-today-direction) .cc-appbar-icon,
+.khonsera-app--unified:has(.cc-today-direction) .cc-appbar-icon svg {
+  width: var(--space-4);
+  height: var(--space-4);
+}
+
+.khonsera-app--unified:has(.cc-today-direction) .cc-tab[data-active="true"],
+.khonsera-app--unified:has(.cc-today-direction)
+  .cc-tab[data-active="true"]
+  .cc-tab-ico {
+  color: var(--kh-today-accent-strong);
+}
+
+.cc-today-direction {
+  width: 100%;
+  max-width: var(--today-column-max);
+  gap: var(--space-4);
+  margin-inline: auto;
+}
+
+/* Header ------------------------------------------------------------------ */
+
+.cc-today-direction .cc-today-head {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--space-4);
+  padding-inline: var(--space-1);
+}
+
+.cc-today-direction .cc-today-head .cc-screen-copy {
+  min-width: 0;
+}
+
+.cc-today-direction .cc-today-head .cc-eyebrow {
+  color: var(--ink-dim);
+  font-family: var(--mono);
+  font-size: var(--fs-micro);
+  font-weight: var(--fw-medium);
+  letter-spacing: var(--ls-eyebrow);
+}
+
+.cc-today-direction .cc-today-head .cc-screen-title {
+  margin-top: var(--space-1);
+  font-size: var(--fs-h1);
+  font-weight: var(--fw-semibold);
+  line-height: var(--lh-h1);
+  letter-spacing: var(--ls-h1);
+}
+
+.cc-today-direction .cc-screen-description {
+  margin-top: var(--space-1);
+  color: var(--ink-dim);
+  font-size: var(--fs-body);
+}
+
+.cc-today-destination {
+  gap: var(--space-1);
+}
+
+.cc-today-destination svg {
+  width: var(--space-4);
+  height: var(--space-4);
+  color: var(--kh-today-accent);
+}
+
+.cc-today-direction .cc-screen-actions {
+  width: auto;
+}
+
+.cc-today-direction .cc-weather {
+  min-width: calc(var(--space-12) + var(--space-12) + var(--space-12));
+  min-height: 0;
+  display: grid;
+  grid-template-columns: var(--space-8) minmax(0, 1fr);
+  grid-template-rows: auto auto;
+  align-items: center;
+  gap: var(--space-0-5) var(--space-3);
+  padding: var(--space-3) var(--space-3-5);
+  border: 0;
+  border-radius: var(--radius-md);
+  background: var(--card);
+  box-shadow: var(--lift-sm);
+}
+
+.cc-today-direction .cc-weather-glyph {
+  width: var(--space-8);
+  height: var(--space-8);
+  grid-row: 1 / 3;
+  color: var(--kh-today-accent);
+}
+
+.cc-today-direction .cc-weather[data-day="false"] .cc-weather-glyph {
+  color: var(--ink-dim);
+}
+
+.cc-today-direction .cc-weather-temp {
+  grid-column: 2;
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: var(--fs-body);
+  font-weight: var(--fw-semibold);
+  letter-spacing: 0;
+}
+
+.cc-today-direction .cc-weather-meta {
+  min-width: 0;
+  grid-column: 2;
+  gap: 0;
+}
+
+.cc-today-direction .cc-weather-headline {
+  overflow: hidden;
+  color: var(--ink);
+  font-size: var(--fs-label);
+  font-weight: var(--fw-medium);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cc-today-direction .cc-weather-place {
+  overflow: hidden;
+  color: var(--ink-dim);
+  font-size: var(--fs-micro);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Today stack -------------------------------------------------------------- */
+
+.cc-today-direction .cc-day-dashboard {
+  gap: var(--space-4);
+}
+
+.cc-today-direction .cc-today-command {
+  min-height: 0;
+  overflow: visible;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.cc-today-direction .cc-today-command-content {
+  min-height: 0;
+  display: block;
+  padding: 0;
+  background: transparent;
+  pointer-events: auto;
+}
+
+.cc-today-direction .cc-today-command-map {
+  display: none;
+}
+
+.cc-today-command .cc-active-tile {
+  width: 100%;
+  min-height: 0;
+  gap: var(--space-4);
+  padding: var(--space-6);
+  overflow: hidden;
+  border: 0 !important;
+  border-radius: var(--radius-xl);
+  background:
+    radial-gradient(
+      circle at top right,
+      color-mix(in srgb, var(--kh-today-accent) 9%, transparent),
+      transparent 42%
+    ),
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--kh-today-accent-soft) 32%, var(--card)),
+      color-mix(in srgb, var(--kh-today-accent-soft) 58%, var(--paper))
+    ) !important;
+  box-shadow: var(--shadow-lg);
+}
+
+.cc-today-command .cc-active-tile::after,
+.cc-today-command .cc-active-tile .pg::after {
+  content: none !important;
+}
+
+.cc-next-move-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.cc-today-command .cc-at-status {
+  gap: var(--space-2);
+  color: var(--kh-today-accent-strong);
+  font-size: var(--fs-label);
+  font-weight: var(--fw-semibold);
+  letter-spacing: var(--ls-eyebrow);
+}
+
+.cc-today-command .cc-at-dot {
+  width: var(--space-2);
+  height: var(--space-2);
+  background: var(--kh-today-accent);
+  box-shadow: 0 0 0 var(--space-1)
+    color-mix(in srgb, var(--kh-today-accent) 16%, transparent);
+}
+
+.cc-next-priority {
+  display: inline-flex;
+  align-items: center;
+  min-height: var(--space-6);
+  padding-inline: var(--space-3);
+  border-radius: var(--radius-pill);
+  background: var(--ink);
+  color: var(--card);
+  font-size: var(--fs-micro);
+  font-weight: var(--fw-medium);
+}
+
+.cc-today-command .cc-setoff-sheet {
+  display: grid;
+  gap: var(--space-3);
+  padding: 0;
+  background: transparent !important;
+  box-shadow: none !important;
+}
+
+.cc-today-command .cc-setoff-eyb {
+  justify-content: flex-start;
+  gap: var(--space-2);
+}
+
+.cc-today-command .cc-setoff-kicker {
+  color: var(--ink-dim);
+  font-size: var(--fs-body);
+  font-weight: var(--fw-regular);
+}
+
+.cc-today-command .cc-setoff-for {
+  overflow: hidden;
+  color: var(--ink-faint);
+  font-size: var(--fs-label);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cc-today-command .cc-setoff-core {
+  justify-content: flex-start;
+  gap: var(--space-4);
+}
+
+.cc-today-command .cc-setoff-figure {
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: var(--fs-display);
+  font-weight: var(--fw-semibold);
+  line-height: var(--lh-display);
+  letter-spacing: var(--ls-display);
+}
+
+.cc-today-command .cc-setoff-colon {
+  color: inherit;
+}
+
+.cc-today-command .cc-leave-ring {
+  width: calc(var(--space-12) + var(--space-8));
+  height: calc(var(--space-12) + var(--space-8));
+  border-radius: var(--radius-pill);
+  background: color-mix(in srgb, var(--card) 72%, transparent);
+  box-shadow: var(--sink);
+}
+
+.cc-today-command .cc-leave-ring circle {
+  stroke-width: var(--space-1);
+}
+
+.cc-today-command .cc-leave-ring-track {
+  stroke: var(--rule-2);
+}
+
+.cc-today-command .cc-leave-ring-progress {
+  stroke: var(--kh-today-accent);
+}
+
+.cc-today-command .cc-leave-ring > span {
+  color: var(--ink-dim);
+  font-size: var(--fs-micro);
+}
+
+.cc-today-command .cc-leave-ring strong {
+  color: var(--ink);
+  font-size: var(--fs-label);
+  font-weight: var(--fw-semibold);
+}
+
+.cc-today-command .cc-next-facts {
+  gap: var(--space-2);
+}
+
+.cc-today-command .cc-next-facts > span {
+  min-height: var(--space-8);
+  gap: var(--space-1);
+  padding-inline: var(--space-3);
+  border: 0;
+  border-radius: var(--radius-pill);
+  background: color-mix(in srgb, var(--card) 72%, transparent);
+  color: var(--ink-2);
+  box-shadow: var(--sink);
+  font-size: var(--fs-label);
+  font-weight: var(--fw-regular);
+}
+
+.cc-today-command .cc-next-facts > span::before {
+  content: none;
+}
+
+.cc-today-command .cc-next-facts svg {
+  width: var(--space-3-5);
+  height: var(--space-3-5);
+  flex: none;
+}
+
+.cc-today-command .cc-setoff-move {
+  max-width: none;
+  color: var(--ink-dim);
+  font-size: var(--fs-body);
+  line-height: var(--lh-body);
+}
+
+.cc-today-command .cc-next-actions {
+  display: flex;
+  grid-template-columns: none;
+  gap: var(--space-2);
+  margin-top: 0;
+}
+
+.cc-today-command .cc-next-action {
+  width: var(--kh-today-icon-size);
+  min-width: var(--kh-today-icon-size);
+  min-height: var(--kh-today-icon-size);
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-pill);
+  background: color-mix(in srgb, var(--card) 68%, transparent);
+  color: var(--ink);
+  box-shadow: var(--lift-sm);
+}
+
+.cc-today-command .cc-next-action:hover {
+  background: var(--card);
+}
+
+.cc-today-command .cc-next-action svg {
+  width: var(--space-4);
+  height: var(--space-4);
+}
+
+.cc-today-command
+  .cc-next-action:not(.cc-next-action--primary)
+  .cc-next-action-label {
+  display: none;
+}
+
+.cc-today-command .cc-next-action--primary {
+  width: auto;
+  min-width: 0;
+  flex: 1;
+  justify-content: center;
+  gap: var(--space-2);
+  padding-inline: var(--space-5);
+  background: var(--kh-today-accent);
+  color: var(--card);
+  box-shadow: 0 var(--space-2) var(--space-5)
+    color-mix(in srgb, var(--kh-today-accent) 22%, transparent);
+}
+
+.cc-today-command .cc-next-action--primary:hover {
+  background: var(--kh-today-accent-strong);
+}
+
+.cc-today-command .cc-next-action:focus-visible,
+.cc-today-buffer-switch:focus-visible,
+.cc-today-context-row:focus-visible {
+  outline: var(--space-0-5) solid var(--kh-today-accent);
+  outline-offset: var(--space-0-5);
+}
+
+/* Weather strip ------------------------------------------------------------ */
+
+.cc-today-direction .cc-day-forecast {
+  gap: var(--space-3);
+}
+
+.cc-today-direction .cc-weather-hours {
+  min-height: 0;
+  display: grid;
+  grid-template-columns: repeat(6, minmax(var(--space-12), 1fr));
+  grid-auto-flow: row;
+  gap: var(--space-1);
+  padding: var(--space-3);
+  overflow-x: auto;
+  border: 0;
+  border-radius: var(--radius-md);
+  background: var(--card);
+  box-shadow: var(--lift-sm);
+}
+
+.cc-today-direction .cc-weather-hour {
+  min-width: var(--space-12);
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.cc-today-direction .cc-weather-hour:first-child {
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.cc-today-direction .cc-weather-hour-time,
+.cc-today-direction .cc-weather-hour:first-child .cc-weather-hour-time {
+  color: var(--ink-dim);
+  font-family: var(--sans);
+  font-size: var(--fs-micro);
+  font-weight: var(--fw-regular);
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.cc-today-direction .cc-weather-hour:first-child .cc-weather-hour-time {
+  color: var(--kh-today-accent-strong);
+  font-weight: var(--fw-semibold);
+  text-transform: uppercase;
+}
+
+.cc-today-direction .cc-weather-hour-temp {
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: var(--fs-body);
+  font-weight: var(--fw-semibold);
+}
+
+.cc-weather-hour-glyph {
+  width: var(--space-4);
+  height: var(--space-4);
+  color: var(--kh-today-accent);
+}
+
+.cc-today-direction .cc-weather-hour-cond {
+  display: none;
+}
+
+/* Itinerary ---------------------------------------------------------------- */
+
+.cc-today-direction .cc-day-primary {
+  gap: 0;
+}
+
+.cc-today-direction .cc-spine-heading {
+  margin: var(--space-1) var(--space-1) var(--space-3);
+  color: var(--ink-dim);
+  font-size: var(--fs-body);
+}
+
+.cc-today-direction .cc-spine-heading .cc-eyebrow {
+  color: var(--ink);
+  font-size: var(--fs-h3);
+  font-weight: var(--fw-semibold);
+  letter-spacing: var(--ls-h3);
+  text-transform: none;
+}
+
+.cc-spine-toolbar {
+  margin-bottom: var(--space-4);
+}
+
+.cc-today-buffer {
+  min-height: calc(var(--space-12) + var(--space-6));
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-md);
+  background: var(--card);
+  box-shadow: var(--lift-sm);
+}
+
+.cc-today-buffer[data-pending="true"] {
+  opacity: 0.72;
+}
+
+.cc-today-buffer-copy {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-0-5);
+}
+
+.cc-today-buffer-copy strong {
+  color: var(--ink);
+  font-size: var(--fs-body);
+  font-weight: var(--fw-semibold);
+}
+
+.cc-today-buffer-copy > span {
+  color: var(--ink-dim);
+  font-size: var(--fs-label);
+}
+
+.cc-today-buffer-switch {
+  width: var(--space-12);
+  height: var(--space-6);
+  position: relative;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-pill);
+  background: var(--rule-2);
+  box-shadow: var(--sink);
+  cursor: pointer;
+  transition:
+    background var(--dur-base) var(--ease-standard),
+    opacity var(--dur-base) var(--ease-standard);
+}
+
+.cc-today-buffer-switch[aria-checked="true"] {
+  background: var(--kh-today-accent);
+}
+
+.cc-today-buffer-switch > span {
+  width: var(--space-5);
+  height: var(--space-5);
+  position: absolute;
+  top: var(--space-0-5);
+  left: var(--space-0-5);
+  border-radius: var(--radius-pill);
+  background: var(--card);
+  box-shadow: var(--shadow-sm);
+  transition: transform var(--dur-base) var(--ease-standard);
+}
+
+.cc-today-buffer-switch[aria-checked="true"] > span {
+  transform: translateX(var(--space-6));
+}
+
+.cc-today-buffer-switch:disabled {
+  cursor: wait;
+}
+
+.cc-today-buffer-error {
+  grid-column: 1 / -1;
+  color: var(--danger);
+  font-size: var(--fs-micro);
+}
+
+.cc-today-direction .cc-spine {
+  width: 100%;
+  position: relative;
+  gap: 0;
+  padding: 0 0 0 calc(var(--space-12) + var(--space-3));
+  overflow: visible;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.cc-today-direction .cc-spine-rail {
+  width: var(--space-0-5);
+  top: var(--space-2);
+  bottom: var(--space-6);
+  left: var(--space-5);
+  background: var(--rule-2);
+}
+
+.cc-today-direction .cc-spine > .cc-node:has(.cc-now-row) {
+  display: none;
+}
+
+.cc-today-direction .cc-spine .cc-node {
+  min-height: 0;
+  display: block;
+  padding: 0 0 var(--space-4);
+  border: 0;
+  background: transparent;
+}
+
+.cc-today-direction .cc-spine .cc-node-dot {
+  width: var(--kh-today-icon-size);
+  height: var(--kh-today-icon-size);
+  top: 0;
+  left: calc(var(--kh-today-timeline-offset) * -1);
+  margin: 0;
+  border: 0;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  box-shadow: none;
+  color: inherit;
+  transform: translateX(-50%);
+}
+
+.cc-today-direction .cc-spine .cc-node[data-state="next"] .cc-node-dot {
+  border: 0;
+  background: transparent;
+  color: inherit;
+}
+
+.cc-timeline-icon {
+  width: var(--kh-today-icon-size) !important;
+  height: var(--kh-today-icon-size) !important;
+  display: grid;
+  place-items: center;
+  transform: none !important;
+  border: 0 !important;
+  border-radius: var(--radius-pill) !important;
+  background: var(--card) !important;
+  box-shadow: var(--lift-sm) !important;
+  color: var(--ink);
+}
+
+.cc-timeline-icon:is([data-kind="rail"], [data-kind="air"]) {
+  background: var(--kh-today-accent) !important;
+  color: var(--card);
+  box-shadow: 0 var(--space-1) var(--space-3)
+    color-mix(in srgb, var(--kh-today-accent) 20%, transparent) !important;
+}
+
+.cc-timeline-icon[data-kind="change"] {
+  color: var(--kh-today-accent-strong);
+  box-shadow: var(--sink), var(--lift-sm) !important;
+}
+
+.cc-timeline-icon svg {
+  width: var(--space-4);
+  height: var(--space-4);
+  stroke-width: 1.7;
+}
+
+.cc-today-direction .cc-spine :is(.cc-walk, .cc-transfer) {
+  width: 100%;
+  max-width: 100%;
+  padding: 0 !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+  box-shadow: none !important;
+}
+
+.cc-today-direction .cc-walk {
+  min-height: var(--kh-today-icon-size);
+  justify-content: center;
+}
+
+.cc-today-direction .cc-walk-head {
+  justify-content: flex-start;
+  gap: var(--space-2);
+}
+
+.cc-today-direction .cc-walk-mode {
+  color: var(--ink);
+  font-size: var(--fs-body);
+  font-weight: var(--fw-semibold);
+}
+
+.cc-today-direction .cc-walk-mins {
+  color: var(--ink-dim);
+  font-family: var(--sans);
+  font-size: var(--fs-body);
+  font-weight: var(--fw-regular);
+}
+
+.cc-today-direction .cc-walk-window {
+  max-width: none;
+  justify-content: flex-start;
+  gap: var(--space-1);
+  color: var(--ink-dim);
+  font-family: var(--sans);
+  font-size: var(--fs-body);
+}
+
+.cc-today-direction .cc-walk-rule {
+  width: auto;
+  height: auto;
+  background: transparent;
+}
+
+.cc-today-direction .cc-walk-dest {
+  align-items: center;
+  justify-content: flex-start;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  color: var(--ink);
+  font-size: var(--fs-body);
+}
+
+.cc-today-direction .cc-walk-spare {
+  margin-left: 0;
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-pill);
+  background: var(--card-2);
+  color: var(--ink-2);
+  font-size: var(--fs-micro);
+}
+
+.cc-today-direction .cc-walk-foot {
+  display: none;
+}
+
+.cc-today-direction .cc-spine :is(.cc-appt, .cc-station-card) {
+  width: 100%;
+  max-width: 100%;
+  padding: var(--space-4) !important;
+  border: 0 !important;
+  border-radius: var(--radius-md) !important;
+  background: var(--card) !important;
+  box-shadow: var(--lift-sm) !important;
+}
+
+.cc-today-direction .cc-transfer {
+  min-height: var(--kh-today-icon-size);
+  color: var(--ink);
+}
+
+.cc-today-direction .cc-transfer .cc-eyebrow,
+.cc-today-direction .cc-transfer .mono {
+  color: var(--kh-today-accent-strong);
+}
+
+.cc-today-direction .cc-transfer-time {
+  color: var(--ink-dim);
+}
+
+.cc-today-direction .cc-spine-toggle {
+  min-height: var(--touch-target);
+  margin: 0 0 var(--space-4);
+  border: 0;
+  border-radius: var(--radius-pill);
+  background: var(--card);
+  box-shadow: var(--lift-sm);
+}
+
+/* Operational rail/air pass face ------------------------------------------ */
+
+.khonsera-app .cc-today-direction .cc-spine .cc-pass.cc-pass--today {
+  width: 100%;
+  max-width: 100%;
+  padding: var(--space-4) !important;
+  overflow: hidden;
+  border: 0 !important;
+  border-radius: var(--radius-md) !important;
+  background: var(--card) !important;
+  box-shadow: var(--lift-sm) !important;
+}
+
+.cc-pass-today-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  color: var(--ink-dim);
+  font-size: var(--fs-label);
+}
+
+.cc-pass-today-time {
+  color: var(--kh-today-accent-strong);
+  font-weight: var(--fw-semibold);
+}
+
+.cc-pass-today-status {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+  color: var(--ink-dim);
+  text-align: right;
+}
+
+.cc-pass-today-status .cc-status-strip {
+  color: var(--kh-today-accent-strong);
+}
+
+.cc-today-direction .cc-pass--today .cc-pass-route {
+  padding: var(--space-3) 0 var(--space-4) !important;
+}
+
+.cc-today-direction .cc-pass--today .cc-pass-code {
+  color: var(--ink) !important;
+  font-family: var(--sans);
+  font-size: var(--fs-h2) !important;
+  font-weight: var(--fw-semibold) !important;
+  letter-spacing: var(--ls-h2) !important;
+}
+
+.cc-today-direction .cc-pass--today .cc-pass-place {
+  color: var(--ink-dim) !important;
+  font-size: var(--fs-label) !important;
+}
+
+.cc-today-direction .cc-pass--today .cc-pass-perf {
+  display: none;
+}
+
+.cc-today-direction .cc-pass--today .cc-pass-stub {
+  grid-template-columns: repeat(3, minmax(0, 1fr)) !important;
+  gap: var(--space-2) !important;
+  padding: var(--space-3) 0 0 !important;
+  border-top: var(--space-0-5) solid var(--rule);
+}
+
+.cc-today-direction .cc-pass--today .cc-pass-stub-cell {
+  gap: var(--space-1) !important;
+}
+
+.cc-today-direction .cc-pass--today .cc-pass-stub-cell > :first-child {
+  color: var(--ink-dim) !important;
+  font-family: var(--sans);
+  font-size: var(--fs-micro) !important;
+  letter-spacing: 0 !important;
+}
+
+.cc-today-direction .cc-pass--today .cc-pass-stub-cell > :last-child {
+  color: var(--ink) !important;
+  font-family: var(--sans) !important;
+  font-size: var(--fs-body) !important;
+  font-weight: var(--fw-semibold);
+}
+
+.cc-today-direction .cc-pass--today .cc-pass-boarding {
+  margin: var(--space-3) 0 0 !important;
+  padding: var(--space-3);
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: var(--kh-today-accent-soft);
+  color: var(--ink);
+}
+
+.cc-today-direction .cc-pass--today .cc-pass-boarding-warn,
+.cc-today-direction .cc-pass--today .cc-pass-boarding-note {
+  color: var(--ink-2);
+}
+
+.cc-today-direction .cc-pass--today .cc-pass-ready {
+  display: none;
+}
+
+.cc-today-direction .cc-pass--today .cc-pass-consequence {
+  padding: var(--space-3) 0 0 !important;
+  color: var(--ink-dim);
+}
+
+/* Contextual exits --------------------------------------------------------- */
+
+.cc-today-direction .cc-day-context {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.cc-today-direction .cc-context-actions--note {
+  min-height: 0;
+  align-items: flex-start;
+  padding: var(--space-4);
+  border: 0;
+  border-radius: var(--radius-md);
+  background: var(--card);
+  box-shadow: var(--lift-sm);
+}
+
+.cc-today-context-row {
+  min-height: calc(var(--space-12) + var(--space-6));
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-md);
+  background: var(--card);
+  color: var(--ink);
+  box-shadow: var(--lift-sm);
+  text-decoration: none;
+  transition:
+    transform var(--dur-fast) var(--ease-standard),
+    box-shadow var(--dur-base) var(--ease-standard);
+}
+
+.cc-today-context-row:hover {
+  box-shadow: var(--lift);
+  transform: translateY(calc(var(--space-0-5) * -1));
+}
+
+.cc-today-context-icon,
+.cc-today-context-chevron {
+  display: inline-grid;
+  place-items: center;
+}
+
+.cc-today-context-icon {
+  color: var(--kh-today-accent);
+}
+
+.cc-today-context-icon svg {
+  width: var(--space-5);
+  height: var(--space-5);
+}
+
+.cc-today-context-copy {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-0-5);
+}
+
+.cc-today-context-copy strong {
+  color: var(--ink);
+  font-size: var(--fs-body);
+  font-weight: var(--fw-semibold);
+}
+
+.cc-today-context-row--ticket .cc-today-context-copy strong {
+  color: var(--ink-dim);
+  font-family: var(--mono);
+  font-size: var(--fs-label);
+  letter-spacing: var(--ls-eyebrow);
+  text-transform: uppercase;
+}
+
+.cc-today-context-copy > span {
+  color: var(--ink-2);
+  font-size: var(--fs-body);
+}
+
+.cc-today-context-chevron {
+  color: var(--ink-dim);
+}
+
+.cc-today-context-chevron svg {
+  width: var(--space-4);
+  height: var(--space-4);
+}
+
+.cc-today-plan-action {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: var(--space-1);
+}
+
+.cc-today-plan-action .cc-btn-gold,
+.cc-today-plan-button {
+  min-height: var(--touch-target);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  padding-inline: var(--space-5);
+  border: 0;
+  border-radius: var(--radius-pill);
+  background: var(--kh-today-accent);
+  color: var(--card);
+  box-shadow: 0 var(--space-2) var(--space-5)
+    color-mix(in srgb, var(--kh-today-accent) 20%, transparent);
+  font-family: var(--sans);
+  font-size: var(--fs-body);
+  font-weight: var(--fw-semibold);
+}
+
+.cc-today-plan-action .cc-btn-gold:hover,
+.cc-today-plan-button:hover {
+  background: var(--kh-today-accent-strong);
+}
+
+@media (min-width: 48rem) {
+  .cc-today-direction {
+    gap: var(--space-5);
+  }
+
+  .cc-today-command .cc-active-tile {
+    padding: var(--space-8);
+  }
+
+  .cc-today-command .cc-setoff-core {
+    gap: var(--space-6);
+  }
+
+  .cc-today-command
+    .cc-next-action:not(.cc-next-action--primary)
+    .cc-next-action-label {
+    display: none;
+  }
+
+  .cc-today-direction .cc-weather-hours {
+    padding: var(--space-4);
+  }
+
+  .cc-today-direction .cc-spine {
+    padding-left: calc(var(--space-12) + var(--space-4));
+  }
+
+  .cc-today-direction .cc-spine-rail {
+    left: var(--space-6);
+  }
+
+  .cc-today-direction .cc-spine .cc-node-dot {
+    left: calc(var(--kh-today-timeline-offset) * -1);
+  }
+}
+
+@media (max-width: 24rem) {
+  .cc-today-direction .cc-today-head {
+    gap: var(--space-2);
+  }
+
+  .cc-today-direction .cc-weather {
+    min-width: calc(var(--space-12) + var(--space-12) + var(--space-8));
+    padding-inline: var(--space-2);
+  }
+
+  .cc-today-direction .cc-weather-glyph {
+    width: var(--space-6);
+    height: var(--space-6);
+  }
+
+  .cc-today-command .cc-active-tile {
+    padding: var(--space-5);
+  }
+
+  .cc-today-command .cc-setoff-for {
+    display: none;
+  }
+
+  .cc-today-command .cc-setoff-figure {
+    font-size: var(--fs-h1);
+  }
+
+  .cc-today-command .cc-leave-ring {
+    width: calc(var(--space-12) + var(--space-5));
+    height: calc(var(--space-12) + var(--space-5));
+  }
+
+  .cc-today-command .cc-next-action--primary {
+    padding-inline: var(--space-4);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cc-today-buffer-switch,
+  .cc-today-buffer-switch > span,
+  .cc-today-context-row {
+    transition: none;
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,6 +17,7 @@ import "./khonsera-edition-iii-round13.css"; // Edition III Round 13 coherence +
 import "./khonsera-edition-iii-nav.css"; // Edition III N1 — premium guidance surface (.cc-nav*) — LAST
 import "./khonsera-instrument.css"; // Instrument Edition v8 — reviewed production direction, final authority
 import "./khonsera-today-direction.css"; // Jul 2026 app direction — unified shell + route-first Today surface
+import "./khonsera-screen-one.css"; // Jul 2026 Screen One — approved compact orange Today direction
 import { PwaRegister } from "@/components/pwa-register";
 
 // Canonical Instrument Edition type stack:

--- a/src/components/concierge/pass.tsx
+++ b/src/components/concierge/pass.tsx
@@ -15,7 +15,8 @@ import { StatusStrip, KIND_LABEL } from "./document-cards";
 // pass downstream, per the brief). Reuses StatusStrip + BarcodePresenter.
 
 function durationLabel(t: TicketVM): string {
-  if (t.kind === "stay") return t.nights ? `${t.nights} night${t.nights > 1 ? "s" : ""}` : "";
+  if (t.kind === "stay")
+    return t.nights ? `${t.nights} night${t.nights > 1 ? "s" : ""}` : "";
   const m = t.legs[0]?.durationMinutes;
   if (!m) return "";
   const h = Math.floor(m / 60);
@@ -31,7 +32,15 @@ function PassIco({ kind }: { kind: TicketVM["kind"] }) {
         ? "M3 18 v-6 h13 a3 3 0 0 1 3 3 v3 M3 12 V7 M19 18 v-3 M3 15 h16"
         : "M6 4 h12 v10 a2 2 0 0 1-2 2 H8 a2 2 0 0 1-2-2 z M6 16 l-2 4 M18 16 l2 4 M9 8 h6"; // train / coach
   return (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
       <path d={d} />
     </svg>
   );
@@ -39,7 +48,17 @@ function PassIco({ kind }: { kind: TicketVM["kind"] }) {
 
 function ArrowRight() {
   return (
-    <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+    <svg
+      width="17"
+      height="17"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
       <path d="M5 12h14M13 6l6 6-6 6" />
     </svg>
   );
@@ -47,7 +66,17 @@ function ArrowRight() {
 
 function ScanIco() {
   return (
-    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+    <svg
+      width="15"
+      height="15"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
       <path d="M3 7V5a2 2 0 0 1 2-2h2M17 3h2a2 2 0 0 1 2 2v2M21 17v2a2 2 0 0 1-2 2h-2M7 21H5a2 2 0 0 1-2-2v-2M7 12h10" />
     </svg>
   );
@@ -66,31 +95,67 @@ export type BoardingVM = {
 // the first letters of the place name when a real CRS/IATA code isn't carried.
 function codeFor(stop: { code?: string; place?: string }): string {
   if (stop.code) return stop.code.toUpperCase();
-  return (stop.place ?? "").replace(/[^A-Za-z]/g, "").slice(0, 3).toUpperCase();
+  return (stop.place ?? "")
+    .replace(/[^A-Za-z]/g, "")
+    .slice(0, 3)
+    .toUpperCase();
 }
 
 // One cell of the boarding-pass stub grid (DEPART · ARRIVE · PLATFORM · SEAT).
-function StubCell({ label, value, badge }: { label: string; value: string; badge?: boolean }) {
+function StubCell({
+  label,
+  value,
+  badge,
+}: {
+  label: string;
+  value: string;
+  badge?: boolean;
+}) {
   return (
     <span
       className="cc-pass-stub-cell"
       data-label={label}
       style={{ display: "flex", flexDirection: "column", gap: 5, minWidth: 0 }}
     >
-      <span className="eyb" style={{ fontSize: 8.5, letterSpacing: "0.18em", color: "var(--ink-faint)" }}>{label}</span>
+      <span
+        className="eyb"
+        style={{
+          fontSize: 8.5,
+          letterSpacing: "0.18em",
+          color: "var(--ink-faint)",
+        }}
+      >
+        {label}
+      </span>
       {badge && value ? (
         <span
           className="mono engr-d"
           style={{
-            alignSelf: "flex-start", display: "inline-flex", alignItems: "center", height: 24,
-            padding: "0 9px", borderRadius: "var(--radius-xs)", background: "var(--char)",
-            color: "var(--cream)", fontWeight: 600, fontSize: 13, lineHeight: 1,
+            alignSelf: "flex-start",
+            display: "inline-flex",
+            alignItems: "center",
+            height: 24,
+            padding: "0 9px",
+            borderRadius: "var(--radius-xs)",
+            background: "var(--char)",
+            color: "var(--cream)",
+            fontWeight: 600,
+            fontSize: 13,
+            lineHeight: 1,
           }}
         >
           {value}
         </span>
       ) : (
-        <span className="mono" style={{ fontSize: 15, color: value ? "var(--ink)" : "var(--ink-faint)" }}>{value || "—"}</span>
+        <span
+          className="mono"
+          style={{
+            fontSize: 15,
+            color: value ? "var(--ink)" : "var(--ink-faint)",
+          }}
+        >
+          {value || "—"}
+        </span>
       )}
     </span>
   );
@@ -100,31 +165,70 @@ export function Pass({
   ticket,
   onShow,
   docked = false,
+  today = false,
   boarding,
 }: {
   ticket: TicketVM;
   onShow?: (ticket: TicketVM) => void;
   docked?: boolean; // on the Planner spine: barcode collapses to "Ticket ready"
+  today?: boolean; // Today uses the compact operational face from the approved screen.
   boarding?: BoardingVM; // day-of: loud platform + train identity + wrong-train guard
 }) {
   const leg = ticket.legs[0];
   const isStay = ticket.kind === "stay";
-  const showBoarding = !!boarding && !isStay && (!!boarding.platform || !!boarding.toward || !!boarding.earlier);
+  const showBoarding =
+    !!boarding &&
+    !isStay &&
+    (!!boarding.platform || !!boarding.toward || !!boarding.earlier);
+  const passClassName = [
+    "cc-pass",
+    docked ? "cc-pass--docked" : null,
+    today ? "cc-pass--today" : null,
+  ]
+    .filter(Boolean)
+    .join(" ");
 
   // Stay keeps a simple check-in/out face (no station codes / platforms).
   if (isStay) {
     return (
-      <div className={docked ? "cc-pass cc-pass--docked" : "cc-pass"} data-kind="stay" style={PASS_SHELL}>
+      <div className={passClassName} data-kind="stay" style={PASS_SHELL}>
         <div className="cc-pass-band" style={BAND}>
-          <span style={BAND_ICO}><span className="engr-ico-d" style={ICO_FLEX}><PassIco kind="stay" /></span></span>
-          <span className="eyb engr-d" style={BAND_KIND}>{KIND_LABEL.stay}</span>
+          <span style={BAND_ICO}>
+            <span className="engr-ico-d" style={ICO_FLEX}>
+              <PassIco kind="stay" />
+            </span>
+          </span>
+          <span className="eyb engr-d" style={BAND_KIND}>
+            {KIND_LABEL.stay}
+          </span>
           <span style={BAND_OP}>{ticket.operator}</span>
         </div>
-        <div className="cc-pass-stub" style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10, padding: "16px 18px" }}>
+        <div
+          className="cc-pass-stub"
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1fr 1fr",
+            gap: 10,
+            padding: "16px 18px",
+          }}
+        >
           <StubCell label="CHECK IN" value={formatClock(ticket.checkIn)} />
           <StubCell label="CHECK OUT" value={formatClock(ticket.checkOut)} />
-          {ticket.roomType ? <StubCell label="ROOM" value={ticket.roomType} /> : null}
-          {ticket.address ? <span className="mono" style={{ gridColumn: "1 / -1", fontSize: 11, color: "var(--ink-dim)" }}>{ticket.address}</span> : null}
+          {ticket.roomType ? (
+            <StubCell label="ROOM" value={ticket.roomType} />
+          ) : null}
+          {ticket.address ? (
+            <span
+              className="mono"
+              style={{
+                gridColumn: "1 / -1",
+                fontSize: 11,
+                color: "var(--ink-dim)",
+              }}
+            >
+              {ticket.address}
+            </span>
+          ) : null}
         </div>
       </div>
     );
@@ -134,50 +238,130 @@ export function Pass({
   const toCode = codeFor(leg?.destination ?? {});
   const platLabel = ticket.kind === "air" ? "GATE" : "PLATFORM";
   const platVal = leg?.origin.platform ?? leg?.destination.platform ?? "";
-  const seatVal = ticket.kind === "air" ? (leg?.seat ?? "") : [leg?.coach, leg?.seat].filter(Boolean).join("·");
+  const seatVal =
+    ticket.kind === "air"
+      ? (leg?.seat ?? "")
+      : [leg?.coach, leg?.seat].filter(Boolean).join("·");
 
   return (
-    <div className={docked ? "cc-pass cc-pass--docked" : "cc-pass"} data-kind={ticket.kind} style={PASS_SHELL}>
-      {/* charcoal operator band */}
-      <div className="cc-pass-band" style={BAND}>
-        <span style={BAND_ICO}><span className="engr-ico-d" style={ICO_FLEX}><PassIco kind={ticket.kind} /></span></span>
-        <span className="eyb engr-d" style={BAND_KIND}>{KIND_LABEL[ticket.kind]}</span>
-        <span style={BAND_OP}>{ticket.operator}</span>
-      </div>
+    <div className={passClassName} data-kind={ticket.kind} style={PASS_SHELL}>
+      {today ? (
+        <div className="cc-pass-today-head">
+          <span className="mono cc-pass-today-time">
+            {formatClock(leg?.origin.time)}
+          </span>
+          <span className="cc-pass-today-status">
+            {leg?.status ? (
+              <StatusStrip status={leg.status} />
+            ) : (
+              <span>On time</span>
+            )}
+            {platVal ? <span aria-hidden>·</span> : null}
+            {platVal ? (
+              <span>
+                {ticket.kind === "air" ? "Gate" : "Platform"} {platVal}
+              </span>
+            ) : null}
+          </span>
+        </div>
+      ) : (
+        <div className="cc-pass-band" style={BAND}>
+          <span style={BAND_ICO}>
+            <span className="engr-ico-d" style={ICO_FLEX}>
+              <PassIco kind={ticket.kind} />
+            </span>
+          </span>
+          <span className="eyb engr-d" style={BAND_KIND}>
+            {KIND_LABEL[ticket.kind]}
+          </span>
+          <span style={BAND_OP}>{ticket.operator}</span>
+        </div>
+      )}
 
       {/* big station-code pair */}
-      <div className="cc-pass-route" style={{ display: "flex", alignItems: "flex-start", gap: 10, padding: "18px 18px 14px" }}>
+      <div
+        className="cc-pass-route"
+        style={{
+          display: "flex",
+          alignItems: "flex-start",
+          gap: 10,
+          padding: "18px 18px 14px",
+        }}
+      >
         <span style={{ minWidth: 0 }}>
-          <span className="engr cc-pass-code" style={CODE}>{fromCode}</span>
-          <span className="cc-pass-place" style={CODE_NAME}>{leg?.origin.place ?? ""}</span>
+          <span className="engr cc-pass-code" style={CODE}>
+            {fromCode}
+          </span>
+          <span className="cc-pass-place" style={CODE_NAME}>
+            {leg?.origin.place ?? ""}
+          </span>
         </span>
-        <span style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", gap: 5, paddingTop: 12 }}>
-          <span className="engr-ico" style={{ color: "var(--ink-faint)", ...ICO_FLEX }}><ArrowRight /></span>
-          <span className="mono" style={{ fontSize: 9.5, color: "var(--ink-faint)", letterSpacing: "0.06em" }}>{durationLabel(ticket)}</span>
+        <span
+          style={{
+            flex: 1,
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            gap: 5,
+            paddingTop: 12,
+          }}
+        >
+          <span
+            className="engr-ico"
+            style={{ color: "var(--ink-faint)", ...ICO_FLEX }}
+          >
+            <ArrowRight />
+          </span>
+          <span
+            className="mono"
+            style={{
+              fontSize: 9.5,
+              color: "var(--ink-faint)",
+              letterSpacing: "0.06em",
+            }}
+          >
+            {durationLabel(ticket)}
+          </span>
         </span>
         <span style={{ minWidth: 0, textAlign: "right" }}>
-          <span className="engr cc-pass-code" style={CODE}>{toCode}</span>
-          <span className="cc-pass-place" style={CODE_NAME}>{leg?.destination.place ?? ""}</span>
+          <span className="engr cc-pass-code" style={CODE}>
+            {toCode}
+          </span>
+          <span className="cc-pass-place" style={CODE_NAME}>
+            {leg?.destination.place ?? ""}
+          </span>
         </span>
       </div>
 
       {/* day-of loud boarding callout (live only) */}
       {showBoarding ? (
-        <div className="cc-pass-boarding" data-awaiting={boarding!.platform ? undefined : "true"} style={{ margin: "0 18px 4px" }}>
+        <div
+          className="cc-pass-boarding"
+          data-awaiting={boarding!.platform ? undefined : "true"}
+          style={{ margin: "0 18px 4px" }}
+        >
           <span className="cc-pass-boarding-plat">
-            <span className="cc-pass-boarding-label">{ticket.kind === "air" ? "Gate" : "Platform"}</span>
-            <span className="cc-pass-boarding-num">{boarding!.platform ?? "—"}</span>
+            <span className="cc-pass-boarding-label">
+              {ticket.kind === "air" ? "Gate" : "Platform"}
+            </span>
+            <span className="cc-pass-boarding-num">
+              {boarding!.platform ?? "—"}
+            </span>
           </span>
           {boarding!.toward ? (
             <span className="cc-pass-boarding-toward">
               <span className="cc-pass-boarding-label">Your train</span>
-              <span className="cc-pass-boarding-dest">towards {boarding!.toward}</span>
+              <span className="cc-pass-boarding-dest">
+                towards {boarding!.toward}
+              </span>
             </span>
           ) : null}
           {boarding!.earlier ? (
             <p className="cc-pass-boarding-warn">{boarding!.earlier}</p>
           ) : !boarding!.platform ? (
-            <p className="cc-pass-boarding-note">Platform not shown yet — watch the boards.</p>
+            <p className="cc-pass-boarding-note">
+              Platform not shown yet — watch the boards.
+            </p>
           ) : null}
         </div>
       ) : null}
@@ -185,22 +369,48 @@ export function Pass({
       <div className="cc-pass-perf perf" style={{ margin: "2px 0" }} />
 
       {/* boarding-pass stub grid */}
-      <div className="cc-pass-stub" style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 10, padding: "13px 18px 6px" }}>
-        <StubCell label="DEPART" value={formatClock(leg?.origin.time)} />
-        <StubCell label="ARRIVE" value={formatClock(leg?.destination.time)} />
-        <StubCell label={platLabel} value={platVal} badge />
-        <StubCell label="SEAT" value={seatVal} badge />
+      <div
+        className="cc-pass-stub"
+        style={{
+          display: "grid",
+          gridTemplateColumns: today ? "repeat(3, 1fr)" : "repeat(4, 1fr)",
+          gap: 10,
+          padding: "13px 18px 6px",
+        }}
+      >
+        <StubCell label="DEPARTS" value={formatClock(leg?.origin.time)} />
+        {today ? <StubCell label={platLabel} value={platVal} /> : null}
+        <StubCell label="ARRIVES" value={formatClock(leg?.destination.time)} />
+        {!today ? <StubCell label={platLabel} value={platVal} badge /> : null}
+        {!today ? <StubCell label="SEAT" value={seatVal} badge /> : null}
       </div>
 
-      {leg?.status ? <div className="cc-pass-status" style={{ padding: "4px 18px 0" }}><StatusStrip status={leg.status} /></div> : null}
-      {ticket.consequence ? <p className="cc-pass-consequence" style={{ padding: "6px 18px 0" }}>{ticket.consequence}</p> : null}
+      {!today && leg?.status ? (
+        <div className="cc-pass-status" style={{ padding: "4px 18px 0" }}>
+          <StatusStrip status={leg.status} />
+        </div>
+      ) : null}
+      {ticket.consequence ? (
+        <p className="cc-pass-consequence" style={{ padding: "6px 18px 0" }}>
+          {ticket.consequence}
+        </p>
+      ) : null}
 
       {/* show ticket — the code lives behind it / in ScanView (brief §6.3) */}
       {leg?.barcodes?.length ? (
         <div className="cc-pass-ready" style={{ padding: "12px 16px 16px" }}>
-          <button onClick={() => onShow?.(ticket)} className="engr-d" style={SHOW_BTN}>
-            <span className="engr-ico-d" style={ICO_FLEX}><ScanIco /></span>
-            <span>Show {ticket.kind === "air" ? "pass" : "ticket"}{ticket.reference ? ` · ${ticket.reference}` : ""}</span>
+          <button
+            onClick={() => onShow?.(ticket)}
+            className="engr-d"
+            style={SHOW_BTN}
+          >
+            <span className="engr-ico-d" style={ICO_FLEX}>
+              <ScanIco />
+            </span>
+            <span>
+              Show {ticket.kind === "air" ? "pass" : "ticket"}
+              {ticket.reference ? ` · ${ticket.reference}` : ""}
+            </span>
           </button>
         </div>
       ) : null}
@@ -210,15 +420,76 @@ export function Pass({
 
 // Shared inline style atoms for the v7 ticket (colour tokens; one-off px per the
 // incremental-migration policy). Centralised here so the JSX reads cleanly.
-const PASS_SHELL: CSSProperties = { display: "block", gap: 0, overflow: "hidden", padding: 0, borderRadius: "var(--radius-lg)", background: "var(--card)", border: "1px solid var(--line)" };
-const BAND: CSSProperties = { display: "flex", alignItems: "center", gap: 10, padding: "11px 16px", background: "var(--char)", color: "var(--cream)" };
-const BAND_ICO: CSSProperties = { display: "inline-grid", placeItems: "center", width: 24, height: 24, borderRadius: "var(--radius-sm)", background: "rgba(243,239,230,0.10)", color: "var(--cream)" };
-const BAND_KIND: CSSProperties = { fontSize: 9, letterSpacing: "0.22em", color: "var(--cream)" };
-const BAND_OP: CSSProperties = { flex: 1, textAlign: "right", fontSize: 10.5, color: "var(--cream-dim)" };
+const PASS_SHELL: CSSProperties = {
+  display: "block",
+  gap: 0,
+  overflow: "hidden",
+  padding: 0,
+  borderRadius: "var(--radius-lg)",
+  background: "var(--card)",
+  border: "1px solid var(--line)",
+};
+const BAND: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 10,
+  padding: "11px 16px",
+  background: "var(--char)",
+  color: "var(--cream)",
+};
+const BAND_ICO: CSSProperties = {
+  display: "inline-grid",
+  placeItems: "center",
+  width: 24,
+  height: 24,
+  borderRadius: "var(--radius-sm)",
+  background: "rgba(243,239,230,0.10)",
+  color: "var(--cream)",
+};
+const BAND_KIND: CSSProperties = {
+  fontSize: 9,
+  letterSpacing: "0.22em",
+  color: "var(--cream)",
+};
+const BAND_OP: CSSProperties = {
+  flex: 1,
+  textAlign: "right",
+  fontSize: 10.5,
+  color: "var(--cream-dim)",
+};
 const ICO_FLEX: CSSProperties = { display: "inline-flex" };
-const CODE: CSSProperties = { display: "block", fontSize: 36, fontWeight: 300, lineHeight: 0.9, letterSpacing: "0.01em", color: "var(--ink)" };
-const CODE_NAME: CSSProperties = { display: "block", fontSize: 11, color: "var(--ink-dim)", marginTop: 6 };
-const SHOW_BTN: CSSProperties = { width: "100%", display: "inline-flex", alignItems: "center", justifyContent: "center", gap: 10, height: 46, padding: "0 14px", border: "none", borderRadius: "var(--radius-md)", background: "var(--char)", color: "var(--cream)", fontFamily: "var(--sans)", fontSize: 13, fontWeight: 600, cursor: "pointer", boxShadow: "var(--lift-char)" };
+const CODE: CSSProperties = {
+  display: "block",
+  fontSize: 36,
+  fontWeight: 300,
+  lineHeight: 0.9,
+  letterSpacing: "0.01em",
+  color: "var(--ink)",
+};
+const CODE_NAME: CSSProperties = {
+  display: "block",
+  fontSize: 11,
+  color: "var(--ink-dim)",
+  marginTop: 6,
+};
+const SHOW_BTN: CSSProperties = {
+  width: "100%",
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  gap: 10,
+  height: 46,
+  padding: "0 14px",
+  border: "none",
+  borderRadius: "var(--radius-md)",
+  background: "var(--char)",
+  color: "var(--cream)",
+  fontFamily: "var(--sans)",
+  fontSize: 13,
+  fontWeight: 600,
+  cursor: "pointer",
+  boxShadow: "var(--lift-char)",
+};
 
 export function PassPeek({
   ticket,

--- a/src/components/plan/live-pass.tsx
+++ b/src/components/plan/live-pass.tsx
@@ -2,7 +2,11 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { Pass } from "@/components/concierge";
-import type { BoardingVM, TicketVM, TravelStatus } from "@/components/concierge";
+import type {
+  BoardingVM,
+  TicketVM,
+  TravelStatus,
+} from "@/components/concierge";
 
 // A Pass for one booked rail hop, enriched with live Darwin status. Each
 // station-to-station leg renders its OWN card; this wrapper fetches the live
@@ -19,7 +23,11 @@ type Live = {
   detail?: string;
   platform?: string | null;
   destination?: string | null; // the train's final destination — "the Corby train"
-  earlierSamePlatform?: { std: string; destination?: string; platform: string } | null;
+  earlierSamePlatform?: {
+    std: string;
+    destination?: string;
+    platform: string;
+  } | null;
 };
 
 export function LivePass({
@@ -28,6 +36,7 @@ export function LivePass({
   time,
   dest,
   docked = false,
+  today = false,
   onShow,
 }: {
   ticket: TicketVM;
@@ -35,6 +44,7 @@ export function LivePass({
   time?: string | null; // planned departure, London HH:MM (matches Darwin <std>)
   dest?: string | null; // hop destination CRS — disambiguates same-minute departures
   docked?: boolean;
+  today?: boolean;
   onShow?: (ticket: TicketVM) => void;
 }) {
   const [live, setLive] = useState<Live | null>(null);
@@ -68,7 +78,12 @@ export function LivePass({
     if (!leg0) return ticket;
     const leg = { ...leg0 };
     if (live.platform) leg.origin = { ...leg.origin, platform: live.platform };
-    if (live.status) leg.status = { status: live.status, label: live.label, detail: live.detail };
+    if (live.status)
+      leg.status = {
+        status: live.status,
+        label: live.label,
+        detail: live.detail,
+      };
     return { ...ticket, legs: [leg, ...ticket.legs.slice(1)] };
   }, [ticket, live]);
 
@@ -89,5 +104,13 @@ export function LivePass({
     return { platform, toward, earlier };
   }, [ticket, live]);
 
-  return <Pass ticket={enriched} boarding={boarding} docked={docked} onShow={onShow} />;
+  return (
+    <Pass
+      ticket={enriched}
+      boarding={boarding}
+      docked={docked}
+      today={today}
+      onShow={onShow}
+    />
+  );
 }

--- a/src/components/plan/plan-add.tsx
+++ b/src/components/plan/plan-add.tsx
@@ -12,7 +12,10 @@ import {
 } from "@/lib/accommodation/types";
 import { wallClockToIso } from "@/lib/time-zone";
 import { TransportHubPicker } from "@/components/transport-hub-picker";
-import { ContactPicker, type BoundContact } from "@/components/plan/contact-picker";
+import {
+  ContactPicker,
+  type BoundContact,
+} from "@/components/plan/contact-picker";
 import {
   PlacePicker,
   type PlaceSelection,
@@ -48,6 +51,7 @@ export function PlanAdd({
   // main action); "tile" is the quieter Build-the-day tile; "inline" is the
   // thin "+ Add here" affordance between two timeline items. Same sheet either way.
   variant = "tile",
+  label,
   // When opened from a gap on the spine, the surrounding time pre-fills the
   // form (the clever bit: add IN context, not add-then-place).
   seedTime,
@@ -58,6 +62,7 @@ export function PlanAdd({
   customerSites: PlacePickerCustomerSite[];
   locations: PlacePickerLocation[];
   variant?: "tile" | "primary" | "inline";
+  label?: string;
   seedTime?: string;
 }) {
   const router = useRouter();
@@ -84,7 +89,8 @@ export function PlanAdd({
   // structured stay detail (ED1) — one object; the arrival payload is the edge
   const [acc, setAcc] = useState<AccommodationDetails>({});
   const [accMore, setAccMore] = useState(false);
-  const setA = (patch: Partial<AccommodationDetails>) => setAcc((p) => ({ ...p, ...patch }));
+  const setA = (patch: Partial<AccommodationDetails>) =>
+    setAcc((p) => ({ ...p, ...patch }));
 
   // transport fields — parity with the brief's booking card (One Toolkit, Two Views):
   // changeovers, service number, seat, class, price.
@@ -102,19 +108,39 @@ export function PlanAdd({
   type Changeover = { hub: Hub; arriveTime: string; departTime: string };
   const [changeovers, setChangeovers] = useState<Changeover[]>([]);
   const setCo = (idx: number, patch: Partial<Changeover>) =>
-    setChangeovers((cs) => cs.map((c, i) => (i === idx ? { ...c, ...patch } : c)));
+    setChangeovers((cs) =>
+      cs.map((c, i) => (i === idx ? { ...c, ...patch } : c)),
+    );
 
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
 
   function reset() {
-    setTitle(""); setPlace(null); setArriveBy(seedTime ?? ""); setLeaveBy("");
-    setMealDate(journeyDate); setMealTime(seedTime ?? "19:30"); setPartySize(""); setWho(null);
-    setFrom({ id: null, label: null }); setTo({ id: null, label: null });
-    setDate(journeyDate); setDepart(""); setArrive(""); setReference("");
-    setServiceNumber(""); setSeatNo(""); setTicketClass(""); setTprice(""); setChangeovers([]);
-    setCheckInDate(journeyDate); setCheckInTime("15:00"); setCheckOutDate(journeyDate); setCheckOutTime("11:00");
-    setAcc({}); setAccMore(false);
+    setTitle("");
+    setPlace(null);
+    setArriveBy(seedTime ?? "");
+    setLeaveBy("");
+    setMealDate(journeyDate);
+    setMealTime(seedTime ?? "19:30");
+    setPartySize("");
+    setWho(null);
+    setFrom({ id: null, label: null });
+    setTo({ id: null, label: null });
+    setDate(journeyDate);
+    setDepart("");
+    setArrive("");
+    setReference("");
+    setServiceNumber("");
+    setSeatNo("");
+    setTicketClass("");
+    setTprice("");
+    setChangeovers([]);
+    setCheckInDate(journeyDate);
+    setCheckInTime("15:00");
+    setCheckOutDate(journeyDate);
+    setCheckOutTime("11:00");
+    setAcc({});
+    setAccMore(false);
     setError(null);
   }
 
@@ -141,8 +167,14 @@ export function PlanAdd({
         return;
       }
       for (const c of changeovers) {
-        if (!c.hub.label) { setError("Pick the changeover station."); return; }
-        if (!c.arriveTime || !c.departTime) { setError("Set the changeover's arrive and depart times."); return; }
+        if (!c.hub.label) {
+          setError("Pick the changeover station.");
+          return;
+        }
+        if (!c.arriveTime || !c.departTime) {
+          setError("Set the changeover's arrive and depart times.");
+          return;
+        }
       }
       // Build the run's segments: from → co1 → … → coN → to. Each changeover is
       // the join between two segments (arrive on one, depart on the next).
@@ -150,13 +182,34 @@ export function PlanAdd({
       let legFrom = from;
       let legDepart = depart;
       for (const c of changeovers) {
-        segments.push({ fromHubId: legFrom.id, fromLabel: legFrom.label!, toHubId: c.hub.id, toLabel: c.hub.label!, date, departTime: legDepart, arriveTime: c.arriveTime });
+        segments.push({
+          fromHubId: legFrom.id,
+          fromLabel: legFrom.label!,
+          toHubId: c.hub.id,
+          toLabel: c.hub.label!,
+          date,
+          departTime: legDepart,
+          arriveTime: c.arriveTime,
+        });
         legFrom = c.hub;
         legDepart = c.departTime;
       }
-      segments.push({ fromHubId: legFrom.id, fromLabel: legFrom.label!, toHubId: to.id, toLabel: to.label!, date, departTime: legDepart, arriveTime: arrive, serviceNumber: serviceNumber || null, seat: seatNo || null });
+      segments.push({
+        fromHubId: legFrom.id,
+        fromLabel: legFrom.label!,
+        toHubId: to.id,
+        toLabel: to.label!,
+        date,
+        departTime: legDepart,
+        arriveTime: arrive,
+        serviceNumber: serviceNumber || null,
+        seat: seatNo || null,
+      });
       // Service number / seat sit on the FIRST segment when there are no changeovers.
-      if (changeovers.length === 0) { segments[0].serviceNumber = serviceNumber || null; segments[0].seat = seatNo || null; }
+      if (changeovers.length === 0) {
+        segments[0].serviceNumber = serviceNumber || null;
+        segments[0].seat = seatNo || null;
+      }
       setPending(true);
       void addBookingRun({
         itineraryId: journeyId,
@@ -177,14 +230,21 @@ export function PlanAdd({
       setPending(true);
       const ci = wallClockToIso(checkInDate, checkInTime) || null;
       const co = wallClockToIso(checkOutDate, checkOutTime) || null;
-      const fcu = acc.free_cancel_until ? wallClockToIso(acc.free_cancel_until, "23:59") || null : null;
-      const details: AccommodationDetails = { ...acc, property_name: place.label, free_cancel_until: fcu };
+      const fcu = acc.free_cancel_until
+        ? wallClockToIso(acc.free_cancel_until, "23:59") || null
+        : null;
+      const details: AccommodationDetails = {
+        ...acc,
+        property_name: place.label,
+        free_cancel_until: fcu,
+      };
       void addManualAnchor({
         itineraryId: journeyId,
         kind: "accommodation",
         title: place.label,
         locationId: place.kind === "location" ? place.location_id : null,
-        customerSiteId: place.kind === "customer_site" ? place.customer_site_id : null,
+        customerSiteId:
+          place.kind === "customer_site" ? place.customer_site_id : null,
         iso: ci,
         leaveIso: co,
         details,
@@ -207,7 +267,8 @@ export function PlanAdd({
         role: "dinner",
         title: title.trim() || place.label,
         locationId: place.kind === "location" ? place.location_id : null,
-        customerSiteId: place.kind === "customer_site" ? place.customer_site_id : null,
+        customerSiteId:
+          place.kind === "customer_site" ? place.customer_site_id : null,
         iso,
         partySize: partySize ? Number(partySize) : null,
         contactId: who?.id ?? null,
@@ -218,23 +279,32 @@ export function PlanAdd({
     // Appointment / Event / Place all sit at a place across an arrive→leave
     // window. For a Place the bound place name IS the title; an Appointment or
     // Event keeps its own "what".
-    const resolvedTitle = title.trim() || (kind === "place" ? place?.label?.trim() ?? "" : "");
+    const resolvedTitle =
+      title.trim() || (kind === "place" ? (place?.label?.trim() ?? "") : "");
     if (!resolvedTitle) {
       setError(kind === "place" ? "Pick or name a place." : "Give it a name.");
       return;
     }
     setPending(true);
     const iso = arriveBy ? wallClockToIso(journeyDate, arriveBy) || null : null;
-    const leaveIso = leaveBy ? wallClockToIso(journeyDate, leaveBy) || null : null;
+    const leaveIso = leaveBy
+      ? wallClockToIso(journeyDate, leaveBy) || null
+      : null;
     void addManualAnchor({
       itineraryId: journeyId,
-      kind: kind === "appointment" ? "appointment" : kind === "event" ? "event" : "place",
+      kind:
+        kind === "appointment"
+          ? "appointment"
+          : kind === "event"
+            ? "event"
+            : "place",
       title: resolvedTitle,
       locationId: place?.kind === "location" ? place.location_id : null,
-      customerSiteId: place?.kind === "customer_site" ? place.customer_site_id : null,
+      customerSiteId:
+        place?.kind === "customer_site" ? place.customer_site_id : null,
       iso,
       leaveIso,
-      contactId: kind === "appointment" ? who?.id ?? null : null,
+      contactId: kind === "appointment" ? (who?.id ?? null) : null,
     }).then(done);
   }
 
@@ -243,340 +313,657 @@ export function PlanAdd({
   return (
     <>
       {variant === "primary" ? (
-        <button type="button" className="cc-btn cc-btn-gold" onClick={() => setOpen(true)}>
-          <span aria-hidden>+</span> Add
+        <button
+          type="button"
+          className="cc-btn cc-btn-gold"
+          onClick={() => setOpen(true)}
+        >
+          <span aria-hidden>+</span> {label ?? "Add"}
         </button>
       ) : variant === "inline" ? (
         <button
           type="button"
           className="cc-spine-add"
           onClick={() => setOpen(true)}
-          aria-label={seedTime ? `Add something around ${seedTime}` : "Add something here"}
+          aria-label={
+            seedTime ? `Add something around ${seedTime}` : "Add something here"
+          }
         >
           <span aria-hidden>+</span>
-          <span className="cc-spine-add-label">Add here{seedTime ? ` · ${seedTime}` : ""}</span>
+          <span className="cc-spine-add-label">
+            Add here{seedTime ? ` · ${seedTime}` : ""}
+          </span>
         </button>
       ) : (
-        <button type="button" className="cc-add-trigger" onClick={() => setOpen(true)}>
+        <button
+          type="button"
+          className="cc-add-trigger"
+          onClick={() => setOpen(true)}
+        >
           <span aria-hidden>+</span> Add
         </button>
       )}
 
       {open ? (
         <Sheet titleId="plan-add-sheet-title" onClose={() => setOpen(false)}>
-            <header className="cc-sheet-head">
-              <span className="cc-eyebrow">Add to your day</span>
-              <h3 id="plan-add-sheet-title" className="cc-sheet-title" tabIndex={-1}>What would you like to add?</h3>
-            </header>
+          <header className="cc-sheet-head">
+            <span className="cc-eyebrow">Add to your day</span>
+            <h3
+              id="plan-add-sheet-title"
+              className="cc-sheet-title"
+              tabIndex={-1}
+            >
+              What would you like to add?
+            </h3>
+          </header>
 
-            <div className="cc-kind-row">
-              {(["appointment", "dinner", "event", "place", "transport", "accommodation"] as Kind[]).map((k) => (
-                <button key={k} type="button" className="cc-kind-chip" data-active={kind === k ? "" : undefined} onClick={() => setKind(k)}>
-                  {k === "appointment"
-                    ? "Appointment"
-                    : k === "dinner"
-                      ? "Dinner"
-                      : k === "event"
-                        ? "Event"
-                        : k === "place"
-                          ? "Place"
-                          : k === "transport"
-                            ? "Transport"
-                            : "Stay"}
+          <div className="cc-kind-row">
+            {(
+              [
+                "appointment",
+                "dinner",
+                "event",
+                "place",
+                "transport",
+                "accommodation",
+              ] as Kind[]
+            ).map((k) => (
+              <button
+                key={k}
+                type="button"
+                className="cc-kind-chip"
+                data-active={kind === k ? "" : undefined}
+                onClick={() => setKind(k)}
+              >
+                {k === "appointment"
+                  ? "Appointment"
+                  : k === "dinner"
+                    ? "Dinner"
+                    : k === "event"
+                      ? "Event"
+                      : k === "place"
+                        ? "Place"
+                        : k === "transport"
+                          ? "Transport"
+                          : "Stay"}
+              </button>
+            ))}
+          </div>
+
+          {kind === "transport" ? (
+            <>
+              <div className="cc-kind-row">
+                <button
+                  type="button"
+                  className="cc-kind-chip"
+                  data-active={tmode === "train" ? "" : undefined}
+                  onClick={() => setTmode("train")}
+                >
+                  Train
                 </button>
-              ))}
-            </div>
-
-            {kind === "transport" ? (
-              <>
-                <div className="cc-kind-row">
-                  <button type="button" className="cc-kind-chip" data-active={tmode === "train" ? "" : undefined} onClick={() => setTmode("train")}>Train</button>
-                  <button type="button" className="cc-kind-chip" data-active={tmode === "flight" ? "" : undefined} onClick={() => setTmode("flight")}>Flight</button>
-                </div>
-                <label className="cc-time-field">
-                  <span className="cc-var-label">From</span>
-                  <TransportHubPicker kind={hubKind} value={from} onChange={setFrom} name="from" placeholder={tmode === "flight" ? "Departure airport" : "From station"} />
+                <button
+                  type="button"
+                  className="cc-kind-chip"
+                  data-active={tmode === "flight" ? "" : undefined}
+                  onClick={() => setTmode("flight")}
+                >
+                  Flight
+                </button>
+              </div>
+              <label className="cc-time-field">
+                <span className="cc-var-label">From</span>
+                <TransportHubPicker
+                  kind={hubKind}
+                  value={from}
+                  onChange={setFrom}
+                  name="from"
+                  placeholder={
+                    tmode === "flight" ? "Departure airport" : "From station"
+                  }
+                />
+              </label>
+              <label className="cc-time-field">
+                <span className="cc-var-label">To</span>
+                <TransportHubPicker
+                  kind={hubKind}
+                  value={to}
+                  onChange={setTo}
+                  name="to"
+                  placeholder={
+                    tmode === "flight" ? "Arrival airport" : "To station"
+                  }
+                />
+              </label>
+              <div className="cc-dur-row">
+                <label>
+                  <span className="cc-var-label">Date</span>
+                  <input
+                    type="date"
+                    value={date}
+                    onChange={(e) => setDate(e.target.value)}
+                  />
                 </label>
-                <label className="cc-time-field">
-                  <span className="cc-var-label">To</span>
-                  <TransportHubPicker kind={hubKind} value={to} onChange={setTo} name="to" placeholder={tmode === "flight" ? "Arrival airport" : "To station"} />
+                <label>
+                  <span className="cc-var-label">Depart</span>
+                  <input
+                    type="time"
+                    value={depart}
+                    onChange={(e) => setDepart(e.target.value)}
+                  />
                 </label>
-                <div className="cc-dur-row">
-                  <label>
-                    <span className="cc-var-label">Date</span>
-                    <input type="date" value={date} onChange={(e) => setDate(e.target.value)} />
-                  </label>
-                  <label>
-                    <span className="cc-var-label">Depart</span>
-                    <input type="time" value={depart} onChange={(e) => setDepart(e.target.value)} />
-                  </label>
-                  <label>
-                    <span className="cc-var-label">Arrive</span>
-                    <input type="time" value={arrive} onChange={(e) => setArrive(e.target.value)} />
-                  </label>
-                </div>
+                <label>
+                  <span className="cc-var-label">Arrive</span>
+                  <input
+                    type="time"
+                    value={arrive}
+                    onChange={(e) => setArrive(e.target.value)}
+                  />
+                </label>
+              </div>
 
-                {/* Changeovers — each splits the journey into two booked legs, like the
+              {/* Changeovers — each splits the journey into two booked legs, like the
                     brief's booking card. */}
-                {changeovers.map((co, idx) => (
-                  <div key={idx} className="cc-co-row">
-                    <div className="cc-co-head">
-                      <span className="cc-var-label">{tmode === "flight" ? "Connection" : "Changeover"} {idx + 1}</span>
-                      <button type="button" className="cc-co-remove" onClick={() => setChangeovers((cs) => cs.filter((_, i) => i !== idx))} aria-label="Remove changeover">Remove</button>
-                    </div>
-                    <TransportHubPicker kind={hubKind} value={co.hub} onChange={(h) => setCo(idx, { hub: h })} name={`co-${idx}`} placeholder={tmode === "flight" ? "Connecting airport" : "Changeover station"} />
-                    <div className="cc-dur-row">
-                      <label>
-                        <span className="cc-var-label">Arrive</span>
-                        <input type="time" value={co.arriveTime} onChange={(e) => setCo(idx, { arriveTime: e.target.value })} />
-                      </label>
-                      <label>
-                        <span className="cc-var-label">Depart onward</span>
-                        <input type="time" value={co.departTime} onChange={(e) => setCo(idx, { departTime: e.target.value })} />
-                      </label>
-                    </div>
+              {changeovers.map((co, idx) => (
+                <div key={idx} className="cc-co-row">
+                  <div className="cc-co-head">
+                    <span className="cc-var-label">
+                      {tmode === "flight" ? "Connection" : "Changeover"}{" "}
+                      {idx + 1}
+                    </span>
+                    <button
+                      type="button"
+                      className="cc-co-remove"
+                      onClick={() =>
+                        setChangeovers((cs) => cs.filter((_, i) => i !== idx))
+                      }
+                      aria-label="Remove changeover"
+                    >
+                      Remove
+                    </button>
                   </div>
-                ))}
-                <button type="button" className="cc-co-add" onClick={() => setChangeovers((cs) => [...cs, { hub: { id: null, label: null }, arriveTime: "", departTime: "" }])}>
-                  + Add {tmode === "flight" ? "connection" : "changeover"}
-                </button>
+                  <TransportHubPicker
+                    kind={hubKind}
+                    value={co.hub}
+                    onChange={(h) => setCo(idx, { hub: h })}
+                    name={`co-${idx}`}
+                    placeholder={
+                      tmode === "flight"
+                        ? "Connecting airport"
+                        : "Changeover station"
+                    }
+                  />
+                  <div className="cc-dur-row">
+                    <label>
+                      <span className="cc-var-label">Arrive</span>
+                      <input
+                        type="time"
+                        value={co.arriveTime}
+                        onChange={(e) =>
+                          setCo(idx, { arriveTime: e.target.value })
+                        }
+                      />
+                    </label>
+                    <label>
+                      <span className="cc-var-label">Depart onward</span>
+                      <input
+                        type="time"
+                        value={co.departTime}
+                        onChange={(e) =>
+                          setCo(idx, { departTime: e.target.value })
+                        }
+                      />
+                    </label>
+                  </div>
+                </div>
+              ))}
+              <button
+                type="button"
+                className="cc-co-add"
+                onClick={() =>
+                  setChangeovers((cs) => [
+                    ...cs,
+                    {
+                      hub: { id: null, label: null },
+                      arriveTime: "",
+                      departTime: "",
+                    },
+                  ])
+                }
+              >
+                + Add {tmode === "flight" ? "connection" : "changeover"}
+              </button>
 
-                <div className="cc-dur-row">
-                  <label>
-                    <span className="cc-var-label">{tmode === "flight" ? "Flight no." : "Service no."} (optional)</span>
-                    <input type="text" value={serviceNumber} onChange={(e) => setServiceNumber(e.target.value)} placeholder={tmode === "flight" ? "BA2772" : "1F23"} />
-                  </label>
-                  <label>
-                    <span className="cc-var-label">Seat (optional)</span>
-                    <input type="text" value={seatNo} onChange={(e) => setSeatNo(e.target.value)} placeholder="12A" />
-                  </label>
-                </div>
-                <div className="cc-dur-row">
-                  <label>
-                    <span className="cc-var-label">{tmode === "flight" ? "Cabin" : "Class"} (optional)</span>
-                    <input type="text" value={ticketClass} onChange={(e) => setTicketClass(e.target.value)} placeholder={tmode === "flight" ? "Economy" : "Standard"} />
-                  </label>
-                  <label>
-                    <span className="cc-var-label">Price (optional)</span>
-                    <input type="text" value={tprice} onChange={(e) => setTprice(e.target.value)} placeholder="£48.50" />
-                  </label>
-                </div>
-                <label className="cc-time-field">
-                  <span className="cc-var-label">Booking ref (optional)</span>
-                  <input type="text" value={reference} onChange={(e) => setReference(e.target.value)} placeholder="e.g. MC287441" />
+              <div className="cc-dur-row">
+                <label>
+                  <span className="cc-var-label">
+                    {tmode === "flight" ? "Flight no." : "Service no."}{" "}
+                    (optional)
+                  </span>
+                  <input
+                    type="text"
+                    value={serviceNumber}
+                    onChange={(e) => setServiceNumber(e.target.value)}
+                    placeholder={tmode === "flight" ? "BA2772" : "1F23"}
+                  />
                 </label>
-              </>
-            ) : kind === "accommodation" ? (
-              <>
-                {/* A stay is a CONSTRAINT, not an event: check-in-from / check-out-by
+                <label>
+                  <span className="cc-var-label">Seat (optional)</span>
+                  <input
+                    type="text"
+                    value={seatNo}
+                    onChange={(e) => setSeatNo(e.target.value)}
+                    placeholder="12A"
+                  />
+                </label>
+              </div>
+              <div className="cc-dur-row">
+                <label>
+                  <span className="cc-var-label">
+                    {tmode === "flight" ? "Cabin" : "Class"} (optional)
+                  </span>
+                  <input
+                    type="text"
+                    value={ticketClass}
+                    onChange={(e) => setTicketClass(e.target.value)}
+                    placeholder={tmode === "flight" ? "Economy" : "Standard"}
+                  />
+                </label>
+                <label>
+                  <span className="cc-var-label">Price (optional)</span>
+                  <input
+                    type="text"
+                    value={tprice}
+                    onChange={(e) => setTprice(e.target.value)}
+                    placeholder="£48.50"
+                  />
+                </label>
+              </div>
+              <label className="cc-time-field">
+                <span className="cc-var-label">Booking ref (optional)</span>
+                <input
+                  type="text"
+                  value={reference}
+                  onChange={(e) => setReference(e.target.value)}
+                  placeholder="e.g. MC287441"
+                />
+              </label>
+            </>
+          ) : kind === "accommodation" ? (
+            <>
+              {/* A stay is a CONSTRAINT, not an event: check-in-from / check-out-by
                     (handover — accommodation is a window the day plans around). */}
-                <div className="cc-time-field">
-                  <span className="cc-var-label">Hotel</span>
-                  <PlacePicker
-                    customers={customers}
-                    customerSites={customerSites}
-                    locations={locations}
-                    value={place}
-                    onChange={setPlace}
-                    placeholder="Search the hotel, or type its name"
+              <div className="cc-time-field">
+                <span className="cc-var-label">Hotel</span>
+                <PlacePicker
+                  customers={customers}
+                  customerSites={customerSites}
+                  locations={locations}
+                  value={place}
+                  onChange={setPlace}
+                  placeholder="Search the hotel, or type its name"
+                />
+              </div>
+              <div className="cc-dur-row">
+                <label>
+                  <span className="cc-var-label">Check-in from</span>
+                  <input
+                    type="date"
+                    value={checkInDate}
+                    onChange={(e) => setCheckInDate(e.target.value)}
                   />
-                </div>
-                <div className="cc-dur-row">
-                  <label>
-                    <span className="cc-var-label">Check-in from</span>
-                    <input type="date" value={checkInDate} onChange={(e) => setCheckInDate(e.target.value)} />
-                  </label>
-                  <label>
-                    <span className="cc-var-label">Time</span>
-                    <input type="time" value={checkInTime} onChange={(e) => setCheckInTime(e.target.value)} />
-                  </label>
-                </div>
-                <div className="cc-dur-row">
-                  <label>
-                    <span className="cc-var-label">Check-out by</span>
-                    <input type="date" value={checkOutDate} onChange={(e) => setCheckOutDate(e.target.value)} />
-                  </label>
-                  <label>
-                    <span className="cc-var-label">Time</span>
-                    <input type="time" value={checkOutTime} onChange={(e) => setCheckOutTime(e.target.value)} />
-                  </label>
-                </div>
-                <div className="cc-dur-row">
-                  <label>
-                    <span className="cc-var-label">Confirmation</span>
-                    <input type="text" value={acc.confirmation_ref ?? ""} onChange={(e) => setA({ confirmation_ref: e.target.value })} placeholder="Booking ref" />
-                  </label>
-                  <label>
-                    <span className="cc-var-label">Booked via</span>
-                    <select value={acc.channel ?? ""} onChange={(e) => setA({ channel: (e.target.value || null) as BookingChannel | null })}>
-                      <option value="">—</option>
-                      {(Object.keys(CHANNEL_LABELS) as BookingChannel[]).map((c) => (
-                        <option key={c} value={c}>{CHANNEL_LABELS[c]}</option>
-                      ))}
-                    </select>
-                  </label>
-                </div>
-                <div className="cc-dur-row">
-                  <label>
-                    <span className="cc-var-label">Room</span>
-                    <input type="text" value={acc.room_type ?? ""} onChange={(e) => setA({ room_type: e.target.value })} placeholder="e.g. King, 2 guests" />
-                  </label>
-                  <label>
-                    <span className="cc-var-label">Board</span>
-                    <select value={acc.board_basis ?? ""} onChange={(e) => setA({ board_basis: (e.target.value || null) as BoardBasis | null })}>
-                      <option value="">—</option>
-                      {(Object.keys(BOARD_LABELS) as BoardBasis[]).map((b) => (
-                        <option key={b} value={b}>{BOARD_LABELS[b]}</option>
-                      ))}
-                    </select>
-                  </label>
-                </div>
-
-                <button type="button" className="cc-stay-expand" aria-expanded={accMore} onClick={() => setAccMore((v) => !v)}>
-                  <span className="cc-chev" aria-hidden>›</span>
-                  Arrival details (wifi, parking, check-in…)
-                </button>
-                {accMore ? (
-                  <div className="cc-stay-detail">
-                    <label className="cc-stay-wide">
-                      <span className="cc-var-label">Hotel phone</span>
-                      <input type="tel" value={acc.phone ?? ""} onChange={(e) => setA({ phone: e.target.value })} placeholder="For 'hold my room, running late'" />
-                    </label>
-                    <label className="cc-stay-wide">
-                      <span className="cc-var-label">Check-in / access</span>
-                      <input type="text" value={acc.access_instructions ?? ""} onChange={(e) => setA({ access_instructions: e.target.value })} placeholder="Front desk · or lockbox code" />
-                    </label>
-                    <label>
-                      <span className="cc-var-label">Wi-Fi network</span>
-                      <input type="text" value={acc.wifi_ssid ?? ""} onChange={(e) => setA({ wifi_ssid: e.target.value })} />
-                    </label>
-                    <label>
-                      <span className="cc-var-label">Wi-Fi password</span>
-                      <input type="text" value={acc.wifi_password ?? ""} onChange={(e) => setA({ wifi_password: e.target.value })} />
-                    </label>
-                    <label className="cc-stay-wide">
-                      <span className="cc-var-label">Parking</span>
-                      <input type="text" value={acc.parking_info ?? ""} onChange={(e) => setA({ parking_info: e.target.value })} placeholder="On-site £18/night · or none" />
-                    </label>
-                    <label className="cc-stay-wide">
-                      <span className="cc-var-label">Breakfast hours</span>
-                      <input type="text" value={acc.breakfast_window ?? ""} onChange={(e) => setA({ breakfast_window: e.target.value })} placeholder="07:00–10:30" />
-                    </label>
-                    <label className="cc-stay-wide">
-                      <span className="cc-var-label">Cancellation</span>
-                      <input type="text" value={acc.cancellation_policy ?? ""} onChange={(e) => setA({ cancellation_policy: e.target.value })} placeholder="Free cancellation policy" />
-                    </label>
-                    <label>
-                      <span className="cc-var-label">Free-cancel until</span>
-                      <input type="date" value={acc.free_cancel_until ?? ""} onChange={(e) => setA({ free_cancel_until: e.target.value })} />
-                    </label>
-                    <label>
-                      <span className="cc-var-label">Price</span>
-                      <input type="text" value={acc.price ?? ""} onChange={(e) => setA({ price: e.target.value })} placeholder="£240" />
-                    </label>
-                  </div>
-                ) : null}
-              </>
-            ) : kind === "dinner" ? (
-              <>
-                {/* A dinner reservation: the restaurant, a fixed time, how many,
-                    and who. Its own bespoke fields — nothing extraneous. */}
-                <div className="cc-time-field">
-                  <span className="cc-var-label">Restaurant</span>
-                  <PlacePicker
-                    customers={customers}
-                    customerSites={customerSites}
-                    locations={locations}
-                    value={place}
-                    onChange={setPlace}
-                    googleTypes="restaurant"
-                    placeholder="Search the restaurant, or type its name"
-                  />
-                </div>
-                <div className="cc-dur-row">
-                  <label>
-                    <span className="cc-var-label">Date</span>
-                    <input type="date" value={mealDate} onChange={(e) => setMealDate(e.target.value)} />
-                  </label>
-                  <label>
-                    <span className="cc-var-label">Time</span>
-                    <input type="time" value={mealTime} onChange={(e) => setMealTime(e.target.value)} />
-                  </label>
-                  <label>
-                    <span className="cc-var-label">Party size</span>
-                    <input type="number" min="1" max="50" value={partySize} onChange={(e) => setPartySize(e.target.value)} placeholder="2" />
-                  </label>
-                </div>
-                <div className="cc-time-field">
-                  <span className="cc-var-label">Who’s coming (optional)</span>
-                  <ContactPicker value={who} onChange={setWho} />
-                </div>
-                <label className="cc-time-field">
-                  <span className="cc-var-label">Name (optional)</span>
-                  <input type="text" value={title} onChange={(e) => setTitle(e.target.value)} placeholder="e.g. Birthday dinner" />
                 </label>
-              </>
-            ) : (
-              <>
-                {/* An Appointment or Event has its own name ("what"), distinct from
+                <label>
+                  <span className="cc-var-label">Time</span>
+                  <input
+                    type="time"
+                    value={checkInTime}
+                    onChange={(e) => setCheckInTime(e.target.value)}
+                  />
+                </label>
+              </div>
+              <div className="cc-dur-row">
+                <label>
+                  <span className="cc-var-label">Check-out by</span>
+                  <input
+                    type="date"
+                    value={checkOutDate}
+                    onChange={(e) => setCheckOutDate(e.target.value)}
+                  />
+                </label>
+                <label>
+                  <span className="cc-var-label">Time</span>
+                  <input
+                    type="time"
+                    value={checkOutTime}
+                    onChange={(e) => setCheckOutTime(e.target.value)}
+                  />
+                </label>
+              </div>
+              <div className="cc-dur-row">
+                <label>
+                  <span className="cc-var-label">Confirmation</span>
+                  <input
+                    type="text"
+                    value={acc.confirmation_ref ?? ""}
+                    onChange={(e) => setA({ confirmation_ref: e.target.value })}
+                    placeholder="Booking ref"
+                  />
+                </label>
+                <label>
+                  <span className="cc-var-label">Booked via</span>
+                  <select
+                    value={acc.channel ?? ""}
+                    onChange={(e) =>
+                      setA({
+                        channel: (e.target.value ||
+                          null) as BookingChannel | null,
+                      })
+                    }
+                  >
+                    <option value="">—</option>
+                    {(Object.keys(CHANNEL_LABELS) as BookingChannel[]).map(
+                      (c) => (
+                        <option key={c} value={c}>
+                          {CHANNEL_LABELS[c]}
+                        </option>
+                      ),
+                    )}
+                  </select>
+                </label>
+              </div>
+              <div className="cc-dur-row">
+                <label>
+                  <span className="cc-var-label">Room</span>
+                  <input
+                    type="text"
+                    value={acc.room_type ?? ""}
+                    onChange={(e) => setA({ room_type: e.target.value })}
+                    placeholder="e.g. King, 2 guests"
+                  />
+                </label>
+                <label>
+                  <span className="cc-var-label">Board</span>
+                  <select
+                    value={acc.board_basis ?? ""}
+                    onChange={(e) =>
+                      setA({
+                        board_basis: (e.target.value ||
+                          null) as BoardBasis | null,
+                      })
+                    }
+                  >
+                    <option value="">—</option>
+                    {(Object.keys(BOARD_LABELS) as BoardBasis[]).map((b) => (
+                      <option key={b} value={b}>
+                        {BOARD_LABELS[b]}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </div>
+
+              <button
+                type="button"
+                className="cc-stay-expand"
+                aria-expanded={accMore}
+                onClick={() => setAccMore((v) => !v)}
+              >
+                <span className="cc-chev" aria-hidden>
+                  ›
+                </span>
+                Arrival details (wifi, parking, check-in…)
+              </button>
+              {accMore ? (
+                <div className="cc-stay-detail">
+                  <label className="cc-stay-wide">
+                    <span className="cc-var-label">Hotel phone</span>
+                    <input
+                      type="tel"
+                      value={acc.phone ?? ""}
+                      onChange={(e) => setA({ phone: e.target.value })}
+                      placeholder="For 'hold my room, running late'"
+                    />
+                  </label>
+                  <label className="cc-stay-wide">
+                    <span className="cc-var-label">Check-in / access</span>
+                    <input
+                      type="text"
+                      value={acc.access_instructions ?? ""}
+                      onChange={(e) =>
+                        setA({ access_instructions: e.target.value })
+                      }
+                      placeholder="Front desk · or lockbox code"
+                    />
+                  </label>
+                  <label>
+                    <span className="cc-var-label">Wi-Fi network</span>
+                    <input
+                      type="text"
+                      value={acc.wifi_ssid ?? ""}
+                      onChange={(e) => setA({ wifi_ssid: e.target.value })}
+                    />
+                  </label>
+                  <label>
+                    <span className="cc-var-label">Wi-Fi password</span>
+                    <input
+                      type="text"
+                      value={acc.wifi_password ?? ""}
+                      onChange={(e) => setA({ wifi_password: e.target.value })}
+                    />
+                  </label>
+                  <label className="cc-stay-wide">
+                    <span className="cc-var-label">Parking</span>
+                    <input
+                      type="text"
+                      value={acc.parking_info ?? ""}
+                      onChange={(e) => setA({ parking_info: e.target.value })}
+                      placeholder="On-site £18/night · or none"
+                    />
+                  </label>
+                  <label className="cc-stay-wide">
+                    <span className="cc-var-label">Breakfast hours</span>
+                    <input
+                      type="text"
+                      value={acc.breakfast_window ?? ""}
+                      onChange={(e) =>
+                        setA({ breakfast_window: e.target.value })
+                      }
+                      placeholder="07:00–10:30"
+                    />
+                  </label>
+                  <label className="cc-stay-wide">
+                    <span className="cc-var-label">Cancellation</span>
+                    <input
+                      type="text"
+                      value={acc.cancellation_policy ?? ""}
+                      onChange={(e) =>
+                        setA({ cancellation_policy: e.target.value })
+                      }
+                      placeholder="Free cancellation policy"
+                    />
+                  </label>
+                  <label>
+                    <span className="cc-var-label">Free-cancel until</span>
+                    <input
+                      type="date"
+                      value={acc.free_cancel_until ?? ""}
+                      onChange={(e) =>
+                        setA({ free_cancel_until: e.target.value })
+                      }
+                    />
+                  </label>
+                  <label>
+                    <span className="cc-var-label">Price</span>
+                    <input
+                      type="text"
+                      value={acc.price ?? ""}
+                      onChange={(e) => setA({ price: e.target.value })}
+                      placeholder="£240"
+                    />
+                  </label>
+                </div>
+              ) : null}
+            </>
+          ) : kind === "dinner" ? (
+            <>
+              {/* A dinner reservation: the restaurant, a fixed time, how many,
+                    and who. Its own bespoke fields — nothing extraneous. */}
+              <div className="cc-time-field">
+                <span className="cc-var-label">Restaurant</span>
+                <PlacePicker
+                  customers={customers}
+                  customerSites={customerSites}
+                  locations={locations}
+                  value={place}
+                  onChange={setPlace}
+                  googleTypes="restaurant"
+                  placeholder="Search the restaurant, or type its name"
+                />
+              </div>
+              <div className="cc-dur-row">
+                <label>
+                  <span className="cc-var-label">Date</span>
+                  <input
+                    type="date"
+                    value={mealDate}
+                    onChange={(e) => setMealDate(e.target.value)}
+                  />
+                </label>
+                <label>
+                  <span className="cc-var-label">Time</span>
+                  <input
+                    type="time"
+                    value={mealTime}
+                    onChange={(e) => setMealTime(e.target.value)}
+                  />
+                </label>
+                <label>
+                  <span className="cc-var-label">Party size</span>
+                  <input
+                    type="number"
+                    min="1"
+                    max="50"
+                    value={partySize}
+                    onChange={(e) => setPartySize(e.target.value)}
+                    placeholder="2"
+                  />
+                </label>
+              </div>
+              <div className="cc-time-field">
+                <span className="cc-var-label">Who’s coming (optional)</span>
+                <ContactPicker value={who} onChange={setWho} />
+              </div>
+              <label className="cc-time-field">
+                <span className="cc-var-label">Name (optional)</span>
+                <input
+                  type="text"
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  placeholder="e.g. Birthday dinner"
+                />
+              </label>
+            </>
+          ) : (
+            <>
+              {/* An Appointment or Event has its own name ("what"), distinct from
                     where it happens. A Place IS its place — one search box, no
                     separate name field (the picked place's name becomes the title). */}
-                {kind === "appointment" || kind === "event" ? (
-                  <label className="cc-time-field">
-                    <span className="cc-var-label">What</span>
-                    <input type="text" value={title} onChange={(e) => setTitle(e.target.value)}
-                      placeholder={kind === "event" ? "Keynote, show, expo…" : "Client meeting"} autoFocus />
-                  </label>
-                ) : null}
-                {/* NOT a <label>: PlacePicker renders its own input plus a
+              {kind === "appointment" || kind === "event" ? (
+                <label className="cc-time-field">
+                  <span className="cc-var-label">What</span>
+                  <input
+                    type="text"
+                    value={title}
+                    onChange={(e) => setTitle(e.target.value)}
+                    placeholder={
+                      kind === "event"
+                        ? "Keynote, show, expo…"
+                        : "Client meeting"
+                    }
+                    autoFocus
+                  />
+                </label>
+              ) : null}
+              {/* NOT a <label>: PlacePicker renders its own input plus a
                     dropdown of <button> options. A wrapping <label> forwards
                     clicks to its control, which swallowed the option click and
                     left the selection unsaved. Use a plain div. */}
-                <div className="cc-time-field">
-                  <span className="cc-var-label">{kind === "place" ? "Place" : "Where"}</span>
-                  <PlacePicker
-                    customers={customers}
-                    customerSites={customerSites}
-                    locations={locations}
-                    value={place}
-                    onChange={setPlace}
-                    placeholder={kind === "place" ? "Search a place, or type a new one" : "Search where it happens"}
-                  />
-                </div>
-                {/* Arrive + leave — set both for a window ("at the office 9 to 5"),
+              <div className="cc-time-field">
+                <span className="cc-var-label">
+                  {kind === "place" ? "Place" : "Where"}
+                </span>
+                <PlacePicker
+                  customers={customers}
+                  customerSites={customerSites}
+                  locations={locations}
+                  value={place}
+                  onChange={setPlace}
+                  placeholder={
+                    kind === "place"
+                      ? "Search a place, or type a new one"
+                      : "Search where it happens"
+                  }
+                />
+              </div>
+              {/* Arrive + leave — set both for a window ("at the office 9 to 5"),
                     or just one. The day solver fills the rest around it. */}
-                <div className="cc-dur-row">
-                  <label>
-                    <span className="cc-var-label">Arrive by</span>
-                    <input type="time" value={arriveBy} onChange={(e) => setArriveBy(e.target.value)} />
-                  </label>
-                  <label>
-                    <span className="cc-var-label">Leave by</span>
-                    <input type="time" value={leaveBy} onChange={(e) => setLeaveBy(e.target.value)} />
-                  </label>
+              <div className="cc-dur-row">
+                <label>
+                  <span className="cc-var-label">Arrive by</span>
+                  <input
+                    type="time"
+                    value={arriveBy}
+                    onChange={(e) => setArriveBy(e.target.value)}
+                  />
+                </label>
+                <label>
+                  <span className="cc-var-label">Leave by</span>
+                  <input
+                    type="time"
+                    value={leaveBy}
+                    onChange={(e) => setLeaveBy(e.target.value)}
+                  />
+                </label>
+              </div>
+              {kind === "appointment" ? (
+                <div className="cc-time-field">
+                  <span className="cc-var-label">Who (optional)</span>
+                  <ContactPicker value={who} onChange={setWho} />
                 </div>
-                {kind === "appointment" ? (
-                  <div className="cc-time-field">
-                    <span className="cc-var-label">Who (optional)</span>
-                    <ContactPicker value={who} onChange={setWho} />
-                  </div>
-                ) : null}
-                <p style={{ marginTop: "calc(-1 * var(--space-1))", fontSize: "var(--fs-micro)", color: "var(--ink-faint)" }}>
-                  Set both for a window, e.g. 09:00 to 17:00. Leave blank if it’s flexible.
-                </p>
-              </>
-            )}
+              ) : null}
+              <p
+                style={{
+                  marginTop: "calc(-1 * var(--space-1))",
+                  fontSize: "var(--fs-micro)",
+                  color: "var(--ink-faint)",
+                }}
+              >
+                Set both for a window, e.g. 09:00 to 17:00. Leave blank if it’s
+                flexible.
+              </p>
+            </>
+          )}
 
-            {error ? <p className="cc-sheet-error">{error}</p> : null}
+          {error ? <p className="cc-sheet-error">{error}</p> : null}
 
-            <div className="cc-sheet-actions">
-              <button type="button" className="cc-btn cc-btn-ghost" onClick={() => setOpen(false)} disabled={pending}>
-                Cancel
-              </button>
-              <button type="button" className="cc-btn cc-btn-gold" onClick={save} disabled={pending}>
-                {pending ? "Adding…" : "Add it"}
-              </button>
-            </div>
+          <div className="cc-sheet-actions">
+            <button
+              type="button"
+              className="cc-btn cc-btn-ghost"
+              onClick={() => setOpen(false)}
+              disabled={pending}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="cc-btn cc-btn-gold"
+              onClick={save}
+              disabled={pending}
+            >
+              {pending ? "Adding…" : "Add it"}
+            </button>
+          </div>
         </Sheet>
       ) : null}
     </>

--- a/src/components/today/live-day.tsx
+++ b/src/components/today/live-day.tsx
@@ -56,7 +56,7 @@ function compactDuration(minutes: number): string {
 function NextActionIcon({
   name,
 }: {
-  name: "arrow" | "share" | "reroute" | "ticket";
+  name: "arrow" | "share" | "reroute" | "ticket" | "walk" | "flag" | "clock";
 }) {
   const path = {
     arrow: "M5 12h14m-5-5 5 5-5 5",
@@ -66,6 +66,9 @@ function NextActionIcon({
       "M16 3h5v5M4 20l6.5-6.5a4 4 0 0 1 5.7 0L21 18M21 3l-6.5 6.5M4 4l5 5",
     ticket:
       "M3 7a2 2 0 0 0 2-2h14a2 2 0 0 0 2 2v2a3 3 0 0 0 0 6v2a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-2a3 3 0 0 0 0-6V7Zm9-2v14",
+    walk: "M13.5 5.5a2 2 0 1 0 0-4 2 2 0 0 0 0 4ZM8.5 10l2.2-2.2 2.8 1.7 2.4 2.5M10.7 7.8 9.5 13l-3.2 3.1M12.2 12.2l2.2 3.2.8 4.1M9.5 13l2.7 2.5-2.1 4",
+    flag: "M5 21V4m0 1h10l-1.5 3L15 11H5",
+    clock: "M12 21a9 9 0 1 0 0-18 9 9 0 0 0 0 18Zm0-13v5l3 2",
   }[name];
 
   return (
@@ -383,10 +386,15 @@ export function LiveDay({
         isArrived || isScheduledOutcome ? "comfortable" : urgencyOf(feas)
       }
     >
-      <span className="cc-at-status">
-        <span className="cc-at-dot" />
-        {status}
-      </span>
+      <div className="cc-next-move-head">
+        <span className="cc-at-status">
+          <span className="cc-at-dot" />
+          {status}
+        </span>
+        <span className="cc-next-priority">
+          {isPreparing ? "Priority" : "Live"}
+        </span>
+      </div>
 
       <div className="pg cc-setoff-sheet">
         <div className="cc-setoff-eyb">
@@ -437,11 +445,20 @@ export function LiveDay({
         {isPreparing ? (
           <div className="cc-next-facts">
             <span>
+              <NextActionIcon name="walk" />
               {feas.travelMinutes} min {mode === "drive" ? "by car" : mode}
             </span>
-            {arrivalLabel ? <span>Arrive by {arrivalLabel}</span> : null}
+            {arrivalLabel ? (
+              <span>
+                <NextActionIcon name="flag" />
+                Arrive by {arrivalLabel}
+              </span>
+            ) : null}
             {feas.bufferMinutes > 0 ? (
-              <span>{feas.bufferMinutes} min early</span>
+              <span>
+                <NextActionIcon name="clock" />
+                {feas.bufferMinutes} min early
+              </span>
             ) : null}
           </div>
         ) : null}
@@ -473,7 +490,7 @@ export function LiveDay({
           className="cc-next-action cc-next-action--primary"
           onClick={() => router.push("/navigate")}
         >
-          <span>View best route</span>
+          <span className="cc-next-action-label">View best route</span>
           <NextActionIcon name="arrow" />
         </button>
         <button
@@ -482,7 +499,7 @@ export function LiveDay({
           onClick={() => void shareTrip()}
         >
           <NextActionIcon name="share" />
-          <span>Share trip</span>
+          <span className="cc-next-action-label">Share trip</span>
         </button>
         <button
           type="button"
@@ -494,7 +511,7 @@ export function LiveDay({
           }}
         >
           <NextActionIcon name="reroute" />
-          <span>Re-route</span>
+          <span className="cc-next-action-label">Re-route</span>
         </button>
         <button
           type="button"
@@ -502,7 +519,7 @@ export function LiveDay({
           onClick={() => router.push("/wallet")}
         >
           <NextActionIcon name="ticket" />
-          <span>Tickets</span>
+          <span className="cc-next-action-label">Tickets</span>
         </button>
       </div>
 

--- a/src/components/today/today-buffer-control.tsx
+++ b/src/components/today/today-buffer-control.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { updateTravelProfile } from "@/lib/actions/travel-profile";
+import { feedbackFromError } from "@/lib/actions/_form";
+
+const DEFAULT_MARGIN_MINUTES = 15;
+
+export function TodayBufferControl({
+  initialMinutes,
+}: {
+  initialMinutes: number;
+}) {
+  const router = useRouter();
+  const preferredMinutes =
+    initialMinutes > 0 ? initialMinutes : DEFAULT_MARGIN_MINUTES;
+  const [enabled, setEnabled] = useState(initialMinutes > 0);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  function toggle() {
+    const nextEnabled = !enabled;
+    setEnabled(nextEnabled);
+    setError(null);
+
+    startTransition(async () => {
+      const result = await updateTravelProfile({
+        default_arrival_buffer_minutes: nextEnabled ? preferredMinutes : 0,
+      });
+
+      if (!result.ok) {
+        setEnabled(!nextEnabled);
+        setError(feedbackFromError(result.error).message);
+        return;
+      }
+
+      router.refresh();
+    });
+  }
+
+  return (
+    <div className="cc-today-buffer" data-pending={pending || undefined}>
+      <span className="cc-today-buffer-copy">
+        <strong>Keep {preferredMinutes}-min margin</strong>
+        <span>Adjust the buffer before departure</span>
+      </span>
+      <button
+        type="button"
+        className="cc-today-buffer-switch"
+        role="switch"
+        aria-checked={enabled}
+        aria-label={`Keep a ${preferredMinutes}-minute arrival margin`}
+        disabled={pending}
+        onClick={toggle}
+      >
+        <span />
+      </button>
+      {error ? (
+        <span className="cc-today-buffer-error" role="alert">
+          {error}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/today/today-direction-layout.test.ts
+++ b/src/components/today/today-direction-layout.test.ts
@@ -14,21 +14,21 @@ const appLayout = readFileSync(
   "utf8",
 );
 const directionCss = readFileSync(
-  new URL("../../app/khonsera-today-direction.css", import.meta.url),
+  new URL("../../app/khonsera-screen-one.css", import.meta.url),
   "utf8",
 );
 
-describe("the approved Today application direction", () => {
-  it("keeps the next move and route map inside one dominant command surface", () => {
+describe("the approved Screen One Today direction", () => {
+  it("keeps one dominant next-move surface ahead of weather and itinerary", () => {
     const command = todayPage.indexOf('className="cc-today-command"');
-    const map = todayPage.indexOf('className="cc-today-command-map"');
     const forecast = todayPage.indexOf('className="cc-day-forecast"');
     const itinerary = todayPage.indexOf('className="cc-day-primary"');
 
     expect(command).toBeGreaterThan(-1);
-    expect(map).toBeGreaterThan(command);
-    expect(forecast).toBeGreaterThan(map);
+    expect(forecast).toBeGreaterThan(command);
     expect(itinerary).toBeGreaterThan(forecast);
+    expect(todayPage).not.toContain('className="cc-today-command-map"');
+    expect(todayPage).not.toContain("<PlanMap");
   });
 
   it("retains the four approved next-move actions", () => {
@@ -44,9 +44,17 @@ describe("the approved Today application direction", () => {
     expect(appLayout).not.toContain("cc-app-desktop");
   });
 
-  it("styles the itinerary as one continuous object", () => {
+  it("keeps the screen controls wired to real product flows", () => {
+    expect(todayPage).toContain("<TodayBufferControl");
+    expect(todayPage).toContain("Tickets today");
+    expect(todayPage).toContain('label="Plan something"');
+  });
+
+  it("implements the compact orange timeline and operational pass", () => {
+    expect(directionCss).toContain("--kh-today-accent: var(--rail)");
+    expect(directionCss).toContain(".cc-today-buffer");
+    expect(directionCss).toContain(".cc-timeline-icon");
+    expect(directionCss).toContain(".cc-pass.cc-pass--today");
     expect(directionCss).toContain(".cc-today-direction .cc-spine {");
-    expect(directionCss).toContain("border-radius: 22px");
-    expect(directionCss).toContain(".cc-today-command-map");
   });
 });

--- a/src/components/today/today-spine-fixed.tsx
+++ b/src/components/today/today-spine-fixed.tsx
@@ -1,9 +1,25 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import {
+  Bike,
+  BriefcaseBusiness,
+  CarFront,
+  Footprints,
+  MapPin,
+  Plane,
+  RefreshCw,
+  Ticket,
+  TrainFront,
+} from "lucide-react";
 import type { SpineAnchor } from "./spine-model";
 import { londonClock, navigateHref, roleLabel } from "./spine-model";
-import { pickNextIndex, READINESS_BUFFER_MIN, STATION_BUFFER_MIN, type EngineAnchor } from "@/lib/today/engine";
+import {
+  pickNextIndex,
+  READINESS_BUFFER_MIN,
+  STATION_BUFFER_MIN,
+  type EngineAnchor,
+} from "@/lib/today/engine";
 import { LivePass } from "@/components/plan/live-pass";
 import { ScanView } from "@/components/concierge";
 import type { BarcodeVM, TicketVM } from "@/components/concierge";
@@ -21,7 +37,11 @@ const TYPE_LABEL: Record<SpineAnchor["type"], string> = {
 };
 
 type State = "past" | "next" | "future";
-type TimedLeg = { departIso: string | null; arriveIso: string | null; spareMinutes: number | null };
+type TimedLeg = {
+  departIso: string | null;
+  arriveIso: string | null;
+  spareMinutes: number | null;
+};
 
 function ms(iso: string | null | undefined): number | null {
   if (!iso) return null;
@@ -58,33 +78,56 @@ function previousPassEndsAt(
   );
 }
 
-function movementTimes(anchor: SpineAnchor, previous: SpineAnchor | null): TimedLeg {
+function movementTimes(
+  anchor: SpineAnchor,
+  previous: SpineAnchor | null,
+): TimedLeg {
   const minutes = anchor.plannedTravelMinutes;
   const targetMs = ms(anchor.arriveByIso);
-  if (minutes == null || targetMs == null) return { departIso: null, arriveIso: null, spareMinutes: null };
+  if (minutes == null || targetMs == null)
+    return { departIso: null, arriveIso: null, spareMinutes: null };
 
   const durationMs = minutes * 60_000;
-  const bufferMinutes = anchor.bufferMinutes ?? (anchor.station ? STATION_BUFFER_MIN : READINESS_BUFFER_MIN);
+  const bufferMinutes =
+    anchor.bufferMinutes ??
+    (anchor.station ? STATION_BUFFER_MIN : READINESS_BUFFER_MIN);
   const preferredArrivalMs = targetMs - bufferMinutes * 60_000;
   const preferredDepartureMs = preferredArrivalMs - durationMs;
-  const previousEndMs = previous ? ms(previous.endIso ?? previous.arriveByIso) : null;
+  const previousEndMs = previous
+    ? ms(previous.endIso ?? previous.arriveByIso)
+    : null;
   const explicitNotBeforeMs = ms(anchor.notBeforeIso);
-  const notBeforeMs = explicitNotBeforeMs ?? (previous?.type === "shift" ? previousEndMs : null);
+  const notBeforeMs =
+    explicitNotBeforeMs ?? (previous?.type === "shift" ? previousEndMs : null);
 
   if (anchor.station) {
-    const departMs = notBeforeMs == null ? preferredDepartureMs : Math.max(preferredDepartureMs, notBeforeMs);
+    const departMs =
+      notBeforeMs == null
+        ? preferredDepartureMs
+        : Math.max(preferredDepartureMs, notBeforeMs);
     const arriveMs = departMs + durationMs;
     const spare = Math.round((targetMs - arriveMs) / 60_000);
-    return { departIso: iso(departMs), arriveIso: iso(arriveMs), spareMinutes: spare };
+    return {
+      departIso: iso(departMs),
+      arriveIso: iso(arriveMs),
+      spareMinutes: spare,
+    };
   }
 
   if (previousEndMs != null) {
     const arriveMs = previousEndMs + durationMs;
     const spare = Math.round((targetMs - arriveMs) / 60_000);
-    return { departIso: iso(previousEndMs), arriveIso: iso(arriveMs), spareMinutes: spare };
+    return {
+      departIso: iso(previousEndMs),
+      arriveIso: iso(arriveMs),
+      spareMinutes: spare,
+    };
   }
 
-  const departMs = notBeforeMs == null ? preferredDepartureMs : Math.max(preferredDepartureMs, notBeforeMs);
+  const departMs =
+    notBeforeMs == null
+      ? preferredDepartureMs
+      : Math.max(preferredDepartureMs, notBeforeMs);
   const arriveMs = departMs + durationMs;
   return {
     departIso: iso(departMs),
@@ -93,11 +136,26 @@ function movementTimes(anchor: SpineAnchor, previous: SpineAnchor | null): Timed
   };
 }
 
-export function TodaySpine({ anchors, nextId, nowOverride }: { anchors: SpineAnchor[]; nextId?: string | null; nowOverride?: number | null }) {
+export function TodaySpine({
+  anchors,
+  nextId,
+  nowOverride,
+  toolbar,
+  resolveEndContext = true,
+}: {
+  anchors: SpineAnchor[];
+  nextId?: string | null;
+  nowOverride?: number | null;
+  toolbar?: ReactNode;
+  resolveEndContext?: boolean;
+}) {
   const [internalNow, setInternalNow] = useState(() => Date.now());
   const [showPast, setShowPast] = useState(false);
   const [showLater, setShowLater] = useState(false);
-  const [scan, setScan] = useState<{ summary: string; barcodes: BarcodeVM[] } | null>(null);
+  const [scan, setScan] = useState<{
+    summary: string;
+    barcodes: BarcodeVM[];
+  } | null>(null);
   const [endContext, setEndContext] = useState<SpineAnchor | null>(null);
   const finalVisibleId = anchors[anchors.length - 1]?.id ?? null;
 
@@ -110,15 +168,21 @@ export function TodaySpine({ anchors, nextId, nowOverride }: { anchors: SpineAnc
   useEffect(() => {
     let active = true;
     setEndContext(null);
-    if (!finalVisibleId) return () => { active = false; };
+    if (!resolveEndContext || !finalVisibleId)
+      return () => {
+        active = false;
+      };
     void loadEndContextForStop(finalVisibleId).then((context) => {
       if (active) setEndContext(context);
     });
-    return () => { active = false; };
-  }, [finalVisibleId]);
+    return () => {
+      active = false;
+    };
+  }, [finalVisibleId, resolveEndContext]);
 
   const resolvedAnchors = useMemo(() => {
-    if (!endContext || anchors.some((anchor) => anchor.id === endContext.id)) return anchors;
+    if (!endContext || anchors.some((anchor) => anchor.id === endContext.id))
+      return anchors;
     return [...anchors, endContext];
   }, [anchors, endContext]);
 
@@ -135,38 +199,69 @@ export function TodaySpine({ anchors, nextId, nowOverride }: { anchors: SpineAnc
       isBlockingSpan: anchor.type === "shift",
     }));
     const index = pickNextIndex(engineAnchors, now);
-    return index == null ? nextId ?? null : resolvedAnchors[index]?.id ?? nextId ?? null;
+    return index == null
+      ? (nextId ?? null)
+      : (resolvedAnchors[index]?.id ?? nextId ?? null);
   }, [resolvedAnchors, nextId, now]);
 
   if (!resolvedAnchors.length) return null;
 
-  const nextIndex = Math.max(0, resolvedAnchors.findIndex((anchor) => anchor.id === activeNextId));
+  const nextIndex = Math.max(
+    0,
+    resolvedAnchors.findIndex((anchor) => anchor.id === activeNextId),
+  );
   const past = resolvedAnchors.slice(0, nextIndex);
-  const currentAndNear = resolvedAnchors.slice(nextIndex, Math.min(resolvedAnchors.length, nextIndex + 5));
-  const later = resolvedAnchors.slice(Math.min(resolvedAnchors.length, nextIndex + 5));
+  const currentAndNear = resolvedAnchors.slice(
+    nextIndex,
+    Math.min(resolvedAnchors.length, nextIndex + 5),
+  );
+  const later = resolvedAnchors.slice(
+    Math.min(resolvedAnchors.length, nextIndex + 5),
+  );
 
   const openTicket = (ticket: TicketVM) => {
     const leg = ticket.legs[0];
     if (!leg?.barcodes?.length) return;
-    setScan({ summary: `${ticket.operator} · ${leg.origin.place} → ${leg.destination.place}`, barcodes: leg.barcodes });
+    setScan({
+      summary: `${ticket.operator} · ${leg.origin.place} → ${leg.destination.place}`,
+      barcodes: leg.barcodes,
+    });
   };
 
   return (
     <section>
       <div className="cc-spine-heading">
         <span className="cc-eyebrow">Your itinerary</span>
-        <span>{resolvedAnchors.length} timed point{resolvedAnchors.length === 1 ? "" : "s"}</span>
+        <span>
+          {resolvedAnchors.length} timed point
+          {resolvedAnchors.length === 1 ? "" : "s"}
+        </span>
       </div>
+      {toolbar ? <div className="cc-spine-toolbar">{toolbar}</div> : null}
       <div className="cc-spine">
         <div className="cc-spine-rail" />
-        {past.length ? <Toggle label={`${past.length} earlier`} open={showPast} onClick={() => setShowPast((value) => !value)} /> : null}
+        {past.length ? (
+          <Toggle
+            label={`${past.length} earlier`}
+            open={showPast}
+            onClick={() => setShowPast((value) => !value)}
+          />
+        ) : null}
         {showPast
           ? past.map((anchor, index) => (
-              <Entry key={anchor.id} anchor={anchor} previous={index ? past[index - 1] : null} state="past" onShowTicket={openTicket} />
+              <Entry
+                key={anchor.id}
+                anchor={anchor}
+                previous={index ? past[index - 1] : null}
+                state="past"
+                onShowTicket={openTicket}
+              />
             ))
           : null}
         <div className="cc-node">
-          <div className="cc-node-dot"><span className="cc-dot-now" /></div>
+          <div className="cc-node-dot">
+            <span className="cc-dot-now" />
+          </div>
           <span className="cc-now-row">
             Now · {londonClock(new Date(now).toISOString())}
           </span>
@@ -177,7 +272,9 @@ export function TodaySpine({ anchors, nextId, nowOverride }: { anchors: SpineAnc
             <Entry
               key={anchor.id}
               anchor={anchor}
-              previous={absoluteIndex > 0 ? resolvedAnchors[absoluteIndex - 1] : null}
+              previous={
+                absoluteIndex > 0 ? resolvedAnchors[absoluteIndex - 1] : null
+              }
               state={index === 0 ? "next" : "future"}
               onShowTicket={openTicket}
             />
@@ -185,15 +282,24 @@ export function TodaySpine({ anchors, nextId, nowOverride }: { anchors: SpineAnc
         })}
         {later.length ? (
           <>
-            <Toggle label={`${later.length} later`} open={showLater} onClick={() => setShowLater((value) => !value)} />
+            <Toggle
+              label={`${later.length} later`}
+              open={showLater}
+              onClick={() => setShowLater((value) => !value)}
+            />
             {showLater
               ? later.map((anchor, index) => {
-                  const absoluteIndex = resolvedAnchors.length - later.length + index;
+                  const absoluteIndex =
+                    resolvedAnchors.length - later.length + index;
                   return (
                     <Entry
                       key={anchor.id}
                       anchor={anchor}
-                      previous={absoluteIndex > 0 ? resolvedAnchors[absoluteIndex - 1] : null}
+                      previous={
+                        absoluteIndex > 0
+                          ? resolvedAnchors[absoluteIndex - 1]
+                          : null
+                      }
                       state="future"
                       onShowTicket={openTicket}
                     />
@@ -203,7 +309,13 @@ export function TodaySpine({ anchors, nextId, nowOverride }: { anchors: SpineAnc
           </>
         ) : null}
       </div>
-      {scan ? <ScanView summary={scan.summary} barcodes={scan.barcodes} onClose={() => setScan(null)} /> : null}
+      {scan ? (
+        <ScanView
+          summary={scan.summary}
+          barcodes={scan.barcodes}
+          onClose={() => setScan(null)}
+        />
+      ) : null}
     </section>
   );
 }
@@ -220,8 +332,14 @@ function Entry({
   onShowTicket: (ticket: TicketVM) => void;
 }) {
   const movement = movementTimes(anchor, previous);
-  const isAppointment = anchor.type === "appointment" || anchor.type === "reservation" || anchor.type === "shift";
-  const showMovement = anchor.plannedTravelMinutes != null && !!navigateHref(anchor) && state !== "past";
+  const isAppointment =
+    anchor.type === "appointment" ||
+    anchor.type === "reservation" ||
+    anchor.type === "shift";
+  const showMovement =
+    anchor.plannedTravelMinutes != null &&
+    !!navigateHref(anchor) &&
+    state !== "past";
   const passOwnsStation = !!anchor.pass && anchor.role !== "changeover";
   const arrivalCoveredByPass =
     anchor.role === "arrival" && previousPassEndsAt(previous, anchor);
@@ -230,7 +348,13 @@ function Entry({
 
   return (
     <>
-      {showMovement ? <MovementCard anchor={anchor} movement={movement} active={state === "next"} /> : null}
+      {showMovement ? (
+        <MovementCard
+          anchor={anchor}
+          movement={movement}
+          active={state === "next"}
+        />
+      ) : null}
       {showAnchor && anchor.role === "changeover" ? (
         <ChangeCard anchor={anchor} state={state} />
       ) : showAnchor && isAppointment ? (
@@ -238,57 +362,124 @@ function Entry({
       ) : showAnchor ? (
         <AnchorCard anchor={anchor} state={state} />
       ) : null}
-      {!anchor.contextOnly && anchor.pass ? <PassCard pass={anchor.pass} state={state} onShowTicket={onShowTicket} /> : null}
+      {!anchor.contextOnly && anchor.pass ? (
+        <PassCard
+          pass={anchor.pass}
+          state={state}
+          onShowTicket={onShowTicket}
+        />
+      ) : null}
     </>
   );
 }
 
-function MovementCard({ anchor, movement, active }: { anchor: SpineAnchor; movement: TimedLeg; active: boolean }) {
-  const mode = anchor.navMode === "drive" ? "Drive" : anchor.navMode === "cycle" ? "Cycle" : "Walk";
-  const destination = anchor.station ? anchor.title : anchor.place ?? anchor.title;
+function MovementCard({
+  anchor,
+  movement,
+  active,
+}: {
+  anchor: SpineAnchor;
+  movement: TimedLeg;
+  active: boolean;
+}) {
+  const mode =
+    anchor.navMode === "drive"
+      ? "Drive"
+      : anchor.navMode === "cycle"
+        ? "Cycle"
+        : "Walk";
+  const destination = anchor.station
+    ? anchor.title
+    : (anchor.place ?? anchor.title);
   return (
     <div className="cc-node" data-state={active ? "next" : "future"}>
-      <div className="cc-node-dot"><span className="cc-med-leg" /></div>
+      <div className="cc-node-dot">
+        <TimelineGlyph
+          kind={
+            anchor.navMode === "drive"
+              ? "drive"
+              : anchor.navMode === "cycle"
+                ? "cycle"
+                : "walk"
+          }
+        />
+      </div>
       <div className="pg cc-walk">
         <div className="cc-walk-head">
           <span className="cc-walk-mode">{mode}</span>
-          <span className="cc-walk-mins mono engr">{anchor.plannedTravelMinutes} min</span>
+          <span className="cc-walk-mins mono engr">
+            {anchor.plannedTravelMinutes} min
+          </span>
         </div>
         {movement.departIso && movement.arriveIso ? (
           <div className="cc-walk-window">
-            <span className="mono cc-walk-time">{londonClock(movement.departIso)}</span>
-            <span className="cc-walk-rule" aria-hidden />
-            <span className="mono cc-walk-time">{londonClock(movement.arriveIso)}</span>
+            <span className="mono cc-walk-time">
+              {londonClock(movement.departIso)}
+            </span>
+            <span className="cc-walk-rule" aria-hidden>
+              →
+            </span>
+            <span className="mono cc-walk-time">
+              {londonClock(movement.arriveIso)}
+            </span>
           </div>
         ) : null}
         <div className="cc-walk-dest">
           <span>→ {destination}</span>
           {movement.spareMinutes != null && movement.spareMinutes > 0 ? (
-            <span className="cc-walk-spare">{movement.spareMinutes} min spare</span>
+            <span className="cc-walk-spare">
+              {movement.spareMinutes} min spare
+            </span>
           ) : movement.spareMinutes != null && movement.spareMinutes < 0 ? (
-            <span className="cc-walk-spare">{Math.abs(movement.spareMinutes)} min late</span>
+            <span className="cc-walk-spare">
+              {Math.abs(movement.spareMinutes)} min late
+            </span>
           ) : null}
         </div>
-        <div className="cc-walk-foot"><span className="sb">Planned</span></div>
+        <div className="cc-walk-foot">
+          <span className="sb">Planned</span>
+        </div>
       </div>
     </div>
   );
 }
 
-function AppointmentCard({ anchor, state }: { anchor: SpineAnchor; state: State }) {
+function AppointmentCard({
+  anchor,
+  state,
+}: {
+  anchor: SpineAnchor;
+  state: State;
+}) {
   return (
     <div className="cc-node" data-state={state}>
-      <div className="cc-node-dot"><span className="cc-med-anchor" /></div>
+      <div className="cc-node-dot">
+        <TimelineGlyph kind="appointment" />
+      </div>
       <div className="pg cc-appt" data-past={state === "past" || undefined}>
-        <div className="cc-appt-head"><span className="cc-eyebrow">{TYPE_LABEL[anchor.type]}</span></div>
+        <div className="cc-appt-head">
+          <span className="cc-eyebrow">{TYPE_LABEL[anchor.type]}</span>
+        </div>
         <h3 className="cc-appt-title">{anchor.title}</h3>
-        {anchor.place && anchor.place !== anchor.title ? <p className="cc-appt-sub">{anchor.place}</p> : null}
+        {anchor.place && anchor.place !== anchor.title ? (
+          <p className="cc-appt-sub">{anchor.place}</p>
+        ) : null}
         <div className="cc-appt-times">
           {anchor.arriveByIso ? (
-            <span className="cc-appt-time"><span className="cc-eyebrow">Starts</span><span className="mono engr cc-appt-clock">{londonClock(anchor.arriveByIso)}</span></span>
+            <span className="cc-appt-time">
+              <span className="cc-eyebrow">Starts</span>
+              <span className="mono engr cc-appt-clock">
+                {londonClock(anchor.arriveByIso)}
+              </span>
+            </span>
           ) : null}
           {anchor.endIso ? (
-            <span className="cc-appt-time"><span className="cc-eyebrow">Ends</span><span className="mono engr cc-appt-clock">{londonClock(anchor.endIso)}</span></span>
+            <span className="cc-appt-time">
+              <span className="cc-eyebrow">Ends</span>
+              <span className="mono engr cc-appt-clock">
+                {londonClock(anchor.endIso)}
+              </span>
+            </span>
           ) : null}
         </div>
       </div>
@@ -298,14 +489,23 @@ function AppointmentCard({ anchor, state }: { anchor: SpineAnchor; state: State 
 
 function AnchorCard({ anchor, state }: { anchor: SpineAnchor; state: State }) {
   const station = anchor.station;
-  const eyebrow = station ? roleLabel(anchor.role, station) : TYPE_LABEL[anchor.type];
+  const eyebrow = station
+    ? roleLabel(anchor.role, station)
+    : TYPE_LABEL[anchor.type];
   return (
     <div className="cc-node" data-state={state}>
-      <div className="cc-node-dot"><span className="cc-med-anchor" /></div>
-      <div className="cc-station-card" data-past={state === "past" || undefined}>
+      <div className="cc-node-dot">
+        <TimelineGlyph kind="place" />
+      </div>
+      <div
+        className="cc-station-card"
+        data-past={state === "past" || undefined}
+      >
         <div className="cc-station-card-head">
           <span className="cc-eyebrow">{eyebrow}</span>
-          <span className="mono cc-station-time">{londonClock(anchor.arriveByIso)}</span>
+          <span className="mono cc-station-time">
+            {londonClock(anchor.arriveByIso)}
+          </span>
         </div>
         <strong className="cc-station-title">{anchor.title}</strong>
       </div>
@@ -316,20 +516,28 @@ function AnchorCard({ anchor, state }: { anchor: SpineAnchor; state: State }) {
 function ChangeCard({ anchor, state }: { anchor: SpineAnchor; state: State }) {
   const arrive = ms(anchor.arriveByIso);
   const depart = ms(anchor.endIso);
-  const minutes = arrive != null && depart != null ? Math.max(0, Math.round((depart - arrive) / 60_000)) : null;
+  const minutes =
+    arrive != null && depart != null
+      ? Math.max(0, Math.round((depart - arrive) / 60_000))
+      : null;
   return (
     <div className="cc-node" data-state={state}>
-      <div className="cc-node-dot"><span className="cc-med-change" /></div>
+      <div className="cc-node-dot">
+        <TimelineGlyph kind="change" />
+      </div>
       <div className="cc-transfer" data-past={state === "past" || undefined}>
         <div className="cc-transfer-head">
           <span>
             <span className="cc-eyebrow">Change</span>
             <strong>{anchor.station?.name ?? anchor.title}</strong>
           </span>
-          {minutes != null ? <span className="mono engr">{minutes}m</span> : null}
+          {minutes != null ? (
+            <span className="mono engr">{minutes}m</span>
+          ) : null}
         </div>
         <p className="cc-transfer-time">
-          {londonClock(anchor.arriveByIso)} arrival · {londonClock(anchor.endIso)} onward
+          {londonClock(anchor.arriveByIso)} arrival ·{" "}
+          {londonClock(anchor.endIso)} onward
         </p>
       </div>
     </div>
@@ -346,13 +554,87 @@ function PassCard({
   onShowTicket: (ticket: TicketVM) => void;
 }) {
   return (
-    <div className="cc-node" data-state={state} data-past={state === "past" || undefined}>
-      <div className="cc-node-dot"><span className="cc-med-pass" /></div>
-      <LivePass ticket={pass.ticket} crs={pass.crs} time={pass.time} dest={pass.dest} docked onShow={onShowTicket} />
+    <div
+      className="cc-node"
+      data-state={state}
+      data-past={state === "past" || undefined}
+    >
+      <div className="cc-node-dot">
+        <TimelineGlyph
+          kind={
+            pass.ticket.kind === "rail"
+              ? "rail"
+              : pass.ticket.kind === "air"
+                ? "air"
+                : "ticket"
+          }
+        />
+      </div>
+      <LivePass
+        ticket={pass.ticket}
+        crs={pass.crs}
+        time={pass.time}
+        dest={pass.dest}
+        docked
+        today
+        onShow={onShowTicket}
+      />
     </div>
   );
 }
 
-function Toggle({ label, open, onClick }: { label: string; open: boolean; onClick: () => void }) {
-  return <button type="button" className="cc-spine-toggle" onClick={onClick}>{open ? "Hide" : "Show"} {label}</button>;
+function TimelineGlyph({
+  kind,
+}: {
+  kind:
+    | "walk"
+    | "cycle"
+    | "drive"
+    | "rail"
+    | "air"
+    | "ticket"
+    | "change"
+    | "appointment"
+    | "place";
+}) {
+  const Icon =
+    kind === "walk"
+      ? Footprints
+      : kind === "cycle"
+        ? Bike
+        : kind === "drive"
+          ? CarFront
+          : kind === "rail"
+            ? TrainFront
+            : kind === "air"
+              ? Plane
+              : kind === "change"
+                ? RefreshCw
+                : kind === "appointment"
+                  ? BriefcaseBusiness
+                  : kind === "place"
+                    ? MapPin
+                    : Ticket;
+
+  return (
+    <span className="cc-timeline-icon" data-kind={kind}>
+      <Icon aria-hidden />
+    </span>
+  );
+}
+
+function Toggle({
+  label,
+  open,
+  onClick,
+}: {
+  label: string;
+  open: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button type="button" className="cc-spine-toggle" onClick={onClick}>
+      {open ? "Hide" : "Show"} {label}
+    </button>
+  );
 }

--- a/src/components/today/today-spine-layout.test.ts
+++ b/src/components/today/today-spine-layout.test.ts
@@ -1,7 +1,8 @@
 import React, { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
-import { TodaySpine } from "@/components/today/today-spine";
+import type { TicketVM } from "@/components/concierge";
+import { TodaySpine } from "./today-spine-fixed";
 import type { SpineAnchor } from "./spine-model";
 
 (globalThis as typeof globalThis & { React: typeof React }).React = React;
@@ -15,9 +16,91 @@ const anchor: SpineAnchor = {
   endIso: "2026-07-28T17:00:00+01:00",
   coord: { lat: 51.8172, lng: -0.356 },
   plannedTravelMinutes: null,
+  navMode: "walk",
   station: null,
   role: "stop",
 };
+
+const railTicket: TicketVM = {
+  id: "screen-one-rail",
+  kind: "rail",
+  operator: "Thameslink",
+  source: "manual",
+  legs: [
+    {
+      id: "screen-one-rail-leg",
+      origin: {
+        place: "Harpenden",
+        code: "HPD",
+        time: "2026-07-28T17:32:00+01:00",
+        platform: "1",
+      },
+      destination: {
+        place: "London St Pancras",
+        code: "STP",
+        time: "2026-07-28T18:02:00+01:00",
+      },
+      status: { status: "on_time" },
+    },
+  ],
+};
+
+const populatedAnchors: SpineAnchor[] = [
+  {
+    id: "station",
+    type: "custom",
+    title: "Harpenden Station",
+    place: "Harpenden",
+    arriveByIso: "2026-07-28T17:22:00+01:00",
+    endIso: "2026-07-28T17:32:00+01:00",
+    coord: { lat: 51.8146, lng: -0.3515 },
+    plannedTravelMinutes: 12,
+    bufferMinutes: 15,
+    navMode: "walk",
+    station: {
+      name: "Harpenden",
+      code: "HPD",
+      kind: "rail_station",
+    },
+    role: "departure",
+    pass: {
+      ticket: railTicket,
+      crs: "HPD",
+      time: "17:32",
+      dest: "STP",
+    },
+  },
+  {
+    id: "change",
+    type: "custom",
+    title: "London St Pancras",
+    place: "London",
+    arriveByIso: "2026-07-28T18:02:00+01:00",
+    endIso: "2026-07-28T18:10:00+01:00",
+    coord: { lat: 51.5308, lng: -0.1238 },
+    plannedTravelMinutes: null,
+    navMode: "walk",
+    station: {
+      name: "London St Pancras",
+      code: "STP",
+      kind: "rail_station",
+    },
+    role: "changeover",
+  },
+  {
+    id: "dinner",
+    type: "reservation",
+    title: "Dinner at Sessions Arts Club",
+    place: "Clerkenwell",
+    arriveByIso: "2026-07-28T18:45:00+01:00",
+    endIso: "2026-07-28T20:30:00+01:00",
+    coord: { lat: 51.5229, lng: -0.111 },
+    plannedTravelMinutes: 18,
+    navMode: "walk",
+    station: null,
+    role: "stop",
+  },
+];
 
 describe("active Today spine layout contract", () => {
   it("renders the instrument spine rather than the retired v7 rail", () => {
@@ -32,5 +115,23 @@ describe("active Today spine layout contract", () => {
     expect(html).toContain("cc-spine-heading");
     expect(html).toContain("Your itinerary");
     expect(html).not.toContain("cc-spine-v7");
+  });
+
+  it("renders a populated multi-leg day with real movement, pass, and change cards", () => {
+    const html = renderToStaticMarkup(
+      createElement(TodaySpine, {
+        anchors: populatedAnchors,
+        nextId: "station",
+        nowOverride: Date.parse("2026-07-28T16:30:00+01:00"),
+        toolbar: createElement("span", null, "Keep 15-min margin"),
+      }),
+    );
+
+    expect(html).toContain("3 timed points");
+    expect(html).toContain("Keep 15-min margin");
+    expect(html).toContain('data-kind="walk"');
+    expect(html).toContain("cc-pass--today");
+    expect(html).toContain("cc-transfer");
+    expect(html).toContain("Dinner at Sessions Arts Club");
   });
 });


### PR DESCRIPTION
## Summary
- replace the map-led Today command with the supplied compact Screen One hierarchy
- keep real Supabase-backed itinerary, live routing, tickets, wallet, and planning actions
- persist the arrival-margin switch through the existing travel profile action
- render open movement/change rows and a compact operational Today pass
- add a preview-only populated design harness (404 in production) for responsive verification

## Verification
- `npm run typecheck`
- `npm test -- --reporter=dot` — 468 passing
- `npm run build` — passed before the preview-only harness was added; Vercel will validate the final commit
- live Supabase schema confirms `travel_profiles.default_arrival_buffer_minutes` is non-null integer with RLS enabled

No database migration is required.