### PR TITLE
Make installed Khonsera update to the current production build

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,25 +1,18 @@
 /*
- * Khonsera service worker — the offline spine for the day-of surfaces. The point
- * is the barrier: you got off the train with no signal and needed your Aztec. The
- * Aztec already draws on-device (bwip-js) from a saved payload; what was missing
- * was the app booting at all with no network. This caches the shell so it does.
+ * Khonsera service worker — the offline spine for the day-of surfaces.
  *
- * Conservative by design (it ships to the live PWA on a real phone):
- *   - Hashed build assets (/_next/static) → cache-first (safe: content-hashed).
- *   - Page navigations → network-first, fall back to the last cached snapshot,
- *     then to /offline (which reads the on-device ticket cache). So fresh content
- *     online, last-known content offline — never a stale app that can't update.
- *   - Cross-origin (Supabase, Darwin, fonts) is never touched — those just fail
- *     offline and the UI keeps its last-known state.
- *
- * Bump VERSION to roll the caches (old ones are deleted on activate).
+ * Hashed Next.js assets are cache-first. Page navigations are network-first and
+ * fall back to the last known page only when the network is unavailable.
+ * The deployment version is supplied in the service-worker URL so an installed
+ * PWA cannot remain indefinitely on an older production JavaScript/CSS bundle.
  */
 
-const VERSION = "khonsera-v2";
+const deploymentVersion =
+  new URL(self.location.href).searchParams.get("v") || "development";
+const VERSION = `khonsera-${deploymentVersion}`;
 const STATIC_CACHE = `${VERSION}-static`;
 const PAGE_CACHE = `${VERSION}-pages`;
 
