### PR TITLE
Superseded: route-specific Today styling pass

### DIFF
--- a/src/app/khonsera-mobile-today-reference.css
+++ b/src/app/khonsera-mobile-today-reference.css
@@ -1,0 +1,441 @@
+/* Approved mobile Today reference — August 2026
+ * Final route-scoped authority. This layer intentionally simplifies the Today
+ * surface while preserving the live production component/data contracts.
+ */
+
+:root {
+  --kh-ref-paper: #f7f3ea;
+  --kh-ref-card: #fffdf8;
+  --kh-ref-ink: #0c2527;
+  --kh-ref-muted: #68706d;
+  --kh-ref-line: #ded8ca;
+  --kh-ref-green: #003f37;
+  --kh-ref-green-2: #075e50;
+  --kh-ref-orange: #d64b17;
+  --kh-ref-orange-2: #a93713;
+  --kh-ref-soft: #f0ede5;
+  --kh-ref-radius: 18px;
+  --kh-ref-shadow: 0 1px 2px rgba(15, 35, 32, .04), 0 8px 24px rgba(52, 45, 28, .04);
+}
+
+.khonsera-app--unified:has(.cc-today-direction) {
+  background: var(--kh-ref-paper) !important;
+  color: var(--kh-ref-ink);
+}
+
+.khonsera-app--unified:has(.cc-today-direction) .cc-app-main {
+  width: 100%;
+  max-width: none;
+  padding: 0 16px calc(104px + env(safe-area-inset-bottom)) !important;
+}
+
+.khonsera-app--unified:has(.cc-today-direction) .cc-appbar {
+  min-height: 76px;
+  padding: calc(14px + env(safe-area-inset-top)) 18px 10px;
+  background: color-mix(in srgb, var(--kh-ref-paper) 92%, transparent);
+  border-bottom: 0;
+  backdrop-filter: blur(18px);
+}
+
+.khonsera-app--unified:has(.cc-today-direction) .cc-appbar .cc-lockup .wm {
+  color: var(--kh-ref-ink);
+  font-size: 16px;
+  font-weight: 650;
+  letter-spacing: .28em;
+}
+
+.khonsera-app--unified:has(.cc-today-direction) .cc-brand-dot { display: none; }
+
+.khonsera-app--unified:has(.cc-today-direction) .cc-appbar .cc-iconbtn {
+  width: 42px !important;
+  height: 42px !important;
+  min-width: 42px !important;
+  min-height: 42px !important;
+  border: 1px solid var(--kh-ref-line);
+  border-radius: 50%;
+  background: var(--kh-ref-card);
+  box-shadow: none;
+}
+
+.cc-today-direction {
+  width: 100%;
+  max-width: 760px;
+  margin: 0 auto;
+  gap: 18px;
+}
+
+.cc-today-direction .cc-today-head {
+  display: block;
+  padding: 18px 0 0;
+}
+
+.cc-today-direction .cc-today-head .cc-eyebrow {
+  color: var(--kh-ref-orange);
+  font-family: var(--sans);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+}
+
+.cc-today-direction .cc-today-head .cc-screen-title {
+  margin: 10px 0 0;
+  color: var(--kh-ref-ink);
+  font-size: clamp(40px, 12vw, 58px);
+  font-weight: 560;
+  line-height: .98;
+  letter-spacing: -.055em;
+}
+
+.cc-today-direction .cc-screen-description {
+  margin-top: 8px;
+  color: var(--kh-ref-muted);
+  font-size: 13px;
+}
+
+.cc-today-direction .cc-weather,
+.cc-today-direction .cc-day-forecast,
+.cc-today-direction .cc-weather-hours,
+.cc-today-direction .cc-today-context,
+.cc-today-direction .cc-map-card,
+.cc-today-direction .cc-today-map,
+.cc-today-direction .cc-today-command-map {
+  display: none !important;
+}
+
+.cc-today-direction .cc-day-dashboard { gap: 16px; }
+
+/* Up next */
+.cc-today-direction .cc-today-command {
+  overflow: hidden;
+  border: 1px solid var(--kh-ref-line);
+  border-radius: var(--kh-ref-radius);
+  background: var(--kh-ref-card);
+  box-shadow: var(--kh-ref-shadow);
+}
+
+.cc-today-direction .cc-today-command-content {
+  min-height: 196px;
+  display: grid;
+  grid-template-columns: 86px minmax(0, 1fr);
+  padding: 0;
+  background: transparent;
+}
+
+.cc-today-command .cc-active-tile {
+  position: relative;
+  min-height: 196px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 22px 18px 18px 106px;
+  border: 0 !important;
+  border-radius: 0;
+  background: var(--kh-ref-card) !important;
+  box-shadow: none;
+}
+
+.cc-today-command .cc-active-tile::before {
+  content: "UP NEXT\A\A↗";
+  white-space: pre;
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 86px;
+  padding-top: 14px;
+  background: linear-gradient(to bottom, var(--kh-ref-green) 0 38px, var(--kh-ref-orange) 38px 100%);
+  color: white;
+  text-align: center;
+  font-size: 11px;
+  font-weight: 800;
+  line-height: 1.8;
+  letter-spacing: .12em;
+}
+
+.cc-next-move-head { min-height: 0; }
+.cc-today-command .cc-at-status,
+.cc-next-priority { display: none !important; }
+
+.cc-today-command .cc-setoff-sheet { gap: 8px; }
+.cc-today-command .cc-setoff-kicker {
+  color: var(--kh-ref-ink);
+  font-size: 22px;
+  font-weight: 650;
+  letter-spacing: -.025em;
+}
+
+.cc-today-command .cc-setoff-core {
+  position: absolute;
+  top: 22px;
+  right: 18px;
+  display: block;
+}
+
+.cc-today-command .cc-setoff-figure {
+  color: var(--kh-ref-ink);
+  font-size: 30px;
+  font-weight: 560;
+  letter-spacing: -.04em;
+}
+
+.cc-today-command .cc-leave-ring { display: none; }
+.cc-today-command .cc-setoff-for {
+  max-width: 70%;
+  color: var(--kh-ref-muted);
+  font-size: 13px;
+  line-height: 1.45;
+  white-space: normal;
+}
+
+.cc-today-command .cc-setoff-move {
+  max-width: 74%;
+  color: var(--kh-ref-ink);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.cc-today-command .cc-next-facts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin-top: auto;
+}
+
+.cc-today-command .cc-next-facts > span {
+  min-height: 30px;
+  padding: 0 10px;
+  border: 0;
+  border-radius: 7px;
+  background: var(--kh-ref-soft);
+  color: var(--kh-ref-ink);
+  box-shadow: none;
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.cc-today-command .cc-next-actions {
+  position: absolute;
+  right: 12px;
+  bottom: 12px;
+  margin: 0;
+}
+
+.cc-today-command .cc-next-action:not(.cc-next-action--primary) { display: none; }
+.cc-today-command .cc-next-action--primary {
+  width: 42px;
+  min-width: 42px;
+  height: 42px;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--kh-ref-ink);
+  box-shadow: none;
+}
+.cc-today-command .cc-next-action--primary .cc-next-action-label { display: none; }
+
+/* Continuous itinerary */
+.cc-today-direction .cc-spine,
+.cc-today-direction .cc-today-spine {
+  position: relative;
+  gap: 0;
+  overflow: hidden;
+  border: 1px solid var(--kh-ref-line);
+  border-radius: var(--kh-ref-radius);
+  background: var(--kh-ref-card);
+  box-shadow: var(--kh-ref-shadow);
+}
+
+.cc-today-direction .cc-spine::before,
+.cc-today-direction .cc-today-spine::before {
+  content: "";
+  position: absolute;
+  z-index: 0;
+  top: 30px;
+  bottom: 30px;
+  left: 73px;
+  width: 1px;
+  background: var(--kh-ref-line);
+}
+
+.cc-today-direction .cc-spine > *,
+.cc-today-direction .cc-today-spine > * {
+  position: relative;
+  z-index: 1;
+}
+
+.cc-today-direction .cc-node,
+.cc-today-direction .cc-anchor,
+.cc-today-direction .cc-leg,
+.cc-today-direction .cc-transfer,
+.cc-today-direction .cc-pass--today,
+.cc-today-direction .cc-pass--docked {
+  margin: 0 !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+  border-bottom: 1px solid var(--kh-ref-line) !important;
+  background: transparent !important;
+  box-shadow: none !important;
+}
+
+.cc-today-direction .cc-spine > *:last-child,
+.cc-today-direction .cc-today-spine > *:last-child { border-bottom: 0 !important; }
+
+.cc-today-direction .cc-node,
+.cc-today-direction .cc-anchor,
+.cc-today-direction .cc-leg,
+.cc-today-direction .cc-transfer {
+  min-height: 76px;
+  padding: 16px 16px 16px 96px !important;
+}
+
+.cc-today-direction .cc-node-time,
+.cc-today-direction .cc-anchor-time,
+.cc-today-direction .cc-leg-time,
+.cc-today-direction time {
+  color: var(--kh-ref-ink);
+  font-family: var(--sans);
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: -.025em;
+}
+
+.cc-today-direction .cc-pass--today,
+.cc-today-direction .cc-pass--docked {
+  padding: 18px 16px 18px 96px !important;
+}
+
+.cc-today-direction .cc-pass-route,
+.cc-today-direction .cc-pass-places,
+.cc-today-direction .cc-pass--today .cc-pass-route {
+  color: var(--kh-ref-ink);
+  font-size: clamp(26px, 8vw, 36px);
+  font-weight: 620;
+  letter-spacing: -.04em;
+}
+
+.cc-today-direction .cc-pass-operator,
+.cc-today-direction .cc-pass-meta,
+.cc-today-direction .cc-pass-detail {
+  color: var(--kh-ref-muted);
+  font-size: 11px;
+}
+
+.cc-today-direction .cc-status-strip,
+.cc-today-direction [data-status="on_time"] {
+  border: 0;
+  border-radius: 999px;
+  background: #eef1e8;
+  color: var(--kh-ref-green-2);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+
+.cc-today-direction [data-status="delayed"],
+.cc-today-direction [data-status="platform_change"] {
+  background: #f7e6db;
+  color: var(--kh-ref-orange-2);
+}
+
+.cc-today-direction .cc-transfer {
+  color: var(--kh-ref-ink);
+}
+
+.cc-today-direction .cc-transfer::before {
+  background: var(--kh-ref-orange) !important;
+  color: white !important;
+}
+
+/* Day summary and utilities */
+.cc-today-direction .cc-day-overview,
+.cc-today-direction .cc-today-overview,
+.cc-today-direction .cc-summary-card {
+  border: 1px solid var(--kh-ref-line);
+  border-radius: var(--kh-ref-radius);
+  background: var(--kh-ref-card);
+  box-shadow: var(--kh-ref-shadow);
+}
+
+.cc-today-direction .cc-quick-access,
+.cc-today-direction .cc-tool-grid,
+.cc-today-direction .cc-utility-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.cc-today-direction .cc-quick-access > *,
+.cc-today-direction .cc-tool-grid > *,
+.cc-today-direction .cc-utility-grid > * {
+  min-width: 0;
+  min-height: 72px;
+  padding: 10px 6px;
+  border: 1px solid var(--kh-ref-line);
+  border-radius: 12px;
+  background: var(--kh-ref-card);
+  color: var(--kh-ref-ink);
+  box-shadow: none;
+  font-size: 10px;
+}
+
+.khonsera-app--unified:has(.cc-today-direction) .cc-tabbar {
+  padding: 0 0 env(safe-area-inset-bottom);
+  border-top: 1px solid var(--kh-ref-line);
+  background: color-mix(in srgb, var(--kh-ref-card) 96%, transparent);
+  backdrop-filter: blur(18px);
+}
+
+.khonsera-app--unified:has(.cc-today-direction) .cc-tab {
+  min-height: 72px;
+  color: var(--kh-ref-ink);
+  font-size: 10px;
+}
+
+.khonsera-app--unified:has(.cc-today-direction) .cc-tab[data-active="true"] {
+  background: var(--kh-ref-green);
+  color: white;
+}
+
+.khonsera-app--unified:has(.cc-today-direction) .cc-tab[data-active="true"] .cc-tab-ico { color: white; }
+
+@media (max-width: 430px) {
+  .cc-today-command .cc-active-tile { padding-left: 96px; }
+  .cc-today-command .cc-setoff-for,
+  .cc-today-command .cc-setoff-move { max-width: 78%; }
+  .cc-today-direction .cc-spine::before,
+  .cc-today-direction .cc-today-spine::before { left: 65px; }
+  .cc-today-direction .cc-node,
+  .cc-today-direction .cc-anchor,
+  .cc-today-direction .cc-leg,
+  .cc-today-direction .cc-transfer,
+  .cc-today-direction .cc-pass--today,
+  .cc-today-direction .cc-pass--docked { padding-left: 84px !important; }
+}
+
+@media (max-width: 350px) {
+  .khonsera-app--unified:has(.cc-today-direction) .cc-app-main { padding-inline: 10px !important; }
+  .cc-today-direction .cc-today-head .cc-screen-title { font-size: 38px; }
+  .cc-today-direction .cc-today-command-content { grid-template-columns: 72px minmax(0, 1fr); }
+  .cc-today-command .cc-active-tile { padding-left: 84px; padding-right: 12px; }
+  .cc-today-command .cc-active-tile::before { width: 72px; }
+  .cc-today-command .cc-setoff-core { right: 12px; }
+  .cc-today-command .cc-setoff-figure { font-size: 26px; }
+  .cc-today-direction .cc-quick-access,
+  .cc-today-direction .cc-tool-grid,
+  .cc-today-direction .cc-utility-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+}
+
+@media (min-width: 900px) {
+  .khonsera-app--unified:has(.cc-today-direction) .cc-app-main {
+    padding-top: 24px !important;
+    padding-bottom: 48px !important;
+  }
+  .cc-today-direction { max-width: 780px; }
+  .cc-today-direction .cc-today-head { padding-top: 24px; }
+  .cc-today-direction .cc-today-head .cc-screen-title { font-size: 62px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .khonsera-app--unified:has(.cc-today-direction) * { scroll-behavior: auto !important; }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,6 +18,7 @@ import "./khonsera-edition-iii-nav.css"; // Edition III N1 — premium guidance 
 import "./khonsera-instrument.css"; // Instrument Edition v8 — reviewed production direction, final authority
 import "./khonsera-today-direction.css"; // Jul 2026 app direction — unified shell + route-first Today surface
 import "./khonsera-screen-one.css"; // Jul 2026 Screen One — approved compact orange Today direction
+import "./khonsera-mobile-today-reference.css"; // Aug 2026 — approved mobile visual reference, final Today authority
 import { PwaRegister } from "@/components/pwa-register";
 
 // Canonical Instrument Edition type stack:


### PR DESCRIPTION
This PR is intentionally closed without merge.

The approved visual reference should not be implemented as a route-specific skin for `/today`. The next implementation will establish the visual language as a shared app-wide system first, then apply it consistently across Today, Plan, Trips, Bookings, Wallet and supporting flows.

The useful visual findings from this pass will be carried into the shared system, but the route-scoped architecture will not.