### PR TITLE
Polish Today card by card and repair the staff demo journey

### DIFF
--- a/src/app/khonsera-today-polish.css
+++ b/src/app/khonsera-today-polish.css
@@ -1,0 +1,414 @@
+/*
+ * Today component QA pass
+ *
+ * A focused card-by-card and control-by-control correction for the shared
+ * Today component family. Demo-only chrome remains scoped; travel cards,
+ * movement rows, passes and actions continue to be shared with live Today.
+ */
+
+/* Page rhythm ------------------------------------------------------------- */
+.khonsera-app .cc-today-direction {
+  gap: 14px;
+}
+
+.khonsera-app .cc-today-direction > .cc-screen-content {
+  row-gap: 14px;
+}
+
+.khonsera-app .cc-today-head {
+  padding-bottom: 12px;
+}
+
+/* Demo identification: obvious, but not the dominant card ---------------- */
+.khonsera-app .cc-today-demo .cc-demo-banner {
+  gap: 8px 12px;
+  padding: 10px 12px;
+  border-color: color-mix(in srgb, var(--kh-orange) 34%, var(--kh-border));
+  border-radius: 12px 12px 12px 5px;
+  background: color-mix(in srgb, var(--kh-orange-soft) 72%, var(--kh-surface));
+  box-shadow: none;
+}
+
+.khonsera-app .cc-today-demo .cc-demo-banner-mark {
+  min-height: 24px;
+  padding: 4px 7px;
+  border-radius: 6px 6px 6px 2px;
+  font-size: 7.5px;
+}
+
+.khonsera-app .cc-today-demo .cc-demo-banner-copy {
+  font-size: 10.5px;
+  line-height: 1.4;
+}
+
+.khonsera-app .cc-today-demo .cc-demo-banner-link {
+  min-height: 32px;
+  display: inline-flex;
+  align-items: center;
+  padding: 0 2px;
+  font-size: 10px;
+  text-decoration: none;
+}
+
+/* Scenario clock: a utility strip, not a second hero ---------------------- */
+.khonsera-app .cc-today-demo .cc-demo-readout {
+  min-height: 54px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 2px 12px;
+  padding: 10px 12px;
+  border-radius: 12px 12px 12px 5px;
+  background: var(--kh-surface-subtle);
+}
+
+.khonsera-app .cc-today-demo .cc-demo-readout strong {
+  font-size: 19px;
+  line-height: 1;
+}
+
+.khonsera-app .cc-today-demo .cc-demo-readout > span:last-child {
+  font-size: 9.5px;
+}
+
+/* Next move: decisive without consuming half the screen ------------------ */
+.khonsera-app .cc-today-command .cc-active-tile {
+  gap: 11px;
+  padding: 16px;
+  border-radius: 17px 17px 17px 6px;
+  box-shadow: 0 12px 28px -24px rgba(39, 31, 20, 0.72) !important;
+}
+
+.khonsera-app .cc-today-command .cc-active-tile::before {
+  width: 4px;
+}
+
+.khonsera-app .cc-next-move-head {
+  min-height: 26px;
+}
+
+.khonsera-app .cc-today-command .cc-at-status {
+  font-size: 8px;
+}
+
+.khonsera-app .cc-next-priority {
+  min-height: 23px;
+  padding: 3px 7px;
+  font-size: 7px;
+}
+
+.khonsera-app .cc-today-command .cc-setoff-sheet {
+  gap: 9px;
+}
+
+.khonsera-app .cc-today-command .cc-setoff-core {
+  min-height: 48px;
+}
+
+.khonsera-app .cc-today-command .cc-setoff-figure,
+.khonsera-app .cc-today-command .cc-setoff-figure--word {
+  font-size: clamp(42px, 12vw, 58px);
+  line-height: 0.9;
+}
+
+.khonsera-app .cc-today-command .cc-next-facts {
+  gap: 5px;
+}
+
+.khonsera-app .cc-today-command .cc-next-facts > span {
+  min-height: 27px;
+  padding: 5px 7px;
+  border-radius: 7px 7px 7px 3px;
+  font-size: 9px;
+}
+
+.khonsera-app .cc-today-command .cc-setoff-move {
+  max-width: none;
+  font-size: 11px;
+  line-height: 1.42;
+}
+
+/* Every action is named. Primary action first, utilities beneath. */
+.khonsera-app .cc-today-command .cc-next-actions {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 7px;
+}
+
+.khonsera-app .cc-today-command .cc-next-action {
+  width: auto;
+  min-width: 0;
+  min-height: 42px;
+  gap: 6px;
+  padding: 0 8px;
+  border-radius: 9px 9px 9px 4px;
+}
+
+.khonsera-app .cc-today-command .cc-next-action--primary {
+  grid-column: 1 / -1;
+  min-height: 45px;
+  justify-content: center;
+}
+
+.khonsera-app .cc-today-command .cc-next-action-label,
+.khonsera-app .cc-today-command .cc-next-action--primary .cc-next-action-label {
+  display: inline;
+  font-size: 9.5px;
+  font-weight: 740;
+  white-space: nowrap;
+}
+
+.khonsera-app .cc-today-command .cc-next-action svg {
+  width: 14px;
+  height: 14px;
+  flex: none;
+}
+
+/* Itinerary alignment ----------------------------------------------------- */
+.khonsera-app .cc-today-direction .cc-spine-heading {
+  min-height: 34px;
+  margin-bottom: 10px;
+  padding-bottom: 9px;
+  font-size: 10.5px;
+}
+
+.khonsera-app .cc-today-direction .cc-node {
+  grid-template-columns: 34px minmax(0, 1fr);
+  column-gap: 10px;
+  padding: 0 0 11px;
+}
+
+.khonsera-app .cc-today-direction .cc-node-dot {
+  width: 34px;
+  min-width: 34px;
+  padding-top: 9px;
+}
+
+.khonsera-app .cc-today-direction .cc-spine-rail {
+  left: 16px;
+}
+
+.khonsera-app .cc-today-direction .cc-now-row {
+  min-height: 25px;
+  padding: 4px 7px;
+  border-radius: 7px 7px 7px 3px;
+  font-size: 8px;
+}
+
+.khonsera-app .cc-today-direction .cc-node-dot :is(
+  .cc-med-leg,
+  .cc-med-anchor,
+  .cc-med-pass,
+  .cc-med-change
+) {
+  width: 32px;
+  height: 32px;
+}
+
+/* Movement rows: retain emphasis, never invert into unreadable white text. */
+.khonsera-app .cc-today-direction .cc-walk {
+  padding: 13px 14px 12px;
+  border-radius: 14px 14px 14px 5px;
+  box-shadow: none;
+}
+
+.khonsera-app .cc-today-direction .cc-node[data-state="next"] .cc-walk {
+  border-color: color-mix(in srgb, var(--kh-green) 42%, var(--kh-border)) !important;
+  background: var(--kh-surface) !important;
+  color: var(--kh-ink) !important;
+  box-shadow: 0 10px 24px -22px rgba(7, 58, 52, 0.72) !important;
+}
+
+.khonsera-app .cc-today-direction .cc-node[data-state="next"] .cc-walk :is(
+  .cc-walk-mins,
+  .cc-walk-time,
+  .cc-walk-dest
+) {
+  color: var(--kh-ink-2) !important;
+}
+
+.khonsera-app .cc-today-direction .cc-node[data-state="next"] .cc-walk-mode {
+  color: var(--kh-orange-strong) !important;
+}
+
+.khonsera-app .cc-today-direction .cc-node[data-state="next"] .cc-walk-spare {
+  color: var(--kh-success) !important;
+}
+
+.khonsera-app .cc-today-direction .cc-node[data-state="next"] .cc-walk-rule {
+  background: var(--kh-border-strong) !important;
+}
+
+.khonsera-app .cc-today-direction .cc-walk-window {
+  margin-top: 8px;
+  font-size: 10.5px;
+}
+
+.khonsera-app .cc-today-direction .cc-walk-dest {
+  align-items: center;
+  flex-direction: row;
+  gap: 8px;
+  margin-top: 8px;
+  font-size: 10.5px;
+}
+
+.khonsera-app .cc-today-direction .cc-walk-foot {
+  display: none;
+}
+
+/* Rail pass: denser hierarchy and a quieter consequence note. */
+.khonsera-app .cc-today-direction .cc-pass--docked {
+  border-radius: 15px 15px 15px 6px !important;
+  box-shadow: 0 12px 28px -24px rgba(39, 31, 20, 0.72) !important;
+}
+
+.khonsera-app .cc-today-direction .cc-pass-today-head {
+  min-height: 38px;
+  padding: 8px 12px 7px;
+}
+
+.khonsera-app .cc-today-direction .cc-pass-today-time {
+  font-size: 13px;
+}
+
+.khonsera-app .cc-today-direction .cc-pass-today-status {
+  font-size: 9px;
+}
+
+.khonsera-app .cc-today-direction .cc-pass--docked .cc-pass-route {
+  padding: 14px 13px 11px !important;
+}
+
+.khonsera-app .cc-today-direction .cc-pass--docked .cc-pass-code {
+  font-size: clamp(27px, 8vw, 34px) !important;
+}
+
+.khonsera-app .cc-today-direction .cc-pass-boarding {
+  gap: 9px;
+  margin: 0 12px 10px;
+  padding: 9px 10px !important;
+  border-radius: 9px 9px 9px 4px;
+}
+
+.khonsera-app .cc-today-direction .cc-pass-boarding-num {
+  font-size: 23px;
+}
+
+.khonsera-app .cc-today-direction .cc-pass-stub {
+  padding: 0 10px 7px !important;
+}
+
+.khonsera-app .cc-today-direction .cc-pass-stub-cell {
+  min-height: 54px;
+  padding: 8px 7px !important;
+}
+
+.khonsera-app .cc-today-direction :is(.cc-pass-consequence, .cc-ticket-consequence) {
+  margin: 0 12px 11px;
+  padding: 8px 9px;
+  border-left-width: 2px;
+  border-radius: 3px 8px 8px 3px;
+  background: var(--kh-green-soft);
+  color: var(--kh-green-strong);
+  font-size: 9.5px;
+}
+
+.khonsera-app .cc-today-direction .cc-pass-ready {
+  padding: 0 12px 12px !important;
+}
+
+.khonsera-app .cc-today-direction .cc-pass-ready > button {
+  min-height: 42px !important;
+  font-size: 10.5px !important;
+}
+
+/* Appointment: compact but still a proper destination card. */
+.khonsera-app .cc-today-direction .cc-appt {
+  padding: 15px;
+  border-radius: 15px 15px 15px 6px;
+}
+
+.khonsera-app .cc-today-direction .cc-appt-title {
+  margin-top: 7px;
+  font-size: clamp(20px, 5.5vw, 25px);
+}
+
+.khonsera-app .cc-today-direction .cc-appt-times {
+  gap: 7px;
+  margin-top: 13px;
+}
+
+.khonsera-app .cc-today-direction .cc-appt-time {
+  min-height: 56px;
+  padding: 8px 9px;
+}
+
+.khonsera-app .cc-today-direction .cc-appt-clock {
+  font-size: 15px;
+}
+
+/* The demo explanation belongs on desktop. Mobile already has the banner. */
+@media (max-width: 759px) {
+  .khonsera-app .cc-today-demo .cc-day-context {
+    display: none;
+  }
+}
+
+@media (max-width: 430px) {
+  .khonsera-app .cc-today-head {
+    grid-template-columns: minmax(0, 1fr) 112px;
+  }
+
+  .khonsera-app .cc-today-head .cc-screen-title {
+    font-size: clamp(34px, 10.5vw, 42px);
+  }
+
+  .khonsera-app .cc-today-direction .cc-weather {
+    min-height: 54px;
+    padding: 8px;
+  }
+
+  .khonsera-app .cc-today-demo .cc-demo-banner {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .khonsera-app .cc-today-demo .cc-demo-banner-copy {
+    grid-column: 1 / -1;
+  }
+
+  .khonsera-app .cc-today-command .cc-active-tile {
+    padding: 15px 14px;
+  }
+
+  .khonsera-app .cc-today-command .cc-next-action-label,
+  .khonsera-app .cc-today-command .cc-next-action--primary .cc-next-action-label {
+    font-size: 8.5px;
+  }
+
+  .khonsera-app .cc-today-direction .cc-node {
+    grid-template-columns: 32px minmax(0, 1fr);
+    column-gap: 8px;
+  }
+
+  .khonsera-app .cc-today-direction .cc-node-dot {
+    width: 32px;
+    min-width: 32px;
+  }
+
+  .khonsera-app .cc-today-direction .cc-spine-rail {
+    left: 15px;
+  }
+
+  .khonsera-app .cc-today-direction .cc-walk-dest {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .khonsera-app .cc-tabbar {
+    padding-top: 5px;
+  }
+
+  .khonsera-app .cc-tab {
+    min-height: 51px;
+    border-radius: 10px 10px 5px 10px;
+  }
+}

--- a/src/app/khonsera-today-polish.test.ts
+++ b/src/app/khonsera-today-polish.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+const layout = readFileSync(join(root, "src/app/layout.tsx"), "utf8");
+const polish = readFileSync(
+  join(root, "src/app/khonsera-today-polish.css"),
+  "utf8",
+);
+const demo = readFileSync(
+  join(root, "src/components/today/today-demo-client.tsx"),
+  "utf8",
+);
+
+describe("Today card-by-card polish", () => {
+  it("loads after the shared layout system so it can correct final placement", () => {
+    const layoutIndex = layout.indexOf('"./khonsera-layout.css"');
+    const polishIndex = layout.indexOf('"./khonsera-today-polish.css"');
+    expect(layoutIndex).toBeGreaterThan(-1);
+    expect(polishIndex).toBeGreaterThan(layoutIndex);
+  });
+
+  it("keeps the active movement leg readable and names every next action", () => {
+    expect(polish).toContain('.cc-node[data-state="next"] .cc-walk');
+    expect(polish).toContain("background: var(--kh-surface) !important");
+    expect(polish).toContain(".cc-next-action-label");
+    expect(polish).toContain("grid-column: 1 / -1");
+  });
+
+  it("keeps mobile demo explanation concise without removing the data boundary", () => {
+    expect(polish).toContain(".cc-today-demo .cc-day-context");
+    expect(polish).toContain("display: none");
+    expect(demo).toContain("Your real Today and account data remain untouched");
+    expect(demo).toContain("No stops, bookings or status are read from or");
+  });
+
+  it("uses a coherent Wellingborough to Harpenden sample journey", () => {
+    expect(demo).toContain('name: "Home, Wellingborough"');
+    expect(demo).toContain('place: "Wellingborough"');
+    expect(demo).toContain('place: "Luton"');
+    expect(demo).toContain('place: "Harpenden"');
+    expect(demo).toContain('reference: "DEMO WEL-01"');
+    expect(demo).toContain('reference: "DEMO LUT-02"');
+  });
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,6 +24,7 @@ import "./khonsera-primary-flows.css"; // Pass 3 — Today and Plan as one plann
 import "./khonsera-secondary-surfaces.css"; // Pass 4 — Plan index, Wallet and supporting list surfaces
 import "./khonsera-demo.css"; // Staff demo boundary — shared components, isolated scenario data
 import "./khonsera-layout.css"; // Pass 5 — spacing, alignment and placement across every app route
+import "./khonsera-today-polish.css"; // Focused QA — Today cards, controls and itinerary hierarchy
 import { PwaRegister } from "@/components/pwa-register";
 
 // Canonical type stack:

--- a/src/components/today/demo-mode-boundary.test.ts
+++ b/src/components/today/demo-mode-boundary.test.ts
@@ -40,7 +40,10 @@ describe("staff Today demo boundary", () => {
 
   it("keeps the scenario visibly and semantically separate from account data", () => {
     expect(demo).toContain('data-demo="true"');
-    expect(demo).toContain("isolated sample data, not your Today");
+    expect(demo).toContain("Sample itinerary only");
+    expect(demo).toContain(
+      "Your real Today and account data remain untouched",
+    );
     expect(demo).not.toContain("createClient");
     expect(demo).not.toContain("setLiveTransitionProgress");
   });

--- a/src/components/today/today-demo-client.tsx
+++ b/src/components/today/today-demo-client.tsx
@@ -19,17 +19,21 @@ import {
 // LiveDay, TodaySpine, pass and navigation components as the real screen, so
 // fixes and design changes carry to both without maintaining a second UI.
 
-const HARPENDEN = {
-  lat: 51.8176,
-  lng: -0.354,
-  name: "Home, Harpenden",
+const HOME = {
+  lat: 52.2962,
+  lng: -0.6896,
+  name: "Home, Wellingborough",
 };
+const WELLINGBOROUGH = { lat: 52.3038, lng: -0.6767 };
 const LUTON = { lat: 51.8821, lng: -0.4147 };
-const WELLINGBOROUGH = { lat: 52.2962, lng: -0.6896 };
+const HARPENDEN = { lat: 51.8147, lng: -0.3516 };
+const REVIEW = { lat: 51.8162, lng: -0.3572 };
 
-const DEPARTURE_MINUTES = 45;
-const ARRIVAL_MINUTES = 70;
-const REVIEW_MINUTES = 95;
+const WEL_DEPARTURE_MINUTES = 45;
+const LUT_ARRIVAL_MINUTES = 68;
+const LUT_DEPARTURE_MINUTES = 74;
+const HPD_ARRIVAL_MINUTES = 85;
+const REVIEW_MINUTES = 98;
 
 const londonClock = (iso: string) =>
   new Intl.DateTimeFormat("en-GB", {
@@ -79,38 +83,78 @@ export function TodayDemoClient({ weather }: { weather: LocalWeather | null }) {
     [base],
   );
 
-  const ticket: TicketVM = useMemo(
+  const firstTicket: TicketVM = useMemo(
     () => ({
-      id: "demo-luton-run",
+      id: "demo-wellingborough-luton",
       kind: "rail",
       operator: "East Midlands Railway",
-      reference: "DEMO 24B",
+      reference: "DEMO WEL-01",
       source: "forwarded",
       consequence:
-        "The Wellingborough arrival leaves a protected walk to the review.",
+        "Your arrival at Luton leaves a protected six-minute change.",
       legs: [
         {
-          id: "demo-luton-leg",
+          id: "demo-wellingborough-luton-leg",
           origin: {
-            place: "Luton",
-            code: "LUT",
-            time: at(DEPARTURE_MINUTES),
+            place: "Wellingborough",
+            code: "WEL",
+            time: at(WEL_DEPARTURE_MINUTES),
             platform: "2",
           },
           destination: {
-            place: "Wellingborough",
-            code: "WEL",
-            time: at(ARRIVAL_MINUTES),
+            place: "Luton",
+            code: "LUT",
+            time: at(LUT_ARRIVAL_MINUTES),
           },
-          durationMinutes: 25,
+          durationMinutes: 23,
           travelClass: "Standard",
           ticketType: "Off-Peak Day Single",
           coach: "B",
-          seat: "24 · table",
+          seat: "42 · table",
           barcodes: [
             {
               format: "aztec",
-              value: "KHONSERA-DEMO-NOT-A-VALID-TICKET",
+              value: "KHONSERA-DEMO-WEL-LUT-NOT-A-VALID-TICKET",
+              passengerLabel: "Demo passenger",
+            },
+          ],
+          status: { status: "on_time", label: "On time" },
+        },
+      ],
+    }),
+    [at],
+  );
+
+  const secondTicket: TicketVM = useMemo(
+    () => ({
+      id: "demo-luton-harpenden",
+      kind: "rail",
+      operator: "Thameslink",
+      reference: "DEMO LUT-02",
+      source: "forwarded",
+      consequence:
+        "Harpenden station leaves a short, comfortable walk to the review.",
+      legs: [
+        {
+          id: "demo-luton-harpenden-leg",
+          origin: {
+            place: "Luton",
+            code: "LUT",
+            time: at(LUT_DEPARTURE_MINUTES),
+            platform: "4",
+          },
+          destination: {
+            place: "Harpenden",
+            code: "HPD",
+            time: at(HPD_ARRIVAL_MINUTES),
+          },
+          durationMinutes: 11,
+          travelClass: "Standard",
+          ticketType: "Anytime Day Single",
+          barcodes: [
+            {
+              format: "aztec",
+              value: "KHONSERA-DEMO-LUT-HPD-NOT-A-VALID-TICKET",
               passengerLabel: "Demo passenger",
             },
           ],
@@ -124,40 +168,62 @@ export function TodayDemoClient({ weather }: { weather: LocalWeather | null }) {
   const anchors: SpineAnchor[] = useMemo(
     () => [
       {
-        id: "demo-luton",
+        id: "demo-wellingborough",
         type: "transport_arrival",
-        title: "Luton Station",
-        arriveByIso: at(DEPARTURE_MINUTES),
-        endIso: at(DEPARTURE_MINUTES),
-        coord: LUTON,
+        title: "Wellingborough Station",
+        arriveByIso: at(WEL_DEPARTURE_MINUTES),
+        endIso: at(WEL_DEPARTURE_MINUTES),
+        coord: WELLINGBOROUGH,
         plannedTravelMinutes: 16,
         bufferMinutes: 8,
+        navMode: navModeForTransition("walk"),
+        station: {
+          name: "Wellingborough",
+          code: "WEL",
+          kind: "rail_station",
+        },
+        role: "departure",
+        pass: {
+          ticket: firstTicket,
+          crs: "WEL",
+          time: londonClock(at(WEL_DEPARTURE_MINUTES)),
+          dest: "LUT",
+        },
+      },
+      {
+        id: "demo-luton-change",
+        type: "transport_arrival",
+        title: "Luton Station",
+        arriveByIso: at(LUT_ARRIVAL_MINUTES),
+        endIso: at(LUT_DEPARTURE_MINUTES),
+        coord: LUTON,
+        plannedTravelMinutes: null,
         navMode: navModeForTransition("walk"),
         station: {
           name: "Luton",
           code: "LUT",
           kind: "rail_station",
         },
-        role: "departure",
+        role: "changeover",
         pass: {
-          ticket,
+          ticket: secondTicket,
           crs: "LUT",
-          time: londonClock(at(DEPARTURE_MINUTES)),
-          dest: "WEL",
+          time: londonClock(at(LUT_DEPARTURE_MINUTES)),
+          dest: "HPD",
         },
       },
       {
-        id: "demo-wellingborough",
+        id: "demo-harpenden",
         type: "transport_arrival",
-        title: "Wellingborough Station",
-        arriveByIso: at(ARRIVAL_MINUTES),
-        endIso: at(ARRIVAL_MINUTES),
-        coord: WELLINGBOROUGH,
-        plannedTravelMinutes: 25,
+        title: "Harpenden Station",
+        arriveByIso: at(HPD_ARRIVAL_MINUTES),
+        endIso: at(HPD_ARRIVAL_MINUTES),
+        coord: HARPENDEN,
+        plannedTravelMinutes: null,
         navMode: navModeForTransition("walk"),
         station: {
-          name: "Wellingborough",
-          code: "WEL",
+          name: "Harpenden",
+          code: "HPD",
           kind: "rail_station",
         },
         role: "arrival",
@@ -166,18 +232,18 @@ export function TodayDemoClient({ weather }: { weather: LocalWeather | null }) {
         id: "demo-review",
         type: "appointment",
         title: "Project review",
-        place: "Wellingborough",
+        place: "The Brew, Harpenden",
         arriveByIso: at(REVIEW_MINUTES),
         endIso: at(REVIEW_MINUTES + 60),
-        coord: WELLINGBOROUGH,
-        plannedTravelMinutes: 8,
-        bufferMinutes: 10,
+        coord: REVIEW,
+        plannedTravelMinutes: 6,
+        bufferMinutes: 7,
         navMode: navModeForTransition("walk"),
         station: null,
         role: "stop",
       },
     ],
-    [at, ticket],
+    [at, firstTicket, secondTicket],
   );
 
   return (
@@ -207,8 +273,7 @@ export function TodayDemoClient({ weather }: { weather: LocalWeather | null }) {
       <div className="cc-demo-banner" role="status">
         <span className="cc-demo-banner-mark">Demo scenario</span>
         <span className="cc-demo-banner-copy">
-          This is isolated sample data, not your Today. It uses the production
-          Today components and live routing services, but cannot change your plan.
+          Sample itinerary only. Your real Today and account data remain untouched.
         </span>
         <Link href={"/settings" as Route} className="cc-demo-banner-link">
           Demo settings
@@ -220,7 +285,7 @@ export function TodayDemoClient({ weather }: { weather: LocalWeather | null }) {
           <div className="cc-demo-readout">
             <span className="cc-demo-readout-label">Scenario clock</span>
             <strong>{londonClock(new Date().toISOString())}</strong>
-            <span>Opened with all services on time</span>
+            <span>Sample journey starts from Wellingborough</span>
           </div>
         </div>
 
@@ -228,8 +293,8 @@ export function TodayDemoClient({ weather }: { weather: LocalWeather | null }) {
           <div className="cc-today-command-content">
             <LiveDay
               anchors={anchors}
-              sub="Demo scenario · from Harpenden"
-              base={HARPENDEN}
+              sub="Demo journey · from Wellingborough"
+              base={HOME}
             />
           </div>
         </section>
@@ -238,7 +303,7 @@ export function TodayDemoClient({ weather }: { weather: LocalWeather | null }) {
           className="cc-day-primary"
           aria-label="Demo itinerary for project review"
         >
-          <TodaySpine anchors={anchors} nextId="demo-luton" />
+          <TodaySpine anchors={anchors} nextId="demo-wellingborough" />
         </section>
 
         <aside className="cc-day-context" aria-label="About this demo">


### PR DESCRIPTION
## Purpose
A focused card-by-card, button-by-button QA pass against the populated mobile Today screenshot.

## Page hierarchy
- compact the demo banner without weakening the data boundary
- demote the scenario clock from a second hero to a utility strip
- reduce the height and visual weight of the next-move card
- preserve the normal Today header and weather treatment

## Controls
- give every next-move action a visible label
- make the route action full-width and primary
- arrange Share, Re-route and Tickets as three equal secondary actions
- keep all controls at mobile-safe touch sizes

## Itinerary
- fix the unreadable white-on-white active walking leg
- tighten rail, marker and card alignment
- reduce excess movement-card and appointment-card height
- densify the rail pass while preserving platform, status and ticket behaviour
- soften the consequence note so it reads as guidance rather than an alert

## Demo scenario
- replace the incoherent Luton-to-Wellingborough sample with a Wellingborough → Luton → Harpenden journey
- include a protected Luton change and two representative rail tickets
- keep all sample data isolated from the signed-in user's Today
- hide repeated technical explanation cards on mobile; the visible demo banner remains

## Safety
- no Supabase writes or account-data contracts changed
- shared Today components remain shared between demo and live Today
- regression tests protect load order, active-leg readability, labelled actions and scenario boundaries