-// Minimal precache: the emergency offline ticket surface + the icons/manifest.
 const PRECACHE = ["/offline", "/manifest.webmanifest", "/icon.svg"];
 
 self.addEventListener("install", (event) => {
@@ -39,74 +32,87 @@ self.addEventListener("activate", (event) => {
     (async () => {
       const keys = await caches.keys();
       await Promise.all(
-        keys.filter((k) => !k.startsWith(VERSION)).map((k) => caches.delete(k)),
+        keys.filter((key) => !key.startsWith(VERSION)).map((key) => caches.delete(key)),
       );
       await self.clients.claim();
     })(),
   );
 });
 
+self.addEventListener("message", (event) => {
+  if (event.data?.type === "SKIP_WAITING") {
+    void self.skipWaiting();
+  }
+});
+
 self.addEventListener("fetch", (event) => {
-  const req = event.request;
-  if (req.method !== "GET") return;
+  const request = event.request;
+  if (request.method !== "GET") return;
 
   let url;
   try {
-    url = new URL(req.url);
+    url = new URL(request.url);
   } catch {
     return;
   }
-  // Only ever handle our own origin — never proxy Supabase / Darwin / fonts.
+
   if (url.origin !== self.location.origin) return;
 
   if (url.pathname.startsWith("/_next/static/")) {
-    event.respondWith(cacheFirst(req));
+    event.respondWith(cacheFirst(request));
     return;
   }
-  if (req.mode === "navigate") {
-    event.respondWith(networkFirstPage(req));
+
+  if (request.mode === "navigate") {
+    event.respondWith(networkFirstPage(request));
     return;
   }
-  // Same-origin static files (icons, brand images, manifest).
-  event.respondWith(staleWhileRevalidate(req));
+
+  event.respondWith(staleWhileRevalidate(request));
 });
 
-async function cacheFirst(req) {
+async function cacheFirst(request) {
   const cache = await caches.open(STATIC_CACHE);
-  const hit = await cache.match(req);
+  const hit = await cache.match(request);
   if (hit) return hit;
+
   try {
-    const res = await fetch(req);
-    if (res.ok) cache.put(req, res.clone());
-    return res;
+    const response = await fetch(request);
+    if (response.ok) await cache.put(request, response.clone());
+    return response;
   } catch {
     return hit || Response.error();
   }
 }
 
-async function networkFirstPage(req) {
+async function networkFirstPage(request) {
   const cache = await caches.open(PAGE_CACHE);
+
   try {
-    const res = await fetch(req);
-    // Cache only real, full responses (not opaque redirects/partials).
-    if (res.ok && res.type === "basic") cache.put(req, res.clone());
-    return res;
+    const response = await fetch(request, { cache: "no-store" });
+    if (response.ok && response.type === "basic") {
+      await cache.put(request, response.clone());
+    }
+    return response;
   } catch {
-    const hit = await cache.match(req);
+    const hit = await cache.match(request);
     if (hit) return hit;
     const offline = await caches.match("/offline");
     return offline || Response.error();
   }
 }
 
-async function staleWhileRevalidate(req) {
+async function staleWhileRevalidate(request) {
   const cache = await caches.open(STATIC_CACHE);
-  const hit = await cache.match(req);
-  const fetching = fetch(req)
-    .then((res) => {
-      if (res.ok && res.type === "basic") cache.put(req, res.clone());
-      return res;
+  const hit = await cache.match(request);
+  const fetching = fetch(request)
+    .then(async (response) => {
+      if (response.ok && response.type === "basic") {
+        await cache.put(request, response.clone());
+      }
+      return response;
     })
     .catch(() => hit);
+
   return hit || fetching;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,6 +34,12 @@ import { PwaRegister } from "@/components/pwa-register";
 //   • JetBrains Mono  — codes, times, eyebrows and technical travel labels.
 const mono = JetBrains_Mono({ subsets: ["latin"], variable: "--font-mono" });
 
+const deploymentVersion =
+  process.env.VERCEL_GIT_COMMIT_SHA ??
+  process.env.VERCEL_DEPLOYMENT_ID ??
+  process.env.NEXT_PUBLIC_APP_VERSION ??
+  "development";
+
 export const metadata: Metadata = {
   title: "Khonsera — travel days that run on time.",
   description:
@@ -78,7 +84,7 @@ export default function RootLayout({
       </head>
       <body>
         {children}
-        <PwaRegister />
+        <PwaRegister version={deploymentVersion} />
       </body>
     </html>
   );

--- a/src/components/pwa-production-refresh.test.ts
+++ b/src/components/pwa-production-refresh.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+const layout = readFileSync(join(root, "src/app/layout.tsx"), "utf8");
+const register = readFileSync(
+  join(root, "src/components/pwa-register.tsx"),
+  "utf8",
+);
+const worker = readFileSync(join(root, "public/sw.js"), "utf8");
+
+describe("production PWA refresh", () => {
+  it("versions the service worker from the Vercel deployment", () => {
+    expect(layout).toContain("VERCEL_GIT_COMMIT_SHA");
+    expect(layout).toContain("<PwaRegister version={deploymentVersion} />");
+    expect(register).toContain("/sw.js?v=");
+    expect(register).toContain('updateViaCache: "none"');
+  });
+
+  it("checks for updates and reloads when a new worker controls the app", () => {
+    expect(register).toContain('"controllerchange"');
+    expect(register).toContain("window.location.reload()");
+    expect(register).toContain("registration.update()");
+    expect(register).toContain('"visibilitychange"');
+    expect(register).toContain('"focus"');
+  });
+
+  it("separates caches by deployment and never serves cached HTML online", () => {
+    expect(worker).toContain('searchParams.get("v")');
+    expect(worker).toContain("const VERSION = `khonsera-${deploymentVersion}`");
+    expect(worker).toContain('{ cache: "no-store" }');
+    expect(worker).toContain('event.data?.type === "SKIP_WAITING"');
+  });
+});

--- a/src/components/pwa-register.tsx
+++ b/src/components/pwa-register.tsx
@@ -2,22 +2,95 @@
 
 import { useEffect } from "react";
 
-// Registers the service worker (public/sw.js) once the page has loaded, so the
-// app shell + last-known day are cached for no-signal use at the barrier. Inert
-// where service workers aren't available (older browsers / non-secure contexts).
-export function PwaRegister() {
+type PwaRegisterProps = {
+  version: string;
+};
+
+// Register the offline worker against the current deployment version. A new
+// Vercel commit therefore produces a new worker URL, and an already-installed
+// PWA reloads once when that worker takes control instead of continuing to run
+// an older JavaScript/CSS bundle indefinitely.
+export function PwaRegister({ version }: PwaRegisterProps) {
   useEffect(() => {
-    if (typeof navigator === "undefined" || !("serviceWorker" in navigator)) return;
-    const register = () => {
-      navigator.serviceWorker.register("/sw.js").catch(() => {
-        /* registration is best-effort; the app works online regardless */
+    if (
+      typeof navigator === "undefined" ||
+      !("serviceWorker" in navigator)
+    ) {
+      return;
+    }
+
+    let disposed = false;
+    let registration: ServiceWorkerRegistration | null = null;
+    let reloadStarted = false;
+    const hadController = Boolean(navigator.serviceWorker.controller);
+
+    const reloadForNewWorker = () => {
+      if (!hadController || reloadStarted || disposed) return;
+      reloadStarted = true;
+      window.location.reload();
+    };
+
+    const activateWaitingWorker = () => {
+      registration?.waiting?.postMessage({ type: "SKIP_WAITING" });
+    };
+
+    const watchInstallingWorker = () => {
+      const worker = registration?.installing;
+      if (!worker) return;
+
+      worker.addEventListener("statechange", () => {
+        if (worker.state === "installed") activateWaitingWorker();
       });
     };
-    if (document.readyState === "complete") register();
-    else {
+
+    const updateRegistration = () => {
+      if (document.visibilityState === "visible") {
+        registration?.update().catch(() => {
+          /* update checks are best-effort */
+        });
+      }
+    };
+
+    const register = async () => {
+      try {
+        const workerUrl = `/sw.js?v=${encodeURIComponent(version)}`;
+        registration = await navigator.serviceWorker.register(workerUrl, {
+          updateViaCache: "none",
+        });
+
+        registration.addEventListener("updatefound", watchInstallingWorker);
+        activateWaitingWorker();
+        await registration.update();
+      } catch {
+        /* registration is best-effort; the online app still works */
+      }
+    };
+
+    navigator.serviceWorker.addEventListener(
+      "controllerchange",
+      reloadForNewWorker,
+    );
+    document.addEventListener("visibilitychange", updateRegistration);
+    window.addEventListener("focus", updateRegistration);
+
+    if (document.readyState === "complete") {
+      void register();
+    } else {
       window.addEventListener("load", register, { once: true });
-      return () => window.removeEventListener("load", register);
     }
-  }, []);
+
+    return () => {
+      disposed = true;
+      navigator.serviceWorker.removeEventListener(
+        "controllerchange",
+        reloadForNewWorker,
+      );
+      document.removeEventListener("visibilitychange", updateRegistration);
+      window.removeEventListener("focus", updateRegistration);
+      window.removeEventListener("load", register);
+      registration?.removeEventListener("updatefound", watchInstallingWorker);
+    };
+  }, [version]);
+
   return null;
 }


### PR DESCRIPTION
## Problem
`khonsera.com` was correctly promoted to commit `9d4d297`, but the installed mobile PWA continued rendering the preceding Today bundle. The screenshot still showed four timed points and the old transfer/marker markup, proving the current production code had not replaced the active client bundle.

## Changes
- version the service-worker URL from the Vercel commit/deployment
- isolate offline caches per deployment and remove superseded caches on activation
- bypass cached HTML while online
- check for worker updates on load, focus and visibility return
- activate a waiting worker immediately
- reload once when a new worker takes control

## Result
The existing Today fixes remain unchanged and shared between live and demo. This PR makes production deployments actually reach installed PWAs instead of leaving them on stale JavaScript and CSS.

## Safety
- offline fallback remains intact
- hashed Next.js assets remain cache-first
- cross-origin requests remain untouched
- first-time service-worker installation does not trigger a reload loop
- regression tests cover deployment versioning and refresh behaviour
