### PR TITLE
Serve the Khonsera service worker outside authentication

### DIFF
--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -8,6 +8,12 @@ const PUBLIC_PATHS = [
   "/login",
   "/signup",
   "/forgot-password",
+  // PWA bootstrap/update assets must remain available before authentication.
+  // A service worker request cannot follow an HTML login redirect and will
+  // otherwise leave an installed app running an obsolete JavaScript bundle.
+  "/sw.js",
+  "/manifest.webmanifest",
+  "/offline",
   // /reset-password is intentionally NOT public — it requires the recovery
   // session that /auth/callback installs after the magic link exchange.
   "/auth/callback",

--- a/src/middleware-public-assets.test.ts
+++ b/src/middleware-public-assets.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+const middleware = readFileSync(join(root, "src/middleware.ts"), "utf8");
+const sessionMiddleware = readFileSync(
+  join(root, "src/lib/supabase/middleware.ts"),
+  "utf8",
+);
+
+describe("PWA assets remain reachable before authentication", () => {
+  it("keeps the service worker outside the auth matcher", () => {
+    expect(middleware).toContain("sw.js");
+    expect(middleware).toContain("manifest.webmanifest");
+    expect(middleware).toContain("offline");
+  });
+
+  it("also treats PWA bootstrap routes as public if the matcher changes", () => {
+    expect(sessionMiddleware).toContain('"/sw.js"');
+    expect(sessionMiddleware).toContain('"/manifest.webmanifest"');
+    expect(sessionMiddleware).toContain('"/offline"');
+  });
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -7,7 +7,10 @@ export async function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
-    // Run on everything except static assets.
-    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+    // Authentication must never intercept the install/update assets used by the
+    // PWA. In particular, /sw.js must be returned as JavaScript even when no
+    // Supabase session is present; redirecting it to /login leaves installed
+    // clients permanently pinned to an old bundle.
+    "/((?!_next/static|_next/image|favicon.ico|sw.js|manifest.webmanifest|offline|icon.svg|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
   ],
 };


### PR DESCRIPTION
## Root cause
The production deployment was current, but unauthenticated requests to `/sw.js` were intercepted by Supabase auth middleware and redirected to `/login`. The browser therefore received HTML instead of a service worker, so installed Khonsera clients could not update and continued rendering the previous Today bundle.

## Changes
- exclude `/sw.js`, `/manifest.webmanifest`, `/offline` and the app icon from the auth middleware matcher
- also classify the service worker, manifest and offline shell as public routes as a defensive second boundary
- add regression coverage for both middleware layers

## Acceptance criterion
The deployed `/sw.js` must return status 200 with JavaScript while signed out, with no login redirect. Once promoted, the existing installed worker can finally receive the current production update containing the Today spine, hub-arrival and transfer fixes.
