### PR TITLE
Never cache Next.js route data in the Khonsera worker

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,10 +1,10 @@
 /*
  * Khonsera service worker — the offline spine for the day-of surfaces.
  *
- * Hashed Next.js assets are cache-first. Page navigations are network-first and
- * fall back to the last known page only when the network is unavailable.
- * The deployment version is supplied in the service-worker URL so an installed
- * PWA cannot remain indefinitely on an older production JavaScript/CSS bundle.
+ * Only immutable, content-hashed Next.js assets are cache-first. Full document
+ * navigations are network-first with an offline fallback. Next.js router/RSC
+ * payloads are always network-only: caching those responses can combine a new
+ * application shell with an obsolete component tree after a deployment.
  */
 
 const deploymentVersion =
@@ -14,6 +14,7 @@ const STATIC_CACHE = `${VERSION}-static`;
 const PAGE_CACHE = `${VERSION}-pages`;
 
 const PRECACHE = ["/offline", "/manifest.webmanifest", "/icon.svg"];
+const SAFE_STATIC_PATHS = new Set(["/manifest.webmanifest", "/icon.svg"]);
 
 self.addEventListener("install", (event) => {
   event.waitUntil(
@@ -32,7 +33,9 @@ self.addEventListener("activate", (event) => {
     (async () => {
       const keys = await caches.keys();
       await Promise.all(
-        keys.filter((key) => !key.startsWith(VERSION)).map((key) => caches.delete(key)),
+        keys
+          .filter((key) => !key.startsWith(VERSION))
+          .map((key) => caches.delete(key)),
       );
       await self.clients.claim();
     })(),
@@ -58,18 +61,41 @@ self.addEventListener("fetch", (event) => {
 
   if (url.origin !== self.location.origin) return;
 
+  // React Server Component and Next router payloads are deployment-specific.
+  // Never read or write them through Cache Storage, even while online.
+  if (isNextRouteData(request, url)) {
+    event.respondWith(fetch(request, { cache: "no-store" }));
+    return;
+  }
+
+  // These filenames are content-hashed, so a cache hit is always the same file.
   if (url.pathname.startsWith("/_next/static/")) {
     event.respondWith(cacheFirst(request));
     return;
   }
 
+  // Full documents remain available offline, but online always wins.
   if (request.mode === "navigate") {
     event.respondWith(networkFirstPage(request));
     return;
   }
 
-  event.respondWith(staleWhileRevalidate(request));
+  // Cache only the deliberately offline-safe manifest and icon. API responses,
+  // route handlers and all other application data stay under normal networking.
+  if (SAFE_STATIC_PATHS.has(url.pathname)) {
+    event.respondWith(staleWhileRevalidate(request));
+  }
 });
+
+function isNextRouteData(request, url) {
+  return Boolean(
+    url.pathname.startsWith("/_next/data/") ||
+      url.searchParams.has("_rsc") ||
+      request.headers.get("RSC") === "1" ||
+      request.headers.has("Next-Router-State-Tree") ||
+      request.headers.has("Next-Router-Prefetch"),
+  );
+}
 
 async function cacheFirst(request) {
   const cache = await caches.open(STATIC_CACHE);

--- a/src/components/pwa-production-refresh.test.ts
+++ b/src/components/pwa-production-refresh.test.ts
@@ -32,4 +32,20 @@ describe("production PWA refresh", () => {
     expect(worker).toContain('{ cache: "no-store" }');
     expect(worker).toContain('event.data?.type === "SKIP_WAITING"');
   });
+
+  it("never caches Next router or React Server Component responses", () => {
+    expect(worker).toContain("function isNextRouteData");
+    expect(worker).toContain('url.searchParams.has("_rsc")');
+    expect(worker).toContain('request.headers.get("RSC") === "1"');
+    expect(worker).toContain('request.headers.has("Next-Router-State-Tree")');
+    expect(worker).toContain('request.headers.has("Next-Router-Prefetch")');
+    expect(worker).toContain('fetch(request, { cache: "no-store" })');
+  });
+
+  it("limits non-hashed cache writes to explicit offline-safe assets", () => {
+    expect(worker).toContain("const SAFE_STATIC_PATHS");
+    expect(worker).toContain('"/manifest.webmanifest"');
+    expect(worker).toContain('"/icon.svg"');
+    expect(worker).not.toContain("event.respondWith(staleWhileRevalidate(request));\n});");
+  });
 });


### PR DESCRIPTION
## Root cause
Production was on the correct commit, but the service worker still treated Next.js RSC/router responses as generic same-origin files and returned them stale-while-revalidate. That can render the current shell with a previous component tree, matching the observed demo: current chrome with the old four-point itinerary, old transfer row and old spine markers.

## Changes
- detect `_rsc`, `RSC`, Next Router State Tree, prefetch and `/_next/data/` requests
- serve all Next route/RSC responses network-only with `cache: no-store`
- keep cache-first only for content-hashed `/_next/static/` assets
- restrict stale-while-revalidate to the manifest and icon
- retain network-first full-document navigation with the offline fallback
- clear superseded caches when the deployment-versioned worker activates

## Safety
- authenticated API and application data are no longer written to Cache Storage
- offline page fallback remains available
- immutable build assets retain efficient caching
- regression tests protect the RSC/router exclusions
