### PR TITLE
Apply detailed Today feedback to spine, transfers and hub arrivals

### DIFF
--- a/src/app/khonsera-today-feedback.css
+++ b/src/app/khonsera-today-feedback.css
@@ -1,0 +1,343 @@
+/*
+ * Today feedback round 2
+ *
+ * Direct corrections from populated mobile review:
+ * - give movement badges breathing room beneath card accents
+ * - replace inherited geometric markers with one legible icon family
+ * - make connection timing a deliberate grid rather than floating metadata
+ * - expose arrival and dwell at transport hubs before the booked service
+ */
+
+/* Shared spine icon family ------------------------------------------------ */
+.khonsera-app .cc-today-direction .cc-node-dot {
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 7px;
+}
+
+.khonsera-app .cc-today-direction .cc-spine-icon {
+  width: 32px;
+  height: 32px;
+  box-sizing: border-box;
+  display: inline-grid;
+  flex: none;
+  place-items: center;
+  border: 1px solid var(--kh-border-strong);
+  border-radius: 999px;
+  background: var(--kh-surface);
+  color: var(--kh-green-strong);
+  box-shadow: 0 5px 14px -11px rgba(30, 28, 22, 0.8);
+}
+
+.khonsera-app .cc-today-direction .cc-spine-icon svg {
+  width: 16px;
+  height: 16px;
+}
+
+.khonsera-app .cc-today-direction .cc-spine-icon[data-kind="now"] {
+  width: 26px;
+  height: 26px;
+  margin-top: 3px;
+  border-color: var(--kh-green-strong);
+  background: var(--kh-green-strong);
+  color: #fff;
+}
+
+.khonsera-app .cc-today-direction .cc-spine-icon[data-kind="hub"] {
+  border-color: color-mix(in srgb, var(--kh-green) 38%, var(--kh-border));
+  background: var(--kh-green-soft);
+  color: var(--kh-green-strong);
+}
+
+.khonsera-app .cc-today-direction .cc-spine-icon[data-kind="change"] {
+  border-color: color-mix(in srgb, var(--kh-orange) 55%, var(--kh-border));
+  background: var(--kh-orange-soft);
+  color: var(--kh-orange-strong);
+}
+
+.khonsera-app .cc-today-direction .cc-spine-icon[data-kind="train"] {
+  border-color: var(--kh-orange);
+  background: var(--kh-orange);
+  color: #fff;
+}
+
+.khonsera-app .cc-today-direction .cc-spine-icon[data-kind="appointment"] {
+  background: var(--kh-surface);
+  color: var(--kh-green-strong);
+}
+
+.khonsera-app .cc-today-direction .cc-spine-icon[data-active="true"]:not([data-kind="train"]):not([data-kind="now"]) {
+  border-color: var(--kh-green-strong);
+  background: var(--kh-green-strong);
+  color: #fff;
+}
+
+.khonsera-app .cc-today-direction .cc-spine-rail {
+  left: 16px;
+  width: 1px;
+  background: linear-gradient(
+    to bottom,
+    var(--kh-orange) 0 62px,
+    var(--kh-border-strong) 62px calc(100% - 28px),
+    transparent 100%
+  ) !important;
+}
+
+.khonsera-app .cc-today-direction .cc-node--now {
+  min-height: 36px;
+  padding-bottom: 7px;
+}
+
+/* Movement card and badge clearance -------------------------------------- */
+.khonsera-app .cc-today-direction .cc-walk {
+  padding: 17px 14px 13px;
+}
+
+.khonsera-app .cc-today-direction .cc-walk::before {
+  height: 3px;
+}
+
+.khonsera-app .cc-today-direction .cc-walk-head {
+  min-height: 23px;
+  align-items: center;
+}
+
+.khonsera-app .cc-today-direction .cc-walk-mode {
+  min-height: 21px;
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 7px;
+  border: 1px solid color-mix(in srgb, var(--kh-orange) 24%, var(--kh-border));
+  border-radius: 999px;
+  background: var(--kh-orange-soft);
+  line-height: 1;
+}
+
+.khonsera-app .cc-today-direction .cc-walk-mins {
+  line-height: 1;
+}
+
+/* Explicit arrival and dwell at a transport hub -------------------------- */
+.khonsera-app .cc-today-direction .cc-hub-arrival {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 11px 14px;
+  align-items: center;
+  padding: 14px 15px;
+  border: 1px solid var(--kh-border);
+  border-radius: 14px 14px 14px 5px;
+  background: var(--kh-surface);
+  color: var(--kh-ink);
+  box-shadow: 0 9px 22px -22px rgba(39, 31, 20, 0.72);
+}
+
+.khonsera-app .cc-today-direction .cc-hub-arrival-copy {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.khonsera-app .cc-today-direction .cc-hub-arrival-copy .cc-eyebrow {
+  color: var(--kh-orange-strong);
+}
+
+.khonsera-app .cc-today-direction .cc-hub-arrival-copy strong {
+  overflow: hidden;
+  color: var(--kh-ink);
+  font-size: 14px;
+  font-weight: 730;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.khonsera-app .cc-today-direction .cc-hub-arrival-window {
+  display: grid;
+  grid-template-columns: auto 14px auto;
+  align-items: center;
+  gap: 7px;
+}
+
+.khonsera-app .cc-today-direction .cc-hub-arrival-window > span:not(.cc-hub-arrival-arrow) {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.khonsera-app .cc-today-direction .cc-hub-arrival-window small {
+  color: var(--kh-ink-faint);
+  font-family: var(--mono);
+  font-size: 7px;
+  font-weight: 750;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.khonsera-app .cc-today-direction .cc-hub-arrival-window strong {
+  color: var(--kh-ink);
+  font-size: 12px;
+  font-weight: 760;
+}
+
+.khonsera-app .cc-today-direction .cc-hub-arrival-arrow {
+  color: var(--kh-orange);
+  font-size: 13px;
+}
+
+.khonsera-app .cc-today-direction .cc-hub-arrival-buffer {
+  grid-column: 1 / -1;
+  width: fit-content;
+  min-height: 23px;
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: var(--kh-green-soft);
+  color: var(--kh-success);
+  font-size: 9px;
+  font-weight: 720;
+}
+
+/* Transfer card: clear place, duration and time relationship -------------- */
+.khonsera-app .cc-today-direction .cc-transfer {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 11px 14px;
+  align-items: center;
+  padding: 14px 15px;
+  border-style: solid;
+  border-color: color-mix(in srgb, var(--kh-orange) 32%, var(--kh-border));
+  border-radius: 14px 14px 14px 5px;
+  background: color-mix(in srgb, var(--kh-orange-soft) 44%, var(--kh-surface));
+}
+
+.khonsera-app .cc-today-direction .cc-transfer-main {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.khonsera-app .cc-today-direction .cc-transfer-main strong {
+  overflow: hidden;
+  color: var(--kh-ink);
+  font-size: 15px;
+  line-height: 1.2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.khonsera-app .cc-today-direction .cc-transfer-duration {
+  min-width: 70px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+  text-align: right;
+}
+
+.khonsera-app .cc-today-direction .cc-transfer-duration strong {
+  color: var(--kh-orange-strong);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.khonsera-app .cc-today-direction .cc-transfer-duration span {
+  color: var(--kh-ink-faint);
+  font-size: 8px;
+}
+
+.khonsera-app .cc-today-direction .cc-transfer-window {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 18px minmax(0, 1fr);
+  align-items: center;
+  gap: 8px;
+  padding-top: 10px;
+  border-top: 1px solid color-mix(in srgb, var(--kh-orange) 18%, var(--kh-border));
+}
+
+.khonsera-app .cc-today-direction .cc-transfer-window > span:not(.cc-transfer-arrow) {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.khonsera-app .cc-today-direction .cc-transfer-window small {
+  color: var(--kh-ink-muted);
+  font-size: 8px;
+}
+
+.khonsera-app .cc-today-direction .cc-transfer-window strong {
+  color: var(--kh-ink);
+  font-size: 11px;
+  font-weight: 760;
+}
+
+.khonsera-app .cc-today-direction .cc-transfer-arrow {
+  color: var(--kh-orange);
+  text-align: center;
+}
+
+@media (max-width: 430px) {
+  .khonsera-app .cc-today-direction .cc-node-dot {
+    width: 32px;
+    min-width: 32px;
+  }
+
+  .khonsera-app .cc-today-direction .cc-spine-icon {
+    width: 30px;
+    height: 30px;
+  }
+
+  .khonsera-app .cc-today-direction .cc-spine-icon svg {
+    width: 15px;
+    height: 15px;
+  }
+
+  .khonsera-app .cc-today-direction .cc-spine-rail {
+    left: 15px;
+  }
+
+  .khonsera-app .cc-today-direction .cc-hub-arrival {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 10px;
+    padding: 13px 14px;
+  }
+
+  .khonsera-app .cc-today-direction .cc-hub-arrival-window {
+    width: 100%;
+    grid-template-columns: minmax(0, 1fr) 14px minmax(0, 1fr);
+    padding-top: 9px;
+    border-top: 1px solid var(--kh-border);
+  }
+
+  .khonsera-app .cc-today-direction .cc-hub-arrival-window > span:last-child {
+    align-items: flex-end;
+    text-align: right;
+  }
+
+  .khonsera-app .cc-today-direction .cc-transfer {
+    gap: 10px 12px;
+    padding: 13px 14px;
+  }
+
+  .khonsera-app .cc-today-direction .cc-transfer-duration {
+    min-width: 62px;
+  }
+
+  .khonsera-app .cc-today-direction .cc-transfer-window > span:not(.cc-transfer-arrow) {
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .khonsera-app .cc-today-direction .cc-transfer-window > span:last-child {
+    align-items: flex-end;
+    text-align: right;
+  }
+}

--- a/src/app/khonsera-today-feedback.test.ts
+++ b/src/app/khonsera-today-feedback.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+const layout = readFileSync(join(root, "src/app/layout.tsx"), "utf8");
+const css = readFileSync(
+  join(root, "src/app/khonsera-today-feedback.css"),
+  "utf8",
+);
+const spine = readFileSync(
+  join(root, "src/components/today/today-spine.tsx"),
+  "utf8",
+);
+
+describe("Today detailed feedback pass", () => {
+  it("loads after the earlier Today polish layer", () => {
+    const polishIndex = layout.indexOf('"./khonsera-today-polish.css"');
+    const feedbackIndex = layout.indexOf('"./khonsera-today-feedback.css"');
+    expect(polishIndex).toBeGreaterThan(-1);
+    expect(feedbackIndex).toBeGreaterThan(polishIndex);
+  });
+
+  it("uses one SVG spine icon family instead of inherited geometric markers", () => {
+    expect(spine).toContain("function SpineIcon");
+    expect(spine).toContain('className="cc-spine-icon"');
+    expect(spine).toContain('kind="train"');
+    expect(spine).toContain('kind="change"');
+    expect(spine).not.toContain('className="cc-med-leg"');
+    expect(css).toContain('.cc-spine-icon[data-kind="train"]');
+  });
+
+  it("adds a distinct transport-hub arrival before a booked departure", () => {
+    expect(spine).toContain("hasImplicitHubArrival");
+    expect(spine).toContain("<HubArrivalCard");
+    expect(spine).toContain("Arrive at station");
+    expect(spine).toContain("min at station");
+    expect(css).toContain(".cc-hub-arrival-window");
+  });
+
+  it("gives badges clearance and structures connection timing", () => {
+    expect(css).toContain("padding: 17px 14px 13px");
+    expect(css).toContain(".cc-walk-mode");
+    expect(spine).toContain("cc-transfer-duration");
+    expect(spine).toContain("cc-transfer-window");
+    expect(css).toContain("grid-column: 1 / -1");
+  });
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,6 +25,7 @@ import "./khonsera-secondary-surfaces.css"; // Pass 4 — Plan index, Wallet and
 import "./khonsera-demo.css"; // Staff demo boundary — shared components, isolated scenario data
 import "./khonsera-layout.css"; // Pass 5 — spacing, alignment and placement across every app route
 import "./khonsera-today-polish.css"; // Focused QA — Today cards, controls and itinerary hierarchy
+import "./khonsera-today-feedback.css"; // Detailed review — spine icons, hub dwell, transfers and badge spacing
 import { PwaRegister } from "@/components/pwa-register";
 
 // Canonical type stack:

--- a/src/components/today/today-spine.tsx
+++ b/src/components/today/today-spine.tsx
@@ -3,7 +3,12 @@
 import { useEffect, useMemo, useState } from "react";
 import type { SpineAnchor } from "./spine-model";
 import { londonClock, navigateHref, roleLabel } from "./spine-model";
-import { pickNextIndex, READINESS_BUFFER_MIN, STATION_BUFFER_MIN, type EngineAnchor } from "@/lib/today/engine";
+import {
+  pickNextIndex,
+  READINESS_BUFFER_MIN,
+  STATION_BUFFER_MIN,
+  type EngineAnchor,
+} from "@/lib/today/engine";
 import { LivePass } from "@/components/plan/live-pass";
 import { ScanView } from "@/components/concierge";
 import type { BarcodeVM, TicketVM } from "@/components/concierge";
@@ -20,7 +25,20 @@ const TYPE_LABEL: Record<SpineAnchor["type"], string> = {
 };
 
 type State = "past" | "next" | "future";
-type TimedLeg = { departIso: string | null; arriveIso: string | null; spareMinutes: number | null };
+type TimedLeg = {
+  departIso: string | null;
+  arriveIso: string | null;
+  spareMinutes: number | null;
+};
+type SpineIconKind =
+  | "now"
+  | "walk"
+  | "cycle"
+  | "drive"
+  | "hub"
+  | "train"
+  | "change"
+  | "appointment";
 
 function ms(iso: string | null | undefined): number | null {
   if (!iso) return null;
@@ -52,41 +70,58 @@ function previousPassEndsAt(
     return true;
   }
 
-  return (
-    normalisePlace(destination.place) === normalisePlace(anchor.station.name)
-  );
+  return normalisePlace(destination.place) === normalisePlace(anchor.station.name);
 }
 
-function movementTimes(anchor: SpineAnchor, previous: SpineAnchor | null): TimedLeg {
+function movementTimes(
+  anchor: SpineAnchor,
+  previous: SpineAnchor | null,
+): TimedLeg {
   const minutes = anchor.plannedTravelMinutes;
   const targetMs = ms(anchor.arriveByIso);
-  if (minutes == null || targetMs == null) return { departIso: null, arriveIso: null, spareMinutes: null };
+  if (minutes == null || targetMs == null) {
+    return { departIso: null, arriveIso: null, spareMinutes: null };
+  }
 
   const durationMs = minutes * 60_000;
-  const bufferMinutes = anchor.bufferMinutes ?? (anchor.station ? STATION_BUFFER_MIN : READINESS_BUFFER_MIN);
+  const bufferMinutes =
+    anchor.bufferMinutes ??
+    (anchor.station ? STATION_BUFFER_MIN : READINESS_BUFFER_MIN);
   const preferredArrivalMs = targetMs - bufferMinutes * 60_000;
   const preferredDepartureMs = preferredArrivalMs - durationMs;
   const previousEndMs = previous ? ms(previous.endIso ?? previous.arriveByIso) : null;
   const explicitNotBeforeMs = ms(anchor.notBeforeIso);
-  const notBeforeMs = explicitNotBeforeMs ?? (previous?.type === "shift" ? previousEndMs : null);
+  const notBeforeMs =
+    explicitNotBeforeMs ?? (previous?.type === "shift" ? previousEndMs : null);
 
   if (anchor.station) {
-    // A fixed span wins over a comfort margin. For a 17:00 shift end, 9-minute
-    // walk and 17:22 train, show the honest 17:00–17:09 leg with 13 minutes spare,
-    // never a fictional 16:58 departure from work.
-    const departMs = notBeforeMs == null ? preferredDepartureMs : Math.max(preferredDepartureMs, notBeforeMs);
+    const departMs =
+      notBeforeMs == null
+        ? preferredDepartureMs
+        : Math.max(preferredDepartureMs, notBeforeMs);
     const arriveMs = departMs + durationMs;
     const spare = Math.round((targetMs - arriveMs) / 60_000);
-    return { departIso: iso(departMs), arriveIso: iso(arriveMs), spareMinutes: spare };
+    return {
+      departIso: iso(departMs),
+      arriveIso: iso(arriveMs),
+      spareMinutes: spare,
+    };
   }
 
   if (previousEndMs != null) {
     const arriveMs = previousEndMs + durationMs;
     const spare = Math.round((targetMs - arriveMs) / 60_000);
-    return { departIso: iso(previousEndMs), arriveIso: iso(arriveMs), spareMinutes: spare };
+    return {
+      departIso: iso(previousEndMs),
+      arriveIso: iso(arriveMs),
+      spareMinutes: spare,
+    };
   }
 
-  const departMs = notBeforeMs == null ? preferredDepartureMs : Math.max(preferredDepartureMs, notBeforeMs);
+  const departMs =
+    notBeforeMs == null
+      ? preferredDepartureMs
+      : Math.max(preferredDepartureMs, notBeforeMs);
   const arriveMs = departMs + durationMs;
   return {
     departIso: iso(departMs),
@@ -95,11 +130,100 @@ function movementTimes(anchor: SpineAnchor, previous: SpineAnchor | null): Timed
   };
 }
 
-export function TodaySpine({ anchors, nextId, nowOverride }: { anchors: SpineAnchor[]; nextId?: string | null; nowOverride?: number | null }) {
+function hasImplicitHubArrival(anchor: SpineAnchor): boolean {
+  return Boolean(
+    anchor.pass &&
+      anchor.station &&
+      anchor.role === "departure" &&
+      anchor.plannedTravelMinutes != null &&
+      anchor.arriveByIso,
+  );
+}
+
+function SpineIcon({
+  kind,
+  active = false,
+}: {
+  kind: SpineIconKind;
+  active?: boolean;
+}) {
+  return (
+    <span
+      className="cc-spine-icon"
+      data-kind={kind}
+      data-active={active || undefined}
+      aria-hidden
+    >
+      <svg
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        {kind === "now" ? (
+          <>
+            <circle cx="12" cy="12" r="7.5" />
+            <path d="M12 8v4l2.7 1.8" />
+          </>
+        ) : kind === "walk" ? (
+          <>
+            <circle cx="13" cy="4.5" r="1.6" />
+            <path d="m10.2 9 2.2-2.1 2.5 1.5 2 2.1M12.4 7l-1.1 5-3 3M13.1 11.5l2.1 3 .7 4M11.3 12l2.4 2.2-1.8 4" />
+          </>
+        ) : kind === "cycle" ? (
+          <>
+            <circle cx="6.5" cy="16.5" r="3.2" />
+            <circle cx="17.5" cy="16.5" r="3.2" />
+            <path d="m8.5 8.5 3.3 8h-5.3l3.8-5.2h4.7l2.5 5.2M8.5 8.5h3" />
+          </>
+        ) : kind === "drive" ? (
+          <>
+            <path d="m5 15 1.3-5.1A2 2 0 0 1 8.2 8.5h7.6a2 2 0 0 1 1.9 1.4L19 15" />
+            <path d="M4 15h16v3H4zM7 18v1.5M17 18v1.5M7.5 13h.01M16.5 13h.01" />
+          </>
+        ) : kind === "hub" ? (
+          <>
+            <path d="M5 20V9l7-4 7 4v11" />
+            <path d="M8 20v-6h8v6M8 10h.01M12 10h.01M16 10h.01" />
+          </>
+        ) : kind === "train" ? (
+          <>
+            <rect x="6" y="3.5" width="12" height="14" rx="2.5" />
+            <path d="M8.5 7.5h7M9 17.5l-2 3M15 17.5l2 3M9 13h.01M15 13h.01" />
+          </>
+        ) : kind === "change" ? (
+          <>
+            <path d="M5 8h12l-3-3M19 16H7l3 3" />
+          </>
+        ) : (
+          <>
+            <rect x="5" y="7" width="14" height="12" rx="2" />
+            <path d="M9 7V5h6v2M8 11h8M12 11v4" />
+          </>
+        )}
+      </svg>
+    </span>
+  );
+}
+
+export function TodaySpine({
+  anchors,
+  nextId,
+  nowOverride,
+}: {
+  anchors: SpineAnchor[];
+  nextId?: string | null;
+  nowOverride?: number | null;
+}) {
   const [internalNow, setInternalNow] = useState(() => Date.now());
   const [showPast, setShowPast] = useState(false);
   const [showLater, setShowLater] = useState(false);
-  const [scan, setScan] = useState<{ summary: string; barcodes: BarcodeVM[] } | null>(null);
+  const [scan, setScan] = useState<{
+    summary: string;
+    barcodes: BarcodeVM[];
+  } | null>(null);
 
   useEffect(() => {
     if (nowOverride != null) return;
@@ -120,38 +244,67 @@ export function TodaySpine({ anchors, nextId, nowOverride }: { anchors: SpineAnc
       isBlockingSpan: anchor.type === "shift",
     }));
     const index = pickNextIndex(engineAnchors, now);
-    return index == null ? nextId ?? null : anchors[index]?.id ?? nextId ?? null;
+    return index == null
+      ? (nextId ?? null)
+      : (anchors[index]?.id ?? nextId ?? null);
   }, [anchors, nextId, now]);
 
   if (!anchors.length) return null;
 
-  const nextIndex = Math.max(0, anchors.findIndex((anchor) => anchor.id === activeNextId));
+  const nextIndex = Math.max(
+    0,
+    anchors.findIndex((anchor) => anchor.id === activeNextId),
+  );
   const past = anchors.slice(0, nextIndex);
-  const currentAndNear = anchors.slice(nextIndex, Math.min(anchors.length, nextIndex + 5));
+  const currentAndNear = anchors.slice(
+    nextIndex,
+    Math.min(anchors.length, nextIndex + 5),
+  );
   const later = anchors.slice(Math.min(anchors.length, nextIndex + 5));
+  const visualPointCount =
+    anchors.length + anchors.filter(hasImplicitHubArrival).length;
 
   const openTicket = (ticket: TicketVM) => {
     const leg = ticket.legs[0];
     if (!leg?.barcodes?.length) return;
-    setScan({ summary: `${ticket.operator} · ${leg.origin.place} → ${leg.destination.place}`, barcodes: leg.barcodes });
+    setScan({
+      summary: `${ticket.operator} · ${leg.origin.place} → ${leg.destination.place}`,
+      barcodes: leg.barcodes,
+    });
   };
 
   return (
     <section>
       <div className="cc-spine-heading">
         <span className="cc-eyebrow">Your itinerary</span>
-        <span>{anchors.length} timed point{anchors.length === 1 ? "" : "s"}</span>
+        <span>
+          {visualPointCount} timed point{visualPointCount === 1 ? "" : "s"}
+        </span>
       </div>
       <div className="cc-spine">
         <div className="cc-spine-rail" />
-        {past.length ? <Toggle label={`${past.length} earlier`} open={showPast} onClick={() => setShowPast((value) => !value)} /> : null}
+        {past.length ? (
+          <Toggle
+            label={`${past.length} earlier`}
+            open={showPast}
+            onClick={() => setShowPast((value) => !value)}
+          />
+        ) : null}
         {showPast
           ? past.map((anchor, index) => (
-              <Entry key={anchor.id} anchor={anchor} previous={index ? past[index - 1] : null} state="past" onShowTicket={openTicket} />
+              <Entry
+                key={anchor.id}
+                anchor={anchor}
+                previous={index ? past[index - 1] : null}
+                state="past"
+                onShowTicket={openTicket}
+              />
             ))
           : null}
-        <div className="cc-node">
-          <div className="cc-node-dot"><span className="cc-dot-now" /></div>
+        <div className="cc-node cc-node--now">
+          <div className="cc-node-dot">
+            <SpineIcon kind="now" active />
+          </div>
           <span className="cc-now-row">
             Now · {londonClock(new Date(now).toISOString())}
           </span>
@@ -170,7 +323,11 @@ export function TodaySpine({ anchors, nextId, nowOverride }: { anchors: SpineAnc
         })}
         {later.length ? (
           <>
-            <Toggle label={`${later.length} later`} open={showLater} onClick={() => setShowLater((value) => !value)} />
+            <Toggle
+              label={`${later.length} later`}
+              open={showLater}
+              onClick={() => setShowLater((value) => !value)}
+            />
             {showLater
               ? later.map((anchor, index) => {
                   const absoluteIndex = anchors.length - later.length + index;
@@ -188,7 +345,13 @@ export function TodaySpine({ anchors, nextId, nowOverride }: { anchors: SpineAnc
           </>
         ) : null}
       </div>
-      {scan ? <ScanView summary={scan.summary} barcodes={scan.barcodes} onClose={() => setScan(null)} /> : null}
+      {scan ? (
+        <ScanView
+          summary={scan.summary}
+          barcodes={scan.barcodes}
+          onClose={() => setScan(null)}
+        />
+      ) : null}
     </section>
   );
 }
@@ -205,16 +368,35 @@ function Entry({
   onShowTicket: (ticket: TicketVM) => void;
 }) {
   const movement = movementTimes(anchor, previous);
-  const isAppointment = anchor.type === "appointment" || anchor.type === "reservation" || anchor.type === "shift";
-  const showMovement = anchor.plannedTravelMinutes != null && !!navigateHref(anchor) && state !== "past";
+  const isAppointment =
+    anchor.type === "appointment" ||
+    anchor.type === "reservation" ||
+    anchor.type === "shift";
+  const showMovement =
+    anchor.plannedTravelMinutes != null &&
+    !!navigateHref(anchor) &&
+    state !== "past";
   const passOwnsStation = !!anchor.pass && anchor.role !== "changeover";
   const arrivalCoveredByPass =
     anchor.role === "arrival" && previousPassEndsAt(previous, anchor);
   const showAnchor = !passOwnsStation && !arrivalCoveredByPass;
+  const showHubArrival =
+    showMovement &&
+    hasImplicitHubArrival(anchor) &&
+    movement.arriveIso != null;
 
   return (
     <>
-      {showMovement ? <MovementCard anchor={anchor} movement={movement} active={state === "next"} /> : null}
+      {showMovement ? (
+        <MovementCard
+          anchor={anchor}
+          movement={movement}
+          active={state === "next"}
+        />
+      ) : null}
+      {showHubArrival ? (
+        <HubArrivalCard anchor={anchor} movement={movement} state={state} />
+      ) : null}
       {showAnchor && anchor.role === "changeover" ? (
         <ChangeCard anchor={anchor} state={state} />
       ) : showAnchor && isAppointment ? (
@@ -222,57 +404,168 @@ function Entry({
       ) : showAnchor ? (
         <AnchorCard anchor={anchor} state={state} />
       ) : null}
-      {anchor.pass ? <PassCard pass={anchor.pass} state={state} onShowTicket={onShowTicket} /> : null}
+      {anchor.pass ? (
+        <PassCard
+          pass={anchor.pass}
+          state={state}
+          onShowTicket={onShowTicket}
+        />
+      ) : null}
     </>
   );
 }
 
-function MovementCard({ anchor, movement, active }: { anchor: SpineAnchor; movement: TimedLeg; active: boolean }) {
-  const mode = anchor.navMode === "drive" ? "Drive" : anchor.navMode === "cycle" ? "Cycle" : "Walk";
-  const destination = anchor.station ? anchor.title : anchor.place ?? anchor.title;
+function MovementCard({
+  anchor,
+  movement,
+  active,
+}: {
+  anchor: SpineAnchor;
+  movement: TimedLeg;
+  active: boolean;
+}) {
+  const mode =
+    anchor.navMode === "drive"
+      ? "Drive"
+      : anchor.navMode === "cycle"
+        ? "Cycle"
+        : "Walk";
+  const iconKind: SpineIconKind =
+    mode === "Drive" ? "drive" : mode === "Cycle" ? "cycle" : "walk";
+  const destination = anchor.station
+    ? anchor.title
+    : (anchor.place ?? anchor.title);
+
   return (
     <div className="cc-node" data-state={active ? "next" : "future"}>
-      <div className="cc-node-dot"><span className="cc-med-leg" /></div>
+      <div className="cc-node-dot">
+        <SpineIcon kind={iconKind} active={active} />
+      </div>
       <div className="pg cc-walk">
         <div className="cc-walk-head">
           <span className="cc-walk-mode">{mode}</span>
-          <span className="cc-walk-mins mono engr">{anchor.plannedTravelMinutes} min</span>
+          <span className="cc-walk-mins mono engr">
+            {anchor.plannedTravelMinutes} min
+          </span>
         </div>
         {movement.departIso && movement.arriveIso ? (
           <div className="cc-walk-window">
-            <span className="mono cc-walk-time">{londonClock(movement.departIso)}</span>
+            <span className="mono cc-walk-time">
+              {londonClock(movement.departIso)}
+            </span>
             <span className="cc-walk-rule" aria-hidden />
-            <span className="mono cc-walk-time">{londonClock(movement.arriveIso)}</span>
+            <span className="mono cc-walk-time">
+              {londonClock(movement.arriveIso)}
+            </span>
           </div>
         ) : null}
         <div className="cc-walk-dest">
           <span>→ {destination}</span>
           {movement.spareMinutes != null && movement.spareMinutes > 0 ? (
-            <span className="cc-walk-spare">{movement.spareMinutes} min spare</span>
+            <span className="cc-walk-spare">
+              {movement.spareMinutes} min spare
+            </span>
           ) : movement.spareMinutes != null && movement.spareMinutes < 0 ? (
-            <span className="cc-walk-spare">{Math.abs(movement.spareMinutes)} min late</span>
+            <span className="cc-walk-spare">
+              {Math.abs(movement.spareMinutes)} min late
+            </span>
           ) : null}
         </div>
-        <div className="cc-walk-foot"><span className="sb">Planned</span></div>
+        <div className="cc-walk-foot">
+          <span className="sb">Planned</span>
+        </div>
       </div>
     </div>
   );
 }
 
-function AppointmentCard({ anchor, state }: { anchor: SpineAnchor; state: State }) {
+function HubArrivalCard({
+  anchor,
+  movement,
+  state,
+}: {
+  anchor: SpineAnchor;
+  movement: TimedLeg;
+  state: State;
+}) {
+  const arrival = movement.arriveIso
+    ? londonClock(movement.arriveIso)
+    : null;
+  const departure = londonClock(anchor.arriveByIso);
+  const dwell = movement.spareMinutes;
+
   return (
     <div className="cc-node" data-state={state}>
-      <div className="cc-node-dot"><span className="cc-med-anchor" /></div>
+      <div className="cc-node-dot">
+        <SpineIcon kind="hub" />
+      </div>
+      <div
+        className="cc-hub-arrival"
+        data-past={state === "past" || undefined}
+      >
+        <div className="cc-hub-arrival-copy">
+          <span className="cc-eyebrow">Arrive at station</span>
+          <strong>{anchor.title}</strong>
+        </div>
+        <div className="cc-hub-arrival-window">
+          <span>
+            <small>Arrive</small>
+            <strong className="mono">{arrival ?? "—"}</strong>
+          </span>
+          <span className="cc-hub-arrival-arrow" aria-hidden>
+            →
+          </span>
+          <span>
+            <small>Train</small>
+            <strong className="mono">{departure}</strong>
+          </span>
+        </div>
+        {dwell != null && dwell > 0 ? (
+          <span className="cc-hub-arrival-buffer">
+            {dwell} min at station
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function AppointmentCard({
+  anchor,
+  state,
+}: {
+  anchor: SpineAnchor;
+  state: State;
+}) {
+  return (
+    <div className="cc-node" data-state={state}>
+      <div className="cc-node-dot">
+        <SpineIcon kind="appointment" />
+      </div>
       <div className="pg cc-appt" data-past={state === "past" || undefined}>
-        <div className="cc-appt-head"><span className="cc-eyebrow">{TYPE_LABEL[anchor.type]}</span></div>
+        <div className="cc-appt-head">
+          <span className="cc-eyebrow">{TYPE_LABEL[anchor.type]}</span>
+        </div>
         <h3 className="cc-appt-title">{anchor.title}</h3>
-        {anchor.place && anchor.place !== anchor.title ? <p className="cc-appt-sub">{anchor.place}</p> : null}
+        {anchor.place && anchor.place !== anchor.title ? (
+          <p className="cc-appt-sub">{anchor.place}</p>
+        ) : null}
         <div className="cc-appt-times">
           {anchor.arriveByIso ? (
-            <span className="cc-appt-time"><span className="cc-eyebrow">Starts</span><span className="mono engr cc-appt-clock">{londonClock(anchor.arriveByIso)}</span></span>
+            <span className="cc-appt-time">
+              <span className="cc-eyebrow">Starts</span>
+              <span className="mono engr cc-appt-clock">
+                {londonClock(anchor.arriveByIso)}
+              </span>
+            </span>
           ) : null}
           {anchor.endIso ? (
-            <span className="cc-appt-time"><span className="cc-eyebrow">Ends</span><span className="mono engr cc-appt-clock">{londonClock(anchor.endIso)}</span></span>
+            <span className="cc-appt-time">
+              <span className="cc-eyebrow">Ends</span>
+              <span className="mono engr cc-appt-clock">
+                {londonClock(anchor.endIso)}
+              </span>
+            </span>
           ) : null}
         </div>
       </div>
@@ -280,16 +573,32 @@ function AppointmentCard({ anchor, state }: { anchor: SpineAnchor; state: State 
   );
 }
 
-function AnchorCard({ anchor, state }: { anchor: SpineAnchor; state: State }) {
+function AnchorCard({
+  anchor,
+  state,
+}: {
+  anchor: SpineAnchor;
+  state: State;
+}) {
   const station = anchor.station;
-  const eyebrow = station ? roleLabel(anchor.role, station) : TYPE_LABEL[anchor.type];
+  const eyebrow = station
+    ? roleLabel(anchor.role, station)
+    : TYPE_LABEL[anchor.type];
+
   return (
     <div className="cc-node" data-state={state}>
-      <div className="cc-node-dot"><span className="cc-med-anchor" /></div>
-      <div className="cc-station-card" data-past={state === "past" || undefined}>
+      <div className="cc-node-dot">
+        <SpineIcon kind={station ? "hub" : "appointment"} />
+      </div>
+      <div
+        className="cc-station-card"
+        data-past={state === "past" || undefined}
+      >
         <div className="cc-station-card-head">
           <span className="cc-eyebrow">{eyebrow}</span>
-          <span className="mono cc-station-time">{londonClock(anchor.arriveByIso)}</span>
+          <span className="mono cc-station-time">
+            {londonClock(anchor.arriveByIso)}
+          </span>
         </div>
         <strong className="cc-station-title">{anchor.title}</strong>
       </div>
@@ -297,24 +606,54 @@ function AnchorCard({ anchor, state }: { anchor: SpineAnchor; state: State }) {
   );
 }
 
-function ChangeCard({ anchor, state }: { anchor: SpineAnchor; state: State }) {
+function ChangeCard({
+  anchor,
+  state,
+}: {
+  anchor: SpineAnchor;
+  state: State;
+}) {
   const arrive = ms(anchor.arriveByIso);
   const depart = ms(anchor.endIso);
-  const minutes = arrive != null && depart != null ? Math.max(0, Math.round((depart - arrive) / 60_000)) : null;
+  const minutes =
+    arrive != null && depart != null
+      ? Math.max(0, Math.round((depart - arrive) / 60_000))
+      : null;
+
   return (
     <div className="cc-node" data-state={state}>
-      <div className="cc-node-dot"><span className="cc-med-change" /></div>
-      <div className="cc-transfer" data-past={state === "past" || undefined}>
-        <div className="cc-transfer-head">
-          <span>
-            <span className="cc-eyebrow">Change</span>
-            <strong>{anchor.station?.name ?? anchor.title}</strong>
-          </span>
-          {minutes != null ? <span className="mono engr">{minutes}m</span> : null}
+      <div className="cc-node-dot">
+        <SpineIcon kind="change" />
+      </div>
+      <div
+        className="cc-transfer"
+        data-past={state === "past" || undefined}
+      >
+        <div className="cc-transfer-main">
+          <span className="cc-eyebrow">Change at</span>
+          <strong>{anchor.station?.name ?? anchor.title}</strong>
         </div>
-        <p className="cc-transfer-time">
-          {londonClock(anchor.arriveByIso)} arrival · {londonClock(anchor.endIso)} onward
-        </p>
+        {minutes != null ? (
+          <div className="cc-transfer-duration">
+            <strong className="mono">{minutes} min</strong>
+            <span>connection</span>
+          </div>
+        ) : null}
+        <div className="cc-transfer-window">
+          <span>
+            <small>Arrive</small>
+            <strong className="mono">
+              {londonClock(anchor.arriveByIso)}
+            </strong>
+          </span>
+          <span className="cc-transfer-arrow" aria-hidden>
+            →
+          </span>
+          <span>
+            <small>Depart</small>
+            <strong className="mono">{londonClock(anchor.endIso)}</strong>
+          </span>
+        </div>
       </div>
     </div>
   );
@@ -330,13 +669,38 @@ function PassCard({
   onShowTicket: (ticket: TicketVM) => void;
 }) {
   return (
-    <div className="cc-node" data-state={state} data-past={state === "past" || undefined}>
-      <div className="cc-node-dot"><span className="cc-med-pass" /></div>
-      <LivePass ticket={pass.ticket} crs={pass.crs} time={pass.time} dest={pass.dest} docked onShow={onShowTicket} />
+    <div
+      className="cc-node"
+      data-state={state}
+      data-past={state === "past" || undefined}
+    >
+      <div className="cc-node-dot">
+        <SpineIcon kind="train" active={state === "next"} />
+      </div>
+      <LivePass
+        ticket={pass.ticket}
+        crs={pass.crs}
+        time={pass.time}
+        dest={pass.dest}
+        docked
+        onShow={onShowTicket}
+      />
     </div>
   );
 }
 
-function Toggle({ label, open, onClick }: { label: string; open: boolean; onClick: () => void }) {
-  return <button type="button" className="cc-spine-toggle" onClick={onClick}>{open ? "Hide" : "Show"} {label}</button>;
+function Toggle({
+  label,
+  open,
+  onClick,
+}: {
+  label: string;
+  open: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button type="button" className="cc-spine-toggle" onClick={onClick}>
+      {open ? "Hide" : "Show"} {label}
+    </button>
+  );
 }


### PR DESCRIPTION
## Purpose
Apply the four annotated mobile Today corrections directly to the shared production components.

## Changes
- add breathing room between the movement badge and the card's top accent
- replace inherited geometric spine markers with one consistent SVG icon family
- restructure transfer timing into a clear place, duration, arrival and departure grid
- insert an explicit transport-hub arrival/dwell stage before booked departures
- count the generated hub arrival as a visible timed point

## Shared behaviour
The changes are implemented in `TodaySpine`, so real Today and the staff demo continue to use the same components and receive the same fixes.

## Safety
- no Supabase contracts or writes changed
- ticket and routing actions are untouched
- demo data remains isolated
- regression coverage protects the final CSS load order and hub/transfer/icon structure
